### PR TITLE
Fixed some bugs in the out sile

### DIFF
--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -295,7 +295,7 @@ class outSileSiesta(SileSiesta):
             # First, we encounter the atomic forces
             while '---' not in line:
                 line = line.split()
-                if not total or max:
+                if not (total or max):
                     F.append([float(x) for x in line[-3:]])
                 line = self.readline()
                 if line == '':

--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -291,6 +291,10 @@ class outSileSiesta(SileSiesta):
             # Now read data
             F = []
             line = self.readline()
+            if 'siesta:' in line:
+                # This is the final summary, we don't need to read it as it does not contain new information
+                # and also it make break things since max forces are not written there
+                return None
 
             # First, we encounter the atomic forces
             while '---' not in line:
@@ -328,8 +332,8 @@ class outSileSiesta(SileSiesta):
             if max and total:
                 return (Fs[..., :-1], Fs[..., -1])
             elif max and not all:
-                # This will return a float (or actually a numpy.dtype)
-                return Fs[0]
+                # This will return a float
+                return np.atleast_1d(Fs)[0]
             return Fs
 
         if all or last:
@@ -342,11 +346,8 @@ class outSileSiesta(SileSiesta):
                 Fs.append(F)
 
             if last:
-                return return_forces(Fs[-2])
-                # F[-2] is really the same as F[-1], the last forces are stated twice
-                # However, the maxForce is not stated in the final summary, that's why we use F[-2]
-            if self.job_completed:
-                return return_forces(Fs[:-1])
+                return return_forces(Fs[-1])
+ 
             return return_forces(Fs)
 
         return return_forces(next_force())


### PR DESCRIPTION
Some things were wrong with my previous implementation, sorry.

- The logic for reading atomic forces was `not total or max` when it should be `not (total or max)`.
- I've noticed (the hard way, i.e. because the method fails for one of my files), that the forces summary is not always written even if the job is completed. I don't know which versions of SIESTA show this behavior. I've added checking if `'siesta:'` is in the line with the forces value to dismiss the summary if it is there, as it does not provide new information. Do you think this is safe to do?
-  When `max and not all`, Fs was an adimensional numpy array and we were trying to retrieve the first item, which results in an error.
