### PR TITLE
Reading geometry from fdf-file when reading a binary requires to know correct number of orbitals.

### DIFF
--- a/sisl/io/siesta/bands.py
+++ b/sisl/io/siesta/bands.py
@@ -66,7 +66,7 @@ class bandsSileSiesta(SileSiesta):
             k = np.empty([nk, 3], np.float64)
             for ik in range(nk):
                 l = [float(x) for x in self.readline().split()]
-                k[ik, :] = l[0:2]
+                k[ik, :] = l[0:3]
                 del l[2]
                 del l[1]
                 del l[0]

--- a/sisl/io/siesta/fdf.py
+++ b/sisl/io/siesta/fdf.py
@@ -1524,7 +1524,7 @@ class fdfSileSiesta(SileSiesta):
         if f.is_file():
             if 'geometry' not in kwargs:
                 # to ensure we get the correct orbital count
-                kwargs['geometry'] = self.read_geometry(True, order=['nc', 'TSHS'])
+                kwargs['geometry'] = self.read_geometry(True, order=['nc', 'TSHS', 'fdf'])
             DM = tsdeSileSiesta(f).read_density_matrix(*args, **kwargs)
             self._r_add_overlap('_r_density_matrix_tsde', DM)
         return DM
@@ -1536,7 +1536,7 @@ class fdfSileSiesta(SileSiesta):
         if f.is_file():
             if 'geometry' not in kwargs:
                 # to ensure we get the correct orbital count
-                kwargs['geometry'] = self.read_geometry(True, order=['nc', 'TSHS'])
+                kwargs['geometry'] = self.read_geometry(True, order=['nc', 'TSHS', 'fdf'])
             DM = dmSileSiesta(f).read_density_matrix(*args, **kwargs)
             self._r_add_overlap('_r_density_matrix_dm', DM)
         return DM
@@ -1623,7 +1623,7 @@ class fdfSileSiesta(SileSiesta):
         if f.is_file():
             if 'geometry' not in kwargs:
                 # to ensure we get the correct orbital count
-                kwargs['geometry'] = self.read_geometry(True, order=['nc', 'TSHS'])
+                kwargs['geometry'] = self.read_geometry(True, order=['nc', 'TSHS', 'fdf'])
             S = hsxSileSiesta(f).read_overlap(*args, **kwargs)
         return S
 
@@ -1634,7 +1634,7 @@ class fdfSileSiesta(SileSiesta):
         if f.is_file():
             if 'geometry' not in kwargs:
                 # to ensure we get the correct orbital count
-                kwargs['geometry'] = self.read_geometry(True, order=['nc', 'TSHS'])
+                kwargs['geometry'] = self.read_geometry(True, order=['nc', 'TSHS', 'fdf'])
             S = onlysSileSiesta(f).read_overlap(*args, **kwargs)
         return S
 
@@ -1682,7 +1682,7 @@ class fdfSileSiesta(SileSiesta):
         if f.is_file():
             if 'geometry' not in kwargs:
                 # to ensure we get the correct orbital count
-                kwargs['geometry'] = self.read_geometry(True, order=['nc', 'TSHS'])
+                kwargs['geometry'] = self.read_geometry(True, order=['nc', 'TSHS', 'fdf'])
             H = hsxSileSiesta(f).read_hamiltonian(*args, **kwargs)
         return H
 


### PR DESCRIPTION
I suggest, adding 'fdf' as an option to read the geometry when `fdfSile.read_hamiltonian` and similar functions. 

These functions rely on knowing the correct number of orbitals.  However, when neither SystemLabel.nc nor SystemLabel.TSHS was generated, an attempt at guessing the geometry is being made.

While reading from the fdf file does not under all circumstances guarantee to return the correct number of orbitals, I would argue it is worth attempting.

