### PR TITLE
Fix crash in Overlap.fromsp due to overridden init

### DIFF
--- a/sisl/io/siesta/siesta_nc.py
+++ b/sisl/io/siesta/siesta_nc.py
@@ -162,7 +162,7 @@ class ncSileSiesta(SileCDFSiesta):
 
         # Now create the tight-binding stuff (we re-create the
         # array, hence just allocate the smallest amount possible)
-        C = cls(geom, dim, nnzpr=1)
+        C = cls(geom, dim=dim, nnzpr=1)
 
         C._csr.ncol = np.array(sp.variables['n_col'][:], np.int32)
         # Update maximum number of connections (in case future stuff happens)

--- a/sisl/physics/densitymatrix.py
+++ b/sisl/physics/densitymatrix.py
@@ -572,7 +572,7 @@ class DensityMatrix(_realspace_DensityMatrix):
 
     def __init__(self, geometry, dim=1, dtype=None, nnzpr=None, **kwargs):
         """ Initialize density matrix """
-        super(DensityMatrix, self).__init__(geometry, dim, dtype, nnzpr, **kwargs)
+        super(DensityMatrix, self).__init__(geometry, dim=dim, dtype=dtype, nnzpr=nnzpr, **kwargs)
         self._reset()
 
     def _reset(self):

--- a/sisl/physics/dynamicalmatrix.py
+++ b/sisl/physics/dynamicalmatrix.py
@@ -22,7 +22,7 @@ class DynamicalMatrix(SparseOrbitalBZ):
     """ Dynamical matrix of a geometry """
 
     def __init__(self, geometry, dim=1, dtype=None, nnzpr=None, **kwargs):
-        super(DynamicalMatrix, self).__init__(geometry, dim, dtype, nnzpr, **kwargs)
+        super(DynamicalMatrix, self).__init__(geometry, dim=dim, dtype=dtype, nnzpr=nnzpr, **kwargs)
         self._reset()
 
     def _reset(self):

