### PR TITLE
Fixing spgeom.set_nsc when new cell is larger

### DIFF
--- a/sisl/sparse_geometry.py
+++ b/sisl/sparse_geometry.py
@@ -266,7 +266,7 @@ class _SparseGeometry(object):
                 old.append(j)
                 new.append(i)
                 deleted[j] = False
-            except:
+            except ValueError:
                 # Not found, i.e. new, so no need to translate
                 pass
 
@@ -307,12 +307,11 @@ class _SparseGeometry(object):
             new = array_arange(new * size, n=n)
 
             # Move data to new positions
-            self._csr.translate_columns(old, new)
+            self._csr.translate_columns(old, new, clean=False)
 
             max_n = new.max() + 1
         else:
             max_n = 0
-
         # Make sure we delete all column values where we have put fake values
         delete = _a.arangei(sc.n_s * size, max(max_n, self.shape[1]))
         if len(delete) > 0:
@@ -322,6 +321,7 @@ class _SparseGeometry(object):
         shape = list(self._csr.shape)
         shape[1] = size * sc.n_s
         self._csr._shape = tuple(shape)
+        self._csr._clean_columns()
 
         self.geometry.set_nsc(*args, **kwargs)
 
@@ -1696,7 +1696,7 @@ class SparseOrbital(_SparseGeometry):
     def sub_orbital(self, atom, orbital):
         """ Retain only a subset of the orbitals on `atom` according to `orbital`
 
-        This allows one to retain only a given subset of the sparse matrix elements. 
+        This allows one to retain only a given subset of the sparse matrix elements.
 
         Parameters
         ----------

--- a/sisl/sparse_geometry.py
+++ b/sisl/sparse_geometry.py
@@ -270,9 +270,6 @@ class _SparseGeometry(object):
                 # Not found, i.e. new, so no need to translate
                 pass
 
-        if len(old) not in [self.n_s, sc.n_s]:
-            raise SislError("Not all supercells are accounted for")
-
         # 1. Ensure that any one of the *old* supercells that
         #    are now deleted are put in the end
         for i, j in enumerate(deleted.nonzero()[0]):

--- a/sisl/tests/test_sparse_geometry.py
+++ b/sisl/tests/test_sparse_geometry.py
@@ -303,6 +303,35 @@ class TestSparseAtom(object):
         assert s.nnz == 4
         assert s[0, 0] == 1
 
+    def test_set_nsc3(self, setup):
+        g = graphene(atom=Atom(6, R=1.43))
+        s = SparseAtom(g)
+        s.set_nsc((3, 3, 1))
+        s.construct([[0.1, 1.43], [1, 2]])
+        s.finalize()
+
+        s55 = s.copy()
+        s55.set_nsc((5, 5, 1))
+        s55.finalize()
+        s77 = s55.copy()
+        s77.set_nsc((7, 7, 1))
+        s77.finalize()
+        s59 = s77.copy()
+        s59.set_nsc((5, 9, 1))
+        s59.finalize()
+        assert s.nnz == s55.nnz
+        assert s.nnz == s77.nnz
+        assert s.nnz == s59.nnz
+
+        s55.set_nsc((3, 3, 1))
+        s55.finalize()
+        s77.set_nsc((3, 3, 1))
+        s55.finalize()
+        s59.set_nsc((3, 3, 1))
+        assert s.nnz == s55.nnz
+        assert s.nnz == s77.nnz
+        assert s.nnz == s59.nnz
+
     def test_edges1(self, setup):
         g = graphene(atom=Atom(6, R=1.43))
         s = SparseAtom(g)


### PR DESCRIPTION
Fixes #151.

* Don't clean on every column translation to avoid deleting new columns
* Don't do the check that all supercells are accounted for (this will happen when expanding along one axis while shrinking another)

I wasn't 100% sure that not using clean in the sparsecsr would work, but I tested it on some phonon bandstructures and it seems ok. ~~Perhaps some tests should be added before merging?~~ I added some tests.