### PR TITLE
Added rudimentary support for Path objects in get_sile

### DIFF
--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -494,7 +494,7 @@ class Geometry(SuperCellChild):
 
         Parameters
         ----------
-        sile : `Sile` or str
+        sile : Sile, str or pathlib.Path
             a `Sile` object which will be used to read the geometry
             if it is a string it will create a new sile using `get_sile`.
 
@@ -516,7 +516,7 @@ class Geometry(SuperCellChild):
 
         Parameters
         ----------
-        sile : Sile or str
+        sile : Sile, str or pathlib.Path
             a `Sile` object which will be used to write the geometry
             if it is a string it will create a new sile using `get_sile`
         *args, **kwargs:

--- a/sisl/grid.py
+++ b/sisl/grid.py
@@ -707,7 +707,7 @@ class Grid(SuperCellChild):
 
         Parameters
         ----------
-        sile : Sile, str
+        sile : Sile, str or pathlib.Path
             a `Sile` object which will be used to read the grid
             if it is a string it will create a new sile using `get_sile`.
         * : args passed directly to ``read_grid(,**)``
@@ -718,6 +718,7 @@ class Grid(SuperCellChild):
         if isinstance(sile, BaseSile):
             return sile.read_grid(*args, **kwargs)
         else:
+            sile = str(sile)
             sile, spec = str_spec(sile)
             if spec is not None:
                 if ',' in spec:
@@ -732,7 +733,7 @@ class Grid(SuperCellChild):
 
         Parameters
         ----------
-        sile : Sile, str
+        sile : Sile, str or pathlib.Path
             a `Sile` object which will be used to write the grid
             if it is a string it will create a new sile using `get_sile`
         """

--- a/sisl/io/sile.py
+++ b/sisl/io/sile.py
@@ -3,6 +3,11 @@ from __future__ import print_function, division
 from functools import wraps
 from os.path import splitext, isfile, dirname, join, abspath, basename
 import gzip
+try:
+    from pathlib import Path
+except ImportError:  # Ancient Python
+    class Path:
+        pass
 
 import numpy as np
 
@@ -272,7 +277,7 @@ def get_sile(file, *args, **kwargs):
 
     Parameters
     ----------
-    file : str
+    file : str or pathlib.Path
        the file to be quried for a correct `Sile` object.
        This file name may contain {<class-name>} which sets
        `cls` in case `cls` is not set.
@@ -285,6 +290,8 @@ def get_sile(file, *args, **kwargs):
        function returns a random one.
     """
     cls = kwargs.pop('cls', None)
+    if isinstance(file, Path):
+        file = str(file)
     sile = get_sile_class(file, *args, cls=cls, **kwargs)
     return sile(str_spec(file)[0], *args, **kwargs)
 

--- a/sisl/physics/densitymatrix.py
+++ b/sisl/physics/densitymatrix.py
@@ -722,7 +722,7 @@ class DensityMatrix(_realspace_DensityMatrix):
 
         Parameters
         ----------
-        sile : `Sile`, str
+        sile : Sile, str or pathlib.Path
             a `Sile` object which will be used to read the density matrix
             and the overlap matrix (if any)
             if it is a string it will create a new sile using `get_sile`.

--- a/sisl/physics/dynamicalmatrix.py
+++ b/sisl/physics/dynamicalmatrix.py
@@ -318,7 +318,7 @@ class DynamicalMatrix(SparseOrbitalBZ):
 
         Parameters
         ----------
-        sile : `Sile`, str
+        sile : Sile, str or pathlib.Path
             a `Sile` object which will be used to read the dynamical matrix.
             If it is a string it will create a new sile using `get_sile`.
         * : args passed directly to ``read_dynamical_matrix(,**)``

--- a/sisl/physics/energydensitymatrix.py
+++ b/sisl/physics/energydensitymatrix.py
@@ -278,7 +278,7 @@ class EnergyDensityMatrix(_realspace_DensityMatrix):
 
         Parameters
         ----------
-        sile : `Sile`, str
+        sile : Sile, str or pathlib.Path
             a `Sile` object which will be used to read the density matrix
             and the overlap matrix (if any)
             if it is a string it will create a new sile using `get_sile`.

--- a/sisl/physics/hamiltonian.py
+++ b/sisl/physics/hamiltonian.py
@@ -336,7 +336,7 @@ class Hamiltonian(SparseOrbitalBZSpin):
 
         Parameters
         ----------
-        sile : `Sile`, str
+        sile : Sile, str or pathlib.Path
             a `Sile` object which will be used to read the Hamiltonian
             and the overlap matrix (if any)
             if it is a string it will create a new sile using `get_sile`.

--- a/sisl/supercell.py
+++ b/sisl/supercell.py
@@ -888,7 +888,7 @@ class SuperCell(object):
 
         Parameters
         ----------
-        sile : `Sile` or str
+        sile : Sile, str or pathlib.Path
             a `Sile` object which will be used to read the supercell
             if it is a string it will create a new sile using `sisl.io.get_sile`.
         """


### PR DESCRIPTION
I tried to allow use of `pathlib.Path` (Py>=3.5) in a number of places that so far only accepted `str`. I ended up just changing `get_sile`, where the `Path` object is converted to `str` immediately. This means Path object "support" is propagated to a number of places automatically, so the documentation needed updating. 

In the places I edited, there was some inconsistency with whether "Sile" was written with backticks. It doesn't seem to matter, so I deleted them.

IMO, everywhere that takes a string as a path, should accept both `Path` and `str` objects. However, there are some complications since `os.path`and the builtin `open` only supports `Path` objects in Python 3.6 and later, so there would be a problem with Python 3.5. Perhaps one day ;)