--- a/sisl/physics/energydensitymatrix.py
+++ b/sisl/physics/energydensitymatrix.py
@@ -41,7 +41,7 @@ class EnergyDensityMatrix(_realspace_DensityMatrix):
     """
 
     def __init__(self, geometry, dim=1, dtype=None, nnzpr=None, **kwargs):
-        super(EnergyDensityMatrix, self).__init__(geometry, dim, dtype, nnzpr, **kwargs)
+        super(EnergyDensityMatrix, self).__init__(geometry, dim=dim, dtype=dtype, nnzpr=nnzpr, **kwargs)
         self._reset()
 
     def _reset(self):

--- a/sisl/physics/hamiltonian.py
+++ b/sisl/physics/hamiltonian.py
@@ -46,7 +46,7 @@ class Hamiltonian(SparseOrbitalBZSpin):
 
     def __init__(self, geometry, dim=1, dtype=None, nnzpr=None, **kwargs):
         """ Initialize Hamiltonian """
-        super(Hamiltonian, self).__init__(geometry, dim, dtype, nnzpr, **kwargs)
+        super(Hamiltonian, self).__init__(geometry, dim=dim, dtype=dtype, nnzpr=nnzpr, **kwargs)
         self._reset()
 
     def _reset(self):

--- a/sisl/physics/overlap.py
+++ b/sisl/physics/overlap.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division
 
-import numpy as np
 from .sparse import SparseOrbitalBZ
 
 __all__ = ['Overlap']
@@ -29,8 +28,9 @@ class Overlap(SparseOrbitalBZ):
 
     def __init__(self, geometry, dtype=None, nnzpr=None, **kwargs):
         """ Initialize Overlap """
-        kwargs["orthogonal"] = True # Avoid the dim += 1 in super
-        super(Overlap, self).__init__(geometry, 1, np.float64, nnzpr, **kwargs)
+        kwargs["orthogonal"] = True  # Avoid the dim += 1 in super
+        kwargs["dim"] = 1
+        super(Overlap, self).__init__(geometry, dtype=dtype, nnzpr=nnzpr, **kwargs)
 
     def _reset(self):
         super(Overlap, self)._reset()
@@ -56,7 +56,7 @@ class Overlap(SparseOrbitalBZ):
            The sparse matrix in a `scipy.sparse` format.
         **kwargs : optional
            any arguments that are directly passed to the ``__init__`` method
-           of the class.
+           of the class. `dtype` and `nnzpr` are overridden.
 
         Returns
         -------

--- a/sisl/physics/sparse.py
+++ b/sisl/physics/sparse.py
@@ -139,7 +139,7 @@ class SparseOrbitalBZ(SparseOrbital):
            returned sparse matrix to be non-orthogonal
         **kwargs : optional
            any arguments that are directly passed to the ``__init__`` method
-           of the class.
+           of the class. `dim`, `dtype`, `nnzpr` and `orthogonal` are overridden.
 
         Returns
         -------
@@ -164,7 +164,7 @@ class SparseOrbitalBZ(SparseOrbital):
             nnzpr = max(nnzpr, P[i].nnz // P[i].shape[0])
 
         # Create the sparse object
-        p = cls(geometry, dim, P[0].dtype, nnzpr, orthogonal=S is None, **kwargs)
+        p = cls(geometry, dim=dim, dtype=P[0].dtype, nnzpr=nnzpr, orthogonal=S is None, **kwargs)
 
         if p._size != P[0].shape[0]:
             raise ValueError(cls.__name__ + '.fromsp cannot create a new class, the geometry ' + \

--- a/sisl/physics/tests/test_overlap.py
+++ b/sisl/physics/tests/test_overlap.py
@@ -1,0 +1,91 @@
+from __future__ import print_function, division
+
+import pytest
+
+import numpy as np
+
+from sisl import Geometry, Atom, SphericalOrbital, AtomicOrbital, SuperCell
+from sisl import Grid, Spin
+from sisl.physics.overlap import Overlap
+
+
+@pytest.fixture
+def setup():
+    class t():
+        def __init__(self):
+            bond = 1.42
+            sq3h = 3.**.5 * 0.5
+            self.sc = SuperCell(np.array([[1.5, sq3h, 0.],
+                                          [1.5, -sq3h, 0.],
+                                          [0., 0., 10.]], np.float64) * bond, nsc=[3, 3, 1])
+
+            n = 60
+            rf = np.linspace(0, bond * 1.01, n)
+            rf = (rf, rf)
+            orb = SphericalOrbital(1, rf, 2.)
+            C = Atom(6, orb.toAtomicOrbital())
+            self.g = Geometry(np.array([[0., 0., 0.],
+                                        [1., 0., 0.]], np.float64) * bond,
+                              atom=C, sc=self.sc)
+            self.D = Overlap(self.g)
+
+            def func(D, ia, idxs, idxs_xyz):
+                idx = D.geom.close(ia, R=(0.1, 1.44), idx=idxs, idx_xyz=idxs_xyz)
+                ia = ia * 3
+
+                i0 = idx[0] * 3
+                i1 = idx[1] * 3
+                # on-site
+                p = 1.
+                D.D[ia, i0] = p
+                D.D[ia+1, i0+1] = p
+                D.D[ia+2, i0+2] = p
+
+                # nn
+                p = 0.1
+
+                # on-site directions
+                D.D[ia, ia+1] = p
+                D.D[ia, ia+2] = p
+                D.D[ia+1, ia] = p
+                D.D[ia+1, ia+2] = p
+                D.D[ia+2, ia] = p
+                D.D[ia+2, ia+1] = p
+
+                D.D[ia, i1+1] = p
+                D.D[ia, i1+2] = p
+
+                D.D[ia+1, i1] = p
+                D.D[ia+1, i1+2] = p
+
+                D.D[ia+2, i1] = p
+                D.D[ia+2, i1+1] = p
+
+            self.func = func
+    return t()
+
+
+@pytest.mark.overlap
+class TestOverlap(object):
+
+    def test_objects(self, setup):
+        assert len(setup.D.xyz) == 2
+        assert setup.g.no == len(setup.D)
+
+    def test_dtype(self, setup):
+        assert setup.D.dtype == np.float64
+
+    def test_ortho(self, setup):
+        assert not setup.D.orthogonal
+
+    def test_set1(self, setup):
+        D = setup.D.copy()
+        D.S[0, 0] = 1.
+        assert D[0, 0] == 1.
+        assert D[1, 0] == 0.
+
+    def test_fromsp(self, setup):
+        D = setup.D.copy()
+        csr = D.tocsr()
+        D2 = Overlap.fromsp(D.geom, csr)
+        assert np.allclose(csr.data, D2.tocsr().data)

--- a/sisl/sparse_geometry.py
+++ b/sisl/sparse_geometry.py
@@ -131,7 +131,7 @@ class _SparseGeometry(object):
         """
         if dtype is None:
             dtype = self.dtype
