### PR TITLE
enh: enable selective dynamics when writing POSCAR files

### DIFF
--- a/sisl/io/vasp/car.py
+++ b/sisl/io/vasp/car.py
@@ -67,9 +67,10 @@ class carSileVASP(SileVASP):
         self._write(fmt.format(*s))
         fmt = ' {:d}' * len(d) + '\n'
         self._write(fmt.format(*d))
+        self._write('Selective dynamics\n')
         self._write('Cartesian\n')
 
-        fmt = '{:18.9f}' * 3 + '\n'
+        fmt = '{:18.9f}' * 3 + ' F F F\n'
         for ia in geometry:
             self._write(fmt.format(*geometry.xyz[ia, :]))
 


### PR DESCRIPTION
For geometry optimizations with `VASP` I find the "Selective Dynamics" format very handy: one simply sets each degree of freedom to either `True` or `False`. I propose that `sisl` should use this format as default for writing `POSCAR` files.