### PR TITLE
Fancier indexing on geometry

### DIFF
--- a/sisl/_namedindex.py
+++ b/sisl/_namedindex.py
@@ -53,6 +53,8 @@ class NamedIndex(object):
         if name in self._name:
             raise SislError(self.__class__.__name__ + '.add_name already contains name {}, please delete group name before adding.'.format(name))
         self._name.append(name)
+        if isinstance(index, np.ndarray) and index.dtype is np.dtype('bool'):
+            index = np.flatnonzero(index)
         self._index.append(arrayi(index).ravel())
 
     def delete_name(self, name):

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -1029,7 +1029,8 @@ class Geometry(SuperCellChild):
         Parameters
         ----------
         atom : array_like
-            indices of all atoms to be removed.
+            indices of all atoms to be removed. Can also be an array of
+            booleans, or in the case of a string, a named region.
         cell   : array_like or SuperCell, optional
             the new associated cell of the geometry (defaults to the same cell)
 
@@ -1038,6 +1039,10 @@ class Geometry(SuperCellChild):
         SuperCell.fit : update the supercell according to a reference supercell
         remove : the negative of this routine, i.e. remove a subset of atoms
         """
+        if isinstance(atom, np.ndarray) and atom.dtype is np.dtype('bool'):
+            atom = np.flatnonzero(atom)
+        elif isinstance(atom, str):
+            atom = self.names[atom]
         atms = self.sc2uc(atom)
         if cell is None:
             return self.__class__(self.xyz[atms, :],
@@ -1114,12 +1119,17 @@ class Geometry(SuperCellChild):
         Parameters
         ----------
         atom : array_like
-            indices of all atoms to be removed.
+            indices of all atoms to be removed. Can also be an array of
+            booleans, or in the case of a string, a named region.
 
         See Also
         --------
         sub : the negative of this routine, i.e. retain a subset of atoms
         """
+        if isinstance(atom, np.ndarray) and atom.dtype is np.dtype('bool'):
+            atom = np.flatnonzero(atom)
+        elif isinstance(atom, str):
+            atom = self.names[atom]
         atom = self.sc2uc(atom)
         atom = np.delete(_a.arangei(self.na), atom)
         return self.sub(atom)


### PR DESCRIPTION
This allows slighty easier-to-read code when using Geometry:
```
geom = si.get_sile("tano_struct.fdf").read_geometry()
geom[geom.xyz[:, 2] > 12.6] = "tip"  # previously, (geom.xyz[:, 2] > 12.6).nonzero()[0] was needed
tip = geom.sub("tip")  # previously geom.sub(geom.names["tip"])
```
I didn't implement the same for Hamiltonians (or others?) because it is a daunting task to figure out where to do it. If you throw a tip I could look at it. Perhaps other functions in Geometry could use the improvement as well.