### PR TITLE
Fixed bug in Geometry.rotate_miller

### DIFF
--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -1570,7 +1570,7 @@ class Geometry(SuperCellChild):
 
         # Now rotate the angle between them
         a = acos(np.sum(lm * lv))
-        return self.rotate(a, cp)
+        return self.rotate(a, cp, rad = True)
 
     def move(self, v, atom=None, cell=False):
         """ Translates the geometry by `v`

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -1570,7 +1570,7 @@ class Geometry(SuperCellChild):
 
         # Now rotate the angle between them
         a = acos(np.sum(lm * lv))
-        return self.rotate(a, cp, rad = True)
+        return self.rotate(a, cp, rad=True)
 
     def move(self, v, atom=None, cell=False):
         """ Translates the geometry by `v`


### PR DESCRIPTION
rotate_miller was passing an angle in radians to Geometry.rotate without the rad keyword set to true and therefore it was not working properly. 