### PR TITLE
Ensure that orbital is pickleable

### DIFF
--- a/sisl/orbital.py
+++ b/sisl/orbital.py
@@ -1046,7 +1046,7 @@ class AtomicOrbital(Orbital):
         # A function is not necessarily pickable, so we store interpolated
         # data which *should* ensure the correct pickable state (to close agreement)
         r = np.linspace(0, self.R, 1000)
-        f = self.orb.f(r)
+        f = self.orb.f(r) if hasattr(self.orb, "f") else None
         return {'name': self.name(), 'r': r, 'f': f, 'q0': self.q0, 'tag': self.tag}
 
     def __setstate__(self, d):


### PR DESCRIPTION
Hey Nick!

If you could merge this or a similar fix to avoid problems when an orbital doesn't have a "f" attribute or it is not a function it would make me very happy, because it was messing with the plots' pickling abilities :)

Thaaanks!