### PR TITLE
Deterministic ordering of tests for parallel runs

### DIFF
--- a/sisl/io/tests/test_object.py
+++ b/sisl/io/tests/test_object.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 import pytest
 import os.path as osp
 import numpy as np
@@ -19,7 +17,7 @@ gsc = get_sile_class
 
 
 def _my_intersect(a, b):
-    return list(set(get_siles(a)).intersection(get_siles(b)))
+    return [k for k in get_siles(a) if k in set(get_siles(b))]
 
 
 def _fnames(base, variants):


### PR DESCRIPTION
When running the tests with pytest-xdist, failure could occur because
a set intersection was used to generate them, which is not
deterministically ordered, so different processes did not have the same
(ordering of) tests. This changes the _my_intersect function to iterate
over a list rather than a set.