### PR TITLE
xyz file parsing works for ase gui-exports

### DIFF
--- a/sisl/io/xyz.py
+++ b/sisl/io/xyz.py
@@ -4,6 +4,7 @@ Sile object for reading/writing XYZ files
 from __future__ import print_function
 
 from collections import defaultdict
+import re
 import numpy as np
 
 # Import sile objects
@@ -11,7 +12,9 @@ from .sile import *
 
 # Import the geometry object
 from sisl import Geometry, SuperCell
-import re
+
+# Warnings
+from sisl.messages import warn
 
 
 __all__ = ['xyzSile']
@@ -91,8 +94,7 @@ class xyzSile(Sile):
             except KeyError:  # cellkey not in keyvals
                 continue
             except ValueError as e:
-                import warnings
-                warnings.warn(
+                warn(
                     "Found a key indicating {cellkey} in xyz file, but "
                     "could not parse it: {e!s}".format(cellkey=cellkey, e=e))
 
@@ -108,8 +110,7 @@ class xyzSile(Sile):
         except KeyError:
             pass
         except ValueError as e:
-            import warnings
-            warnings.warn(
+            warn(
                 "Found a key indicating nsc in xyz file, but "
                 "could not parse it: {e!s}".format(e=e))
 

--- a/sisl/io/xyz.py
+++ b/sisl/io/xyz.py
@@ -82,7 +82,7 @@ class xyzSile(Sile):
                 if len(values) != 9:
                     raise ValueError(
                         "There are not exactly 9 values associated to the"
-                        f" {cellkey} values")
+                        " {cellkey} values".format(cellkey=cellkey))
                 cell.shape = (9,)
                 for i, il in enumerate(values):
                     cell[i] = float(il)
@@ -93,8 +93,8 @@ class xyzSile(Sile):
             except ValueError as e:
                 import warnings
                 warnings.warn(
-                    f"Found a key indicating {cellkey} in xyz file, but "
-                    f"could not parse it: {e!s}")
+                    "Found a key indicating {cellkey} in xyz file, but "
+                    "could not parse it: {e!s}".format(cellkey=cellkey, e=e))
 
         # Now set nsc if its there
         try:
@@ -111,7 +111,7 @@ class xyzSile(Sile):
             import warnings
             warnings.warn(
                 "Found a key indicating nsc in xyz file, but "
-                f"could not parse it: {e!s}")
+                "could not parse it: {e!s}".format(e=e))
 
         sp = [None] * na
         xyz = np.empty([na, 3], np.float64)


### PR DESCRIPTION
The comment line in an ASE-gui exported xyz file looks like so:

```
Lattice="34.56 0.0 0.0 0.0 24.94153163 0.0 0.0 0.0 69.13138595" Properties=species:S:1:pos:R:3 pbc="F F F"
```

And attempting to read such an xyz file with sisl resulted in a crash. I changed the xyzSile code to allow parsing this type of xyz file as well. 