### PR TITLE
Enhancing the siesta outSile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,10 @@ build
 *.pyc
 *.so
 __config__.py
-index.rst
 docs/build
 docs/sisl
 sisl.egg-info
 sisl/info.py
 sisl/io/siesta/_siesta.so
 sisl/**/*.html
+.vscode/

--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -295,7 +295,7 @@ class outSileSiesta(SileSiesta):
             if last:
                 return Fs[-1]
             if self.job_completed:
-                return Fs[:-1]
+                return np.array(Fs[:-1])
             return np.array(Fs)
 
         return next_force()

--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -272,6 +272,9 @@ class outSileSiesta(SileSiesta):
                 - atomic (default): (nMDsteps, nAtoms, 3)
                 - total: (nMDsteps, 3)
                 - maxF: (nMDsteps, )
+            
+            If `all` is `False`, the first dimension does not exist. In the case of maxF, the returned value
+            will therefore be just a float, not an array.
         """
         if all:
             last = False

--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -269,7 +269,10 @@ class outSileSiesta(SileSiesta):
 
             # Now read data
             F = []
-            line = self.readline()
+            line = self.readline() # This line may be the first separator
+            if '---' in line:
+                line = self.readline()
+
             while '---' not in line:
                 line = line.split()
                 F.append([float(x) for x in line[-3:]])

--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -296,7 +296,7 @@ class outSileSiesta(SileSiesta):
                 return Fs[-1]
             if self.job_completed:
                 return Fs[:-1]
-            return Fs
+            return np.array(Fs)
 
         return next_force()
 

--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -325,7 +325,7 @@ class outSileSiesta(SileSiesta):
                 Fs.append(F)
 
             if last:
-                return Fs[-1]
+                return Fs[-1] if not maxF else Fs[-2]
             if self.job_completed:
                 return np.array(Fs[:-1])
             return np.array(Fs)

--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -239,7 +239,7 @@ class outSileSiesta(SileSiesta):
         return next_geom()[1]
 
     @sile_fh_open()
-    def read_force(self, last=True, all=False, total=False, maxF=False):
+    def read_force(self, last=True, all=False, total=False, max=False):
         """ Reads the forces from the Siesta output file
 
         Parameters
@@ -251,9 +251,8 @@ class outSileSiesta(SileSiesta):
            If `True` `last` is ignored
         total: bool, optional
             return the total forces instead of the atomic forces.
-        maxF: bool, optional
+        max: bool, optional
             whether only the maximum atomic force should be returned for each step.
-            If `True`, `total` is ignored.
 
             Setting it to `True` is equivalent to `max(outSile.read_force())` in case atomic forces
             are written in the output file (`WriteForces .true.` in the fdf file)
@@ -271,10 +270,12 @@ class outSileSiesta(SileSiesta):
             The shape of the array will be different depending on the type of forces requested:
                 - atomic (default): (nMDsteps, nAtoms, 3)
                 - total: (nMDsteps, 3)
-                - maxF: (nMDsteps, )
+                - max: (nMDsteps, )
             
-            If `all` is `False`, the first dimension does not exist. In the case of maxF, the returned value
+            If `all` is `False`, the first dimension does not exist. In the case of max, the returned value
             will therefore be just a float, not an array.
