### PR TITLE
Fixed reading overlaps where geometry=None may be passed

### DIFF
--- a/sisl/io/siesta/binaries.py
+++ b/sisl/io/siesta/binaries.py
@@ -171,7 +171,7 @@ class onlysSileSiesta(SileBinSiesta):
     def read_overlap(self, **kwargs):
         """ Returns the overlap matrix from the TranSiesta file """
         tshs_g = self.read_geometry()
-        geom = _geometry_align(tshs_g, kwargs.get('geometry', tshs_g), self.__class__, 'read_overlap')
+        geom = _geometry_align(tshs_g, kwargs.get('geometry', None) or tshs_g, self.__class__, 'read_overlap')
 
         # read the sizes used...
         sizes = _siesta.read_tshs_sizes(self.file)


### PR DESCRIPTION
Fixes #153

I was a little unsure how to approach that issue because it could be fixed in several places.
However where I fixed it is definitely the simplest place to do it. 
That's not the only motivation though. `kwargs` often have default values of None, but this read_overlap function didn't handle the case were it was None at all. So I thought it was also more appropriate to handle the situation there.