### PR TITLE
Dynamical matrix from gulp works for norbs%12!=0

### DIFF
--- a/sisl/io/gulp/got.py
+++ b/sisl/io/gulp/got.py
@@ -222,7 +222,7 @@ class gotSileGULP(SileGULP):
         # default range
         dat = np.empty([no], dtype=dtype)
         i, j = 0, 0
-        while True:
+        while i < no:
             l = self.readline().strip()
             if len(l) == 0:
                 break
@@ -240,8 +240,6 @@ class gotSileGULP(SileGULP):
                     i += 1
                     # reset column
                     j = 0
-                    if i >= no:
-                        break
             else:
                 # add the values (12 values == 3*4)
                 # for atoms on each line
@@ -255,8 +253,7 @@ class gotSileGULP(SileGULP):
 
                         i += 1
                         j = 0
-                        if i >= no:
-                            break
+                        break
 
         # clean-up for memory
         del dat


### PR DESCRIPTION
An error would cause `gotSileGULP.read_dynamical_matrix()` to crash if the number of orbitals was not divisible by 12 (the number of forces gulp outputs per line).