+
+            If `total` and `max` are both `True`, they are returned separately as a tuple: (total, max)
         """
         if all:
             last = False
@@ -295,7 +296,7 @@ class outSileSiesta(SileSiesta):
             # First, we encounter the atomic forces
             while '---' not in line:
                 line = line.split()
-                if not total or maxF:
+                if not total or max:
                     F.append([float(x) for x in line[-3:]])
                 line = self.readline()
                 if line == '':
@@ -308,11 +309,22 @@ class outSileSiesta(SileSiesta):
                 
             line = self.readline()
             #And after that we can read the max force
-            if maxF and len(line.split()) != 0:
+            if max and len(line.split()) != 0:
                 line = self.readline()
-                F = float(line.split()[1])
+                maxF = float(line.split()[1])
 
-            return F if maxF else np.array(F)
+                # In case total is also requested, we are going to store it all in the same variable
+                # It will be separated later
+                F = maxF if not total else [*F, maxF]
+
+            return F if max and not total else np.array(F)
+        
+        def return_forces(Fs):
+
+            if Fs.ndim == 1:
+                return (Fs[:-1], Fs[-1]) if max and total else Fs
+            else:
+                return (Fs[:, :-1], Fs[:, -1]) if max and total else Fs
 
         # list of all forces
         Fs = []
@@ -324,13 +336,20 @@ class outSileSiesta(SileSiesta):
                     break
                 Fs.append(F)
 
-            if last:
-                return Fs[-1] if not maxF else Fs[-2]
-            if self.job_completed:
-                return np.array(Fs[:-1])
-            return np.array(Fs)
+            if not (last and max and not total):
+                # If last and max and not total, Fs is just a float :)
+                Fs = np.array(Fs)
 
-        return next_force()
+            if last:
+                return return_forces(Fs[-2])
+                # F[-2] is really the same as F[-1], the last forces are stated twice
+                # However, the maxForce is not stated in the final summary, that's why we use F[-2]
+            if self.job_completed:
+                return return_forces(Fs[:-1])
+            return return_forces(Fs)
+        
+        Fs = next_force()
+        return return_forces(Fs)
 
     @sile_fh_open()
     def read_stress(self, key='static', last=True, all=False):

--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -249,19 +249,29 @@ class outSileSiesta(SileSiesta):
         all: bool, optional
            return a list of all forces (like an MD)
            If `True` `last` is ignored
+        total: bool, optional
+            return the total forces instead of the atomic forces.
         maxF: bool, optional
             whether only the maximum atomic force should be returned for each step.
-            Note that this is not the same as doing `max(outSile.read_force(total=True))` since
-            the forces returned in that case are averages on each axis.
+            If `True`, `total` is ignored.
 
             Setting it to `True` is equivalent to `max(outSile.read_force())` in case atomic forces
             are written in the output file (`WriteForces .true.` in the fdf file)
 
+            Note that this is not the same as doing `max(outSile.read_force(total=True))` since
+            the forces returned in that case are averages on each axis.
+
+            
         Returns
         -------
         numpy.ndarray or None
             returns ``None`` if the forces are not found in the
             output, otherwise forces will be returned
+
+            The shape of the array will be different depending on the type of forces requested:
+                - atomic (default): (nMDsteps, nAtoms, 3)
+                - total: (nMDsteps, 3)
+                - maxF: (nMDsteps, )
         """
         if all:
             last = False

--- a/sisl/io/siesta/tests/test_out.py
+++ b/sisl/io/siesta/tests/test_out.py
@@ -43,8 +43,11 @@ def test_md_nose_out(sisl_files):
     nAtoms = 10
     atomicF = out.read_force(all=True)
     totalF = out.read_force(total=True)
-    maxF = out.read_force(maxF=True)
+    maxF = out.read_force(max=True)
     assert atomicF.shape == (nOutputs, nAtoms, 3 )
+    assert totalF.shape == (nOutputs, 3)
+    assert maxF.shape == (nOutputs, )
+    totalF, maxF = out.read_force(total=True, max=True)
     assert totalF.shape == (nOutputs, 3)
     assert maxF.shape == (nOutputs, )
 

--- a/sisl/io/siesta/tests/test_out.py
+++ b/sisl/io/siesta/tests/test_out.py
@@ -29,14 +29,24 @@ def test_md_nose_out(sisl_files):
 
     # try and read all outputs
     # there are 5 outputs in this output file.
-    assert len(out.read_geometry(all=True)) == 5
-    assert len(out.read_force(all=True)) == 5
-    assert len(out.read_stress(all=True)) == 5
+    nOutputs = 5
+    assert len(out.read_geometry(all=True)) == nOutputs
+    assert len(out.read_force(all=True)) == nOutputs
+    assert len(out.read_stress(all=True)) == nOutputs
     f0 = out.read_force(last=False)
     f = out.read_force()
     f1 = out.read_data(force=True)
     assert not np.allclose(f0, f)
     assert np.allclose(f1, f)
+
+    #Check that we can read the different types of forces
+    nAtoms = 10
+    atomicF = out.read_force(all=True)
+    totalF = out.read_force(total=True)
+    maxF = out.read_force(maxF=True)
+    assert atomicF.shape == (nOutputs, nAtoms, 3 )
+    assert totalF.shape == (nOutputs, 3)
+    assert maxF.shape == (nOutputs, )
 
     s0 = out.read_stress(last=False)
     s = out.read_stress()


### PR DESCRIPTION
*In the visualization module, plots have the ability to listen to changes in files*. The main idea I had in mind for providing this feature was to **monitorize simulations in real time**. The outSile is clearly a main target for this type of application and I would like to enhance it so that we can benefit from it.

**With this in mind:**
- In the `read_force()` method, I added the possibility to read *total forces* and *max force* apart from the atomic forces which were already implemented. I added also some tests for it.
- The `read_scf()` method is awesome for this application! :)
- I did not want to touch anything because the way in which you manage file handles seems very well organized and I did not want to mess up with it, but: is there a possibility that the `_job_completed` attribute could be determined on `__init__()` by reading the last line of the file? It seems weird that you need to read a property that reads all the file to know whether the job is completed or not.
