### PR TITLE
WIP: improved Geometry.sort, for #191

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 0.9.9
 =====
 
+- Changed Geometry.sort to be more diverse (this may break old code)
+  This new way of sorting is way more flexible and allows very fine
+  control, partially fixes #191
+
 - Added a bilayer geometry which can create twisted bilayers #181, #186
 
 - Enabled VASP *CAR files to write/read dynamic specifications #185

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
 
 - Changed Geometry.sort to be more diverse (this may break old code)
   This new way of sorting is way more flexible and allows very fine
-  control, partially fixes #191
+  control, fixes #191, #197
 
 - Added a bilayer geometry which can create twisted bilayers #181, #186
 

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -1072,12 +1072,13 @@ class Geometry(SuperCellChild):
            for subsequent sorting methods).
            In either case the returned indices must never hold any other indices but the ones passed
            as ``atom``.
-        ascend : bool, optional
-            control ascending or descending sorting, default ``True``
+        ascend, descend : bool, optional
+            control ascending or descending sorting for all subsequent sorting methods.
+            Default ``ascend=True``.
         atol : float, optional
-            absolute tolerance when sorting numerical arrays. When a selection of sorted coordinates
-            are grouped via `atol`, we ensure such a group does not alter its indices. I.e. the group
-            is *always* ascending indices.
+            absolute tolerance when sorting numerical arrays for subsequent sorting methods.
+            When a selection of sorted coordinates are grouped via `atol`, we ensure such
+            a group does not alter its indices. I.e. the group is *always* ascending indices.
             Note this may have unwanted side-effects if `atol` is very large.
             Default ``1e-9``.
 
@@ -1121,6 +1122,7 @@ class Geometry(SuperCellChild):
         >>> geom.sort(axis=2, ascend=False, lattice=0)
 
         Sort according to :math:`z` (descending), then first lattice vector (ascending)
+        Note how integer suffixes has no importance.
 
         >>> geom.sort(ascend0=False, axis=2, ascend1=True, lattice=0)
 
@@ -1161,11 +1163,23 @@ class Geometry(SuperCellChild):
         A too high `atol` may have unexpected side-effects. This is because of the way
         the sorting algorithm splits the sections for nested sorting.
         So for coordinates with a continuous displacement the sorting may break and group
-        a large range into 1 group.
+        a large range into 1 group. Consider the following array to be split in groups
+        while sorting.
 
-        >>> a = np.arange(5) * 0.1
-        >>> (np.diff(a) > 0.05).nonzero()[0]
+        >>> a = np.arange(5) * 0.01
+        >>> a[3:] += 0.1
+
+        For a high tolerance we have:
+
+        >>> (np.diff(a) > 0.02).nonzero()[0]
+        [2]
+
+        This would split the sorting into sections ``a[:3]`` and ``a[3:]``
+
+        >>> (np.diff(a) > 0.002).nonzero()[0]
         [0, 1, 2, 3]
