### PR TITLE
Overlap object and i/o

### DIFF
--- a/sisl/io/siesta/binaries.py
+++ b/sisl/io/siesta/binaries.py
@@ -18,6 +18,7 @@ from sisl import Geometry, Atom, Atoms, SuperCell, Grid
 from sisl.unit.siesta import unit_convert
 from sisl.physics.sparse import SparseOrbitalBZ
 from sisl.physics import Hamiltonian, DensityMatrix, EnergyDensityMatrix
+from sisl.physics.overlap import Overlap
 from ._help import *
 
 
@@ -189,7 +190,7 @@ class onlysSileSiesta(SileBinSiesta):
         _bin_check(self, 'read_overlap', 'could not read overlap matrix.')
 
         # Create the Hamiltonian container
-        S = SparseOrbitalBZ(geom, nnzpr=1)
+        S = Overlap(geom, nnzpr=1)
 
         # Create the new sparse matrix
         S._csr.ncol = ncol.astype(np.int32, copy=False)
@@ -597,7 +598,7 @@ class hsxSileSiesta(SileBinSiesta):
                             'inconsistent with HSX file.')
 
         # Create the Hamiltonian container
-        S = SparseOrbitalBZ(geom, nnzpr=1)
+        S = Overlap(geom, nnzpr=1)
 
         # Create the new sparse matrix
         S._csr.ncol = ncol.astype(np.int32, copy=False)

--- a/sisl/io/siesta/siesta_nc.py
+++ b/sisl/io/siesta/siesta_nc.py
@@ -13,6 +13,7 @@ from sisl.physics import SparseOrbitalBZ
 from sisl.physics import DensityMatrix, EnergyDensityMatrix
 from sisl.physics import DynamicalMatrix
 from sisl.physics import Hamiltonian
+from sisl.physics.overlap import Overlap
 try:
     from . import _siesta
 except:
@@ -217,7 +218,7 @@ class ncSileSiesta(SileCDFSiesta):
 
     def read_overlap(self, **kwargs):
         """ Returns a overlap matrix from the underlying NetCDF file """
-        S = self._read_class(SparseOrbitalBZ, **kwargs)
+        S = self._read_class(Overlap, **kwargs)
 
         sp = self._crt_grp(self, 'SPARSE')
         S._csr._D[:, 0] = sp.variables['S'][:]

--- a/sisl/io/siesta/tests/test_siesta.py
+++ b/sisl/io/siesta/tests/test_siesta.py
@@ -59,6 +59,14 @@ def test_nc_overlap(sisl_tmp, sisl_system):
     S.finalize()
     assert np.allclose(S._csr._D.sum(), tb.no)
 
+    # Write test
+    f = sisl_tmp('s.nc', _dir)
+    with ncSileSiesta(f, "w") as s:
+        S.write(s)
+    S2 = ncSileSiesta(f).read_overlap()
+    assert S._csr.spsame(S2._csr)
+    assert np.allclose(S._csr._D, S2._csr._D)
+
 
 def test_nc_dynamical_matrix(sisl_tmp, sisl_system):
     f = sisl_tmp('grdyn.nc', _dir)

--- a/sisl/physics/overlap.py
+++ b/sisl/physics/overlap.py
@@ -1,12 +1,4 @@
-from __future__ import print_function, division
-
 import numpy as np
-from scipy.interpolate import CubicSpline
-
-from sisl._help import _range as range
-import sisl._array as _a
-from .distribution import get_distribution
-from .electron import EigenvalueElectron, EigenstateElectron, spin_squared
 from .sparse import SparseOrbitalBZ
 
 __all__ = ['Overlap']
@@ -15,9 +7,10 @@ __all__ = ['Overlap']
 class Overlap(SparseOrbitalBZ):
     """ Sparse Overlap matrix object
 
-    Generally speaking, the Overlap should be accessed as part of eg. `Hamiltonian.S` rather than as a separate object.
-    This class should only be used when the overlap is not particularly associated to another physical object like the
-    Hamiltonian. This could be eg. the output of a Siesta "onlyS" calculation.
+    The Overlap object contains orbital overlaps. It should be used when the overlaps are not associated with
+    another physical object such as a Hamiltonian, as is the case with eg. Siesta onlyS outputs.
+    When the overlap is associated with a Hamiltonian, then this object should not be used as the overlap is stored
+    in the Hamiltonian itself.
 
     Parameters
     ----------
@@ -88,8 +81,6 @@ class Overlap(SparseOrbitalBZ):
             if it is a string it will create a new sile using `get_sile`.
         * : args passed directly to ``read_overlap(,**)``
         """