-        new = self.__class__(self.geometry.copy(), self.dim, dtype, 1, **self._cls_kwargs())
+        new = self.__class__(self.geometry.copy(), dim=self.dim, dtype=dtype, nnzpr=1, **self._cls_kwargs())
         # Be sure to copy the content of the SparseCSR object
         new._csr = self._csr.copy(dtype=dtype)
         return new
@@ -717,7 +717,7 @@ class _SparseGeometry(object):
             nnzpr = max(nnzpr, P[i].nnz // P[i].shape[0])
 
         # Create the sparse object
-        p = cls(geometry, dim, P[0].dtype, nnzpr, **kwargs)
+        p = cls(geometry, dim=dim, dtype=P[0].dtype, nnzpr=nnzpr, **kwargs)
 
         if p._size != P[0].shape[0]:
             raise ValueError(cls.__name__ + '.fromsp cannot create a new class, the geometry ' + \
@@ -1039,7 +1039,7 @@ class SparseAtom(_SparseGeometry):
         # Now we have a correct geometry, and
         # we are now ready to create the sparsity pattern
         # Reduce the sparsity pattern, first create the new one
-        S = self.__class__(geom, self.dim, self.dtype, np.amax(self._csr.ncol), **self._cls_kwargs())
+        S = self.__class__(geom, dim=self.dim, dtype=self.dtype, nnzpr=np.amax(self._csr.ncol), **self._cls_kwargs())
 
         def _sca2sca(M, a, m, seps, axis):
             # Converts an o from M to m
@@ -1098,7 +1098,7 @@ class SparseAtom(_SparseGeometry):
         idx.shape = (-1,)
 
         # Now create the new sparse orbital class
-        S = self.__class__(geom, self.dim, self.dtype, 1, **self._cls_kwargs())
+        S = self.__class__(geom, dim=self.dim, dtype=self.dtype, nnzpr=1, **self._cls_kwargs())
         S._csr = self._csr.sub(idx)
 
         return S
@@ -1129,7 +1129,7 @@ class SparseAtom(_SparseGeometry):
         """
         # Create the new sparse object
         g = self.geometry.tile(reps, axis)
-        S = self.__class__(g, self.dim, self.dtype, 1, **self._cls_kwargs())
+        S = self.__class__(g, dim=self.dim, dtype=self.dtype, nnzpr=1, **self._cls_kwargs())
 
         # Now begin to populate it accordingly
         # Retrieve local pointers to the information
@@ -1209,7 +1209,7 @@ class SparseAtom(_SparseGeometry):
         """
         # Create the new sparse object
         g = self.geometry.repeat(reps, axis)
-        S = self.__class__(g, self.dim, self.dtype, 1, **self._cls_kwargs())
+        S = self.__class__(g, dim=self.dim, dtype=self.dtype, nnzpr=1, **self._cls_kwargs())
 
         # Now begin to populate it accordingly
         # Retrieve local pointers to the information
@@ -1552,7 +1552,7 @@ class SparseOrbital(_SparseGeometry):
         # Now we have a correct geometry, and
         # we are now ready to create the sparsity pattern
         # Reduce the sparsity pattern, first create the new one
-        S = self.__class__(geom, self.dim, self.dtype, np.amax(self._csr.ncol), **self._cls_kwargs())
+        S = self.__class__(geom, dim=self.dim, dtype=self.dtype, nnzpr=np.amax(self._csr.ncol), **self._cls_kwargs())
 
         def _sco2sco(M, o, m, seps, axis):
             # Converts an o from M to m
@@ -1690,7 +1690,7 @@ class SparseOrbital(_SparseGeometry):
         idx.shape = (-1,)
 
         # Now create the new sparse orbital class
-        S = self.__class__(geom, self.dim, self.dtype, 1, **self._cls_kwargs())
+        S = self.__class__(geom, dim=self.dim, dtype=self.dtype, nnzpr=1, **self._cls_kwargs())
         S._csr = self._csr.sub(idx)
 
         return S
@@ -1768,7 +1768,7 @@ class SparseOrbital(_SparseGeometry):
             geom.atoms.replace_atom(old_atom, new_atom)
 
         # Now create the new sparse orbital class
-        SG = self.__class__(geom, self.dim, self.dtype, 1, **self._cls_kwargs())
+        SG = self.__class__(geom, dim=self.dim, dtype=self.dtype, nnzpr=1, **self._cls_kwargs())
 
         rem_orbs = delete(_a.arangei(old_atom.no), orbital)
         # Find orbitals to remove (note this HAS to be from the original array)
@@ -1806,7 +1806,7 @@ class SparseOrbital(_SparseGeometry):
         """
         # Create the new sparse object
         g = self.geometry.tile(reps, axis)
-        S = self.__class__(g, self.dim, self.dtype, 1, **self._cls_kwargs())
+        S = self.__class__(g, dim=self.dim, dtype=self.dtype, nnzpr=1, **self._cls_kwargs())
 
         # Now begin to populate it accordingly
         # Retrieve local pointers to the information
@@ -1886,7 +1886,7 @@ class SparseOrbital(_SparseGeometry):
         """
         # Create the new sparse object
         g = self.geometry.repeat(reps, axis)
-        S = self.__class__(g, self.dim, self.dtype, 1, **self._cls_kwargs())
+        S = self.__class__(g, dim=self.dim, dtype=self.dtype, nnzpr=1, **self._cls_kwargs())
 
         # Now begin to populate it accordingly
         # Retrieve local pointers to the information
@@ -2108,7 +2108,7 @@ class SparseOrbital(_SparseGeometry):
         # Now we have the correct geometry, then create the correct
         # class
         # New indices and data (the constructor for SparseCSR copies)
-        full = self.__class__(geom, self.dim, self.dtype, 1, **self._cls_kwargs())
+        full = self.__class__(geom, dim=self.dim, dtype=self.dtype, nnzpr=1, **self._cls_kwargs())
         full._csr.ptr = concatenate((self._csr.ptr[:-1], other._csr.ptr))
         full._csr.ptr[self.no:] += self._csr.ptr[-1]
         full._csr.ncol = concatenate((self._csr.ncol, other._csr.ncol))
@@ -2308,7 +2308,7 @@ class SparseOrbital(_SparseGeometry):
         # create the new sparsity patterns with offset
 
         # New indices and data (the constructor for SparseCSR copies)
-        full = self.__class__(geom, self.dim, self.dtype, 1, **self._cls_kwargs())
+        full = self.__class__(geom, dim=self.dim, dtype=self.dtype, nnzpr=1, **self._cls_kwargs())
         full._csr.ptr = concatenate((self._csr.ptr[:-1], other._csr.ptr))
         full._csr.ptr[self.no:] += self._csr.ptr[-1]
         full._csr.ncol = concatenate((self._csr.ncol, other._csr.ncol))


### PR DESCRIPTION
Using Overlap.fromsp would crash with the message "__init__() takes from
2 to 4 positional arguments but 5 were given". This was due to the class
instantiation call in super().fromsp which used positional arguments
that coincided with that class's kwargs, but not with the Overlap
object's kwargs. Putting the `dim` kwarg into **kwargs was also
necessary to allow it being passed (but still overridden), similar to
the `orthogonal` keyword.