+
+        This would split the sorting into sections ``a[:1]``, ``a[1:2]``, ``a[2:3]``, ``a[3:4]`` and ``a[4:5]``
         """
         # We need a way to easily handle nested lists
         # This small class handles lists and allows appending nested lists
@@ -4154,7 +4168,7 @@ class Geometry(SuperCellChild):
                 ns._geometry = ns._geometry.sort(**kwargs)
         p.add_argument(*opts('--sort'), nargs=1, metavar='SORT',
                        action=Sort,
-                       help='Semi-colon separated options for sort [axis=0;descend;lattice=(1, 2)].')
+                       help='Semi-colon separated options for sort, please always encapsulate in quotation ["axis=0;descend;lattice=(1, 2)"].')
 
         # Print some common information about the
         # geometry (to stdout)

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -1027,6 +1027,7 @@ class Geometry(SuperCellChild):
         There are many ways to sort a `Geometry`.
         - by Cartesian coordinates, `axis`
         - by lattice vectors, `lattice`
+        - by user defined vectors, `vector`
         - a combination of the above in arbitrary order
 
         Additionally one may sort ascending or descending.
@@ -1075,6 +1076,7 @@ class Geometry(SuperCellChild):
         All arguments may be suffixed with integers. This allows multiple keyword arguments
         to control sorting algorithms
         in different order. It also allows changing of sorting settings between different calls.
+        Note that the integers have no relevance to the order of execution!
         See examples.
 
         Returns
@@ -1136,6 +1138,11 @@ class Geometry(SuperCellChild):
         Sort along a user defined vector ``[2, 1, 0]``
 
         >>> geom.sort(vector=[2, 1, 0])
+
+        Integer specification has no influence on the order of operations.
+        It is _always_ the keyword argument order that determines the operation.
+
+        >>> assert geom.sort(axis2=1, axis0=0, axis1=2) == geom.sort(axis=(1, 0, 2))
 
         A too high `atol` may have unexpected side-effects. This is because of the way
         the sorting algorithm splits the sections for nested sorting.

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -1133,7 +1133,7 @@ class Geometry(SuperCellChild):
 
         >>> assert geom.sort() == geom.sort(axis=(0, 1, 2))
 
-        Sort along a user defined lattice vector ``[2, 1, 0]``
+        Sort along a user defined vector ``[2, 1, 0]``
 
         >>> geom.sort(vector=[2, 1, 0])
 

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -4104,7 +4104,7 @@ class Geometry(SuperCellChild):
                         val = lstranges(strmap(int, val))
                     # parse `val` to appropriate values
                     # we always add integers to allow users to use the same keywords on commandline
-                    kwargs[opt + str(i)] = val
+                    kwargs[opt.strip() + str(i)] = val
                 ns._geometry = ns._geometry.sort(**kwargs)
         p.add_argument(*opts('--sort'), nargs=1, metavar='SORT',
                        action=Sort,

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -1177,7 +1177,7 @@ class Geometry(SuperCellChild):
 
         def _sort(val, nl, **kwargs):
             """ We do not sort according to lexsort """
-            if len(val) <= 0:
+            if len(val) <= 1:
                 # no values to sort
                 return nl
 

--- a/sisl/tests/test_geometry.py
+++ b/sisl/tests/test_geometry.py
@@ -1307,7 +1307,7 @@ def test_geometry_sort_simple():
     for ix in idx:
         assert np.all(np.diff(bi.fxyz[ix, 1]) >= -atol)
 
-    s, idx = bi.sort(axis=0, ascending=False, lattice=1, ret_atom=True)
+    s, idx = bi.sort(axis=0, ascending=False, lattice=1, vector=[0, 0, 1], ret_atom=True)
     assert np.all(np.diff(s.xyz[:, 0]) >= -atol)
     for ix in idx:
         # idx is according to bi

--- a/sisl/tests/test_geometry.py
+++ b/sisl/tests/test_geometry.py
@@ -1339,6 +1339,46 @@ def test_geometry_sort_int():
         assert np.all(np.diff(bi.fxyz[ix, 1] * bi.sc.length[i]) <= atol)
 
 
+def test_geometry_sort_atom():
+    bi = sisl_geom.bilayer().tile(2, 0).repeat(2, 1)
+
+    atom = [[2, 0], [3, 1]]
+    out = bi.sort(atom=atom)
+
+    atom = np.concatenate(atom)
+    all_atoms = np.arange(len(bi))
+    all_atoms[np.sort(atom)] = atom[:]
+    assert np.allclose(out.xyz, bi.sub(all_atoms).xyz)
+
+
+def test_geometry_sort_func():
+    bi = sisl_geom.bilayer().tile(2, 0).repeat(2, 1)
+
+    def reverse_sorting(geometry, atom, **kwargs):
+        l = []
+        for at in atom:
+            l.append(at[::-1])
+        return l
+    atom = [[2, 0], [3, 1]]
+    out = bi.sort(func=reverse_sorting, atom=atom)
+
+    all_atoms = np.arange(len(bi))
+    all_atoms[1] = 2
+    all_atoms[2] = 1
+
+    assert np.allclose(out.xyz, bi.sub(all_atoms).xyz)
+
+    # Ensure that they are swapped
+    atom = [2, 0]
+    out = bi.sort(func=reverse_sorting, atom=atom)
+
+    assert np.allclose(out.xyz, bi.xyz)
+
+    out = bi.sort(func=reverse_sorting)
+    all_atoms = np.arange(len(bi))[::-1]
+    assert np.allclose(out.xyz, bi.sub(all_atoms).xyz)
+
+
 @pytest.mark.xfail(raises=ValueError)
 def test_geometry_sort_fail_keyword():
     sisl_geom.bilayer().sort(not_found_keyword=True)

--- a/sisl/tests/test_geometry.py
+++ b/sisl/tests/test_geometry.py
@@ -1287,3 +1287,58 @@ class TestGeometry:
         idx22, idx44 = gr22.overlap(gr44, offset=-offset)
         assert np.allclose(idx22, np.arange(gr22.na))
         assert np.allclose(idx44, idx)
+
+
+def test_geometry_sort_simple():
+    bi = sisl_geom.bilayer().tile(2, 0).repeat(3, 1)
+
+    # the default tolerance is 1e-9, and since we are sorting
+    # in each group, we may in the end find another ordering
+    atol = 1e-9
+
+    for i in [0, 1, 2]:
+        s = bi.sort(axis=i)
+        assert np.all(np.diff(s.xyz[:, i]) >= -atol)
+        s = bi.sort(lattice=i)
+        assert np.all(np.diff(s.fxyz[:, i] * bi.sc.length[i]) >= -atol)
+
+    s, idx = bi.sort(axis=0, lattice=1, ret_atom=True)
+    assert np.all(np.diff(s.xyz[:, 0]) >= -atol)
+    for ix in idx:
+        assert np.all(np.diff(bi.fxyz[ix, 1]) >= -atol)
+
+    s, idx = bi.sort(axis=0, ascending=False, lattice=1, ret_atom=True)
+    assert np.all(np.diff(s.xyz[:, 0]) >= -atol)
+    for ix in idx:
+        # idx is according to bi
+        assert np.all(np.diff(bi.fxyz[ix, 1] * bi.sc.length[i]) <= atol)
+
+
+def test_geometry_sort_int():
+    bi = sisl_geom.bilayer().tile(2, 0).repeat(3, 1)
+
+    # the default tolerance is 1e-9, and since we are sorting
+    # in each group, we may in the end find another ordering
+    atol = 1e-9
+
+    for i in [0, 1, 2]:
+        s = bi.sort(axis0=i)
+        assert np.all(np.diff(s.xyz[:, i]) >= -atol)
+        s = bi.sort(lattice3=i)
+        assert np.all(np.diff(s.fxyz[:, i] * bi.sc.length[i]) >= -atol)
+
+    s, idx = bi.sort(axis12314=0, lattice0=1, ret_atom=True)
+    assert np.all(np.diff(s.xyz[:, 0]) >= -atol)
+    for ix in idx:
+        assert np.all(np.diff(bi.fxyz[ix, 1]) >= -atol)
+
+    s, idx = bi.sort(ascending1=True, axis15=0, ascending0=False, lattice235=1, ret_atom=True)
+    assert np.all(np.diff(s.xyz[:, 0]) >= -atol)
+    for ix in idx:
+        # idx is according to bi
+        assert np.all(np.diff(bi.fxyz[ix, 1] * bi.sc.length[i]) <= atol)
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_geometry_sort_fail_keyword():
+    sisl_geom.bilayer().sort(not_found_keyword=True)


### PR DESCRIPTION
This change allows very complicated sort calls.

- [x] ascending/descending along lattice vectors
- [x] ascending/descending along Cartesian coordinates
- [x] ascending/descending along a vector
- [x] external function to sort indices
- [x] species
- [x] group labelling
- [x] combinations (e.g. first species, then axes), this is particularly easy since Python >=3.6 uses ordered dicts for `**kwargs`, so `sort` should change interface to `**kwargs`
- [x] the above on a subset of atoms

All sorts are now chained (much like lexsort).
One can now do

    geom.sort(axis=0, lattice=0, axis1=1)

to first sort Cartesian x, then for each subgroup in this
sort according to first lattice vector, then for each subgroup
sort according to Cartesian y.

Note how axis1 allows numeric flags to allow multiple same
sorting algorithms for the same (to achieve different order
of sort).
One can also add ascending/descending

    geom.sort(axis=0, ascend=False, lattice=1, ascend=True, axis=1)

to ascend-sort x, descend-sort fa, ascend-sort y.

Also added preliminary support for sort in sgeom.

@tfrederiksen could you please have a look