### PR TITLE
Zak phase from closed-loop integration

### DIFF
--- a/sisl/physics/electron.py
+++ b/sisl/physics/electron.py
@@ -736,10 +736,10 @@ def berry_phase(contour, sub=None, eigvals=False, closed=True, method='berry'):
        return the eigenvalues of the product of the overlap matrices
     closed : bool, optional
        whether or not to include the connection of the last and first points in the loop
-    method : string, optional
+    method : {'berry', 'zak'}
        'berry' will return the usual integral of the Berry connection over the specified contour
        'zak' will compute the Zak phase for 1D systems by performing a closed loop integration but
-       taking into account the Bloch factor exp(-i 2\pi/a x) accumulated over a Brillouin zone,
+       taking into account the Bloch factor :math:`e^{-i2\pi/a x}` accumulated over a Brillouin zone,
        see J. Zak, "Berry's phase for energy bands in solids" PRL 62, 2747 (1989).
 
     Notes
@@ -820,7 +820,7 @@ def berry_phase(contour, sub=None, eigvals=False, closed=True, method='berry'):
             if method == 'zak':
                 g = contour.parent.geometry
                 axis = contour.k[1] - contour.k[0]
-                axis /= np.linalg.norm(axis)
+                axis /= (axis ** 2).sum() ** 0.5
                 phase = dot(g.xyz[g.o2a(_a.arangei(g.no)), :], dot(axis, g.rcell)).reshape(1, -1)
                 prev.state *= np.exp(-1j*phase)
 
@@ -844,7 +844,7 @@ def berry_phase(contour, sub=None, eigvals=False, closed=True, method='berry'):
             if method == 'zak':
                 g = contour.parent.geometry
                 axis = contour.k[1] - contour.k[0]
-                axis /= np.linalg.norm(axis)
+                axis /= (axis ** 2).sum() ** 0.5
                 phase = dot(g.xyz[g.o2a(_a.arangei(g.no)), :], dot(axis, g.rcell)).reshape(1, -1)
                 prev.state *= np.exp(-1j*phase)
             if closed:

--- a/sisl/physics/tests/test_hamiltonian.py
+++ b/sisl/physics/tests/test_hamiltonian.py
@@ -615,6 +615,19 @@ class TestHamiltonian(object):
         bz2 = BandStructure.param_circle(H, 20, 0.01, [0, 0, 1], [1/3] * 3, loop=True)
         assert np.allclose(elec.berry_phase(bz1), elec.berry_phase(bz2))
 
+    def test_berry_phase_zak(self):
+        # SSH model, topological cell
+        g = Geometry([[-.6, 0, 0], [0.6, 0, 0]], Atom(1, 1.001), sc=[2, 10, 10])
+        g.set_nsc([3, 1, 1])
+        H = Hamiltonian(g)
+        H.construct([(0.1, 1.0, 1.5), (0, 1., 0.5)])
+        # Contour
+        k = np.linspace(0.0, 1.0, 101)
+        K = np.zeros([k.size, 3])
+        K[:, 0] = k
+        bz = BrillouinZone(H, K)
+        assert np.allclose(np.abs(elec.berry_phase(bz, sub=0, method='zak')), np.pi)
+
     def test_gauge_inv_eff(self, setup):
         R, param = [0.1, 1.5], [1., 0.1]
         g = setup.g.tile(2, 0).tile(2, 1).tile(2, 2)

--- a/sisl/physics/tests/test_hamiltonian.py
+++ b/sisl/physics/tests/test_hamiltonian.py
@@ -5,7 +5,7 @@ import pytest
 import warnings
 import numpy as np
 
-from sisl import Geometry, Atom, SuperCell, Hamiltonian, Spin, BandStructure, MonkhorstPack
+from sisl import Geometry, Atom, SuperCell, Hamiltonian, Spin, BandStructure, MonkhorstPack, BrillouinZone
 from sisl import Grid, SphericalOrbital, SislError
 from sisl import electron as elec
 


### PR DESCRIPTION
The discretized Zak phase over [0, 2\pi/a] (1BZ) can be written as
```
\phi = - Im \ln [<0|1><1|2>...<N-1|N>]
= - Im \ln [<0|1><1|2>...<N-1|exp(i 2\pi/a x)|0>]
```
The Bloch phases in the latter form, which explicitly introduce a position-dependence of the orbitals in the unit cell, allows to close the integration loop (even in 1D). This route is advantageous over an "open-loop integration" because it avoids possible arbitrary phases associated with the diagonalization for the states |0> and |N>. In other words, arbitrary phases cancel for pairs |i><i|, but this is not necessarily guaranteed for the combination |N><0|.