-        # This only works because, they *must*
-        # have been imported previously
         from sisl.io import get_sile, BaseSile
         if isinstance(sile, BaseSile):
             return sile.read_overlap(*args, **kwargs)

--- a/sisl/physics/overlap.py
+++ b/sisl/physics/overlap.py
@@ -1,0 +1,109 @@
+from __future__ import print_function, division
+
+import numpy as np
+from scipy.interpolate import CubicSpline
+
+from sisl._help import _range as range
+import sisl._array as _a
+from .distribution import get_distribution
+from .electron import EigenvalueElectron, EigenstateElectron, spin_squared
+from .sparse import SparseOrbitalBZ
+
+__all__ = ['Overlap']
+
+
+class Overlap(SparseOrbitalBZ):
+    """ Sparse Overlap matrix object
+
+    Generally speaking, the Overlap should be accessed as part of eg. `Hamiltonian.S` rather than as a separate object.
+    This class should only be used when the overlap is not particularly associated to another physical object like the
+    Hamiltonian. This could be eg. the output of a Siesta "onlyS" calculation.
+
+    Parameters
+    ----------
+    geometry : Geometry
+      parent geometry to create a density matrix from. The density matrix will
+      have size equivalent to the number of orbitals in the geometry
+    dtype : np.dtype, optional
+      data type contained in the density matrix.
+    nnzpr : int, optional
+      number of initially allocated memory per orbital in the density matrix.
+      For increased performance this should be larger than the actual number of entries
+      per orbital.
+    """
+
+    def __init__(self, geometry, dtype=None, nnzpr=None, **kwargs):
+        """ Initialize Overlap """
+        kwargs.update({"orthogonal": True})  # Avoid the dim += 1 in super
+        super().__init__(geometry, 1, np.float64, nnzpr, **kwargs)
+        self._orthogonal = False
+        self._reset()
+
+    def _reset(self):
+        super()._reset()
+        self.S_idx = 0
+        self.Sk = self.Pk
+        self.dSk = self.dPk
+        self.ddSk = self.ddPk
+
+    @classmethod
+    def fromsp(cls, geometry, P=None, S=None, **kwargs):
+        r""" Create an Overlap object from a preset `Geometry` and a sparse matrix
+
+        The passed sparse matrix is in one of `scipy.sparse` formats.
+
+        Note that the method for creating Overlap objects is (nearly) identical to eg. Hamiltonians, but you may not
+        pass any 'P' matrices. Instead you must use the `S` keyword argument.
+
+        Parameters
+        ----------
+        geometry : Geometry
+           geometry to describe the new sparse geometry
+        S : scipy.sparse, required, keyword only
+           The sparse matrix in a `scipy.sparse` format.
+        **kwargs : optional
+           any arguments that are directly passed to the ``__init__`` method
+           of the class.
+
+        Returns
+        -------
+        Overlap
+             a new Overlap object
+        """
+        if S is None:
+            raise TypeError("fromsp() is missing 1 required keyword argument: 'S'")
+        if P is not None and len(P) != 0:
+            raise TypeError("Cannot create an Overlap object with anything other than S")
+        return super().fromsp(geometry, P=[S], S=None, **kwargs)
+
+    @staticmethod
+    def read(sile, *args, **kwargs):
+        """ Reads Overlap from `Sile` using `read_overlap`.
+
+        Parameters
+        ----------
+        sile : Sile, str or pathlib.Path
+            a `Sile` object which will be used to read the Overlap
+            and the overlap matrix (if any)
+            if it is a string it will create a new sile using `get_sile`.
+        * : args passed directly to ``read_overlap(,**)``
+        """
+        # This only works because, they *must*
+        # have been imported previously
+        from sisl.io import get_sile, BaseSile
+        if isinstance(sile, BaseSile):
+            return sile.read_overlap(*args, **kwargs)
+        else:
+            with get_sile(sile) as fh:
+                return fh.read_overlap(*args, **kwargs)
+
+    def write(self, sile, *args, **kwargs):
+        """ Writes a Hamiltonian to the `Sile` as implemented in the :code:`Sile.write_hamiltonian` method """
+        # This only works because, they *must*
+        # have been imported previously
+        from sisl.io import get_sile, BaseSile
+        if isinstance(sile, BaseSile):
+            sile.write_overlap(self, *args, **kwargs)
+        else:
+            with get_sile(sile, 'w') as fh:
+                fh.write_overlap(self, *args, **kwargs)


### PR DESCRIPTION
I ran into an issue when I was reading some .onlyS files and then writing them to .nc files, as it was working fine, but somehow the actual data disappeared. I realized some functionality was missing and implemented it. 