### PR TITLE
Added some noisy files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
+__pycache__
+.eggs
+.pytest_cache
+dist
 build
 *.pyc
+*.so
+__config__.py
 index.rst
 docs/build
 docs/sisl


### PR DESCRIPTION
Eg. when using `setup.py develop`, a number of files will be laying around.

On a side note: Should the cython-generated C-files not also be in gitignore?