### PR TITLE
bug: ignore geometry constraints in POSCAR/CONTCAR

### DIFF
--- a/sisl/io/vasp/car.py
+++ b/sisl/io/vasp/car.py
@@ -135,7 +135,7 @@ class carSileVASP(SileVASP):
 
         xyz = np.empty([na, 3], np.float64)
         for ia in range(na):
-            xyz[ia, :] = list(map(float, self.readline().split()))
+            xyz[ia, :] = list(map(float, self.readline().split()[:3]))
         if cart:
             # The unit of the coordinates are cartesian
             xyz *= self._scale


### PR DESCRIPTION
The `VASP` geometry files `POSCAR/CONTCAR` generally contain 6 columns, corresponding to first the coordinates (3 floats) and then the geometry constraints (3 boolean values).

This PR fixes the error associated with reading the last three columns.