### PR TITLE
Getting and setting atoms by tag in sisl.Atoms

### DIFF
--- a/sisl/atom.py
+++ b/sisl/atom.py
@@ -1106,6 +1106,9 @@ class Atom(metaclass=AtomMeta):
             return [self.orbital[o] for o in range(ol[0], ol[1], ol[2])]
         elif isinstance(key, Integral):
             return self.orbital[key]
+        elif isinstance(key, str):
+            orbs = [orb for orb in self.orbital if key.lower() in orb.name().lower()]
+            return orbs if len(orbs) != 1 else orbs[0]
         return [self.orbital[o] for o in np.asarray(key).ravel()]
 
     def maxR(self):

--- a/sisl/atom.py
+++ b/sisl/atom.py
@@ -1683,17 +1683,23 @@ class Atoms:
             return [self.atom[self._specie[s]] for s in range(sl[0], sl[1], sl[2])]
         elif isinstance(key, Integral):
             return self.atom[self._specie[key]]
+        elif isinstance(key, str):
+            return [at for at in self.atom if at.tag == key][0]
         return [self.atom[i] for i in self._specie[_a.asarrayi(key).ravel()]]
 
     def __setitem__(self, key, value):
         """ Overwrite an `Atom` object corresponding to the key(s) """
+        #If key is a string, we replace the atom that matches 'key'
+        if isinstance(key, str):
+            return self.replace_atom(self[key], value)
+
         # Convert to array
         if isinstance(key, slice):
             sl = key.indices(len(self))
             key = _a.arangei(sl[0], sl[1], sl[2])
         else:
             key = _a.asarrayi(key).ravel()
-
+        
         if len(key) == 0:
             if value not in self:
                 self._atom.append(value)

--- a/sisl/tests/test_atoms.py
+++ b/sisl/tests/test_atoms.py
@@ -57,8 +57,10 @@ def test_len(setup):
 def test_get1():
     atoms = Atoms(['C', 'C', 'Au'])
     assert atoms[2] == Atom('Au')
+    assert atoms['Au'] == Atom('Au')
     assert atoms[0] == Atom('C')
     assert atoms[1] == Atom('C')
+    assert atoms['C'] == Atom('C')
     assert atoms[0:2] == [Atom('C')]*2
     assert atoms[1:] == [Atom('C'), Atom('Au')]
 
@@ -70,6 +72,9 @@ def test_set1():
     assert atom[1] == Atom('C')
     atom[1] = Atom('Au')
     assert atom[0] == Atom('C')
+    assert atom[1] == Atom('Au')
+    atom['C'] = Atom('Au')
+    assert atom[0] == Atom('Au')
     assert atom[1] == Atom('Au')
 
 
@@ -84,6 +89,12 @@ def test_set2():
     assert atom[1] != Atom('Au')
     assert atom[1] == Atom('Au', [-1] * 2)
     assert len(atom.atom) == 2
+    atom['C'] = Atom('Au', [-1] * 2)
+    assert atom[0] != Atom('Au')
+    assert atom[0] == Atom('Au', [-1] * 2)
+    assert atom[1] != Atom('Au')
+    assert atom[1] == Atom('Au', [-1] * 2)
+    assert len(atom.atom) == 1
 
 
 def test_set3():


### PR DESCRIPTION
Hi!

I just needed this and since there was no functionality implemented yet for getting atoms by tag in the `Atoms` class I thought it doesn't do harm to have it there just in case someone might find it useful.

Basically:

```python
atoms = sisl.Atoms(["C","C","Au")
atoms["C"]
```
will get you the atom object with tag "C".

and

```python
atoms["C"] = "N"
```
acts as a shortcut for `replace_atom` and will replace all "C" atoms by "N".

I also implemented some tests for it.

Sorry for submitting so much pull requests, I thought since I need these things, someone in the future might find it handy :)