### PR TITLE
Added __repr__ to some common classes

### DIFF
--- a/sisl/atom.py
+++ b/sisl/atom.py
@@ -1175,6 +1175,9 @@ class Atom(object):
         orbs = ',\n '.join([str(o) for o in self.orbital])
         return self.__class__.__name__ + '{{{0}, Z: {1:d}, mass(au): {2:.5f}, maxR: {3:.5f},\n {4}\n}}'.format(self.tag, self.Z, self.mass, self.maxR(), orbs)
 
+    def __repr__(self):
+        return f"<sisl.{self.__class__.__name__} {self.tag}, Z={self.Z}, M={self.mass}, maxR={self.maxR()}, no={len(self.orbital)}>"
+
     def __len__(self):
         """ Return number of orbitals in this atom """
         return self.no
@@ -1643,6 +1646,9 @@ class Atoms(object):
         for a, idx in self.iter(True):
             s += ' {1}: {0},\n'.format(len(idx), str(a).replace('\n', '\n '))
         return s + '}'
+
+    def __repr__(self):
+        return f"<sisl.{self.__class__.__name__} nspecies={len(self._atom)}, na={len(self)}, no={self.no}>"
 
     def __len__(self):
         """ Return number of atoms in the object """

--- a/sisl/atom.py
+++ b/sisl/atom.py
@@ -1176,7 +1176,7 @@ class Atom(object):
         return self.__class__.__name__ + '{{{0}, Z: {1:d}, mass(au): {2:.5f}, maxR: {3:.5f},\n {4}\n}}'.format(self.tag, self.Z, self.mass, self.maxR(), orbs)
 
     def __repr__(self):
-        return f"<sisl.{self.__class__.__name__} {self.tag}, Z={self.Z}, M={self.mass}, maxR={self.maxR()}, no={len(self.orbital)}>"
+        return f"<{self.__module__}.{self.__class__.__name__} {self.tag}, Z={self.Z}, M={self.mass}, maxR={self.maxR()}, no={len(self.orbital)}>"
 
     def __len__(self):
         """ Return number of orbitals in this atom """
@@ -1648,7 +1648,7 @@ class Atoms(object):
         return s + '}'
 
     def __repr__(self):
-        return f"<sisl.{self.__class__.__name__} nspecies={len(self._atom)}, na={len(self)}, no={self.no}>"
+        return f"<{self.__module__}.{self.__class__.__name__} nspecies={len(self._atom)}, na={len(self)}, no={self.no}>"
 
     def __len__(self):
         """ Return number of atoms in the object """

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -585,7 +585,7 @@ class Geometry(SuperCellChild):
 
     def __repr__(self):
         """ A simple, short string representation. """
-        return f"<sisl.{self.__class__.__name__} na={self.na}, no={self.no}, nsc={self.nsc}>"
+        return f"<{self.__module__}.{self.__class__.__name__} na={self.na}, no={self.no}, nsc={self.nsc}>"
 
     def iter(self):
         """ An iterator over all atomic indices

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -583,6 +583,10 @@ class Geometry(SuperCellChild):
             s += ',\n ' + str(self.names).replace('\n', '\n ')
         return (s + ',\n maxR: {0:.5f},\n {1}\n}}'.format(self.maxR(), str(self.sc).replace('\n', '\n '))).strip()
 
+    def __repr__(self):
+        """ A simple, short string representation. """
+        return f"<sisl.{self.__class__.__name__} na={self.na}, no={self.no}, nsc={self.nsc}>"
+
     def iter(self):
         """ An iterator over all atomic indices
 

--- a/sisl/orbital.py
+++ b/sisl/orbital.py
@@ -130,6 +130,11 @@ class Orbital(object):
             return self.__class__.__name__ + '{{R: {0:.5f}, q0: {1}, tag: {2}}}'.format(self.R, self.q0, self.tag)
         return self.__class__.__name__ + '{{R: {0:.5f}, q0: {1}}}'.format(self.R, self.q0)
 
+    def __repr__(self):
+        if self.tag:
+            return f"<sisl.{self.__class__.__name__} R={self.R:.3f}, q0={self.q0}, tag={self.tag}>"
+        return f"<sisl.{self.__class__.__name__} R={self.R:.3f}, q0={self.q0}>"
+
     def name(self, tex=False):
         """ Return a named specification of the orbital (`tag`) """
         return self.tag
@@ -513,6 +518,11 @@ class SphericalOrbital(Orbital):
         if len(self.tag) > 0:
             return self.__class__.__name__ + '{{l: {0}, R: {1}, q0: {2}, tag: {3}}}'.format(self.l, self.R, self.q0, self.tag)
         return self.__class__.__name__ + '{{l: {0}, R: {1}, q0: {2}}}'.format(self.l, self.R, self.q0)
+
+    def __repr__(self):
+        if self.tag:
+            return f"<sisl.{self.__class__.__name__} l={self.l}, R={self.R:.3f}, q0={self.q0}, tag={self.tag}>"
+        return f"<sisl.{self.__class__.__name__} l={self.l}, R={self.R:.3f}, q0={self.q0}>"
 
     def radial(self, r, is_radius=True):
         r""" Calculate the radial part of the wavefunction :math:`f(\mathbf R)`
@@ -955,6 +965,11 @@ class AtomicOrbital(Orbital):
         if len(self.tag) > 0:
             return self.__class__.__name__ + '{{{0}, q0: {1}, tag: {2}, {3}}}'.format(self.name(), self.q0, self.tag, str(self.orb))
         return self.__class__.__name__ + '{{{0}, q0: {1}, {2}}}'.format(self.name(), self.q0, str(self.orb))
+
+    def __repr__(self):
+        if self.tag:
+            return f"<sisl.{self.__class__.__name__} {self.name()} q0={self.q0}, tag={self.tag}>"
+        return f"<sisl.{self.__class__.__name__} {self.name()} q0={self.q0}>"
 
     def set_radial(self, *args):
         r""" Update the internal radial function used as a :math:`f(|\mathbf r|)`

--- a/sisl/orbital.py
+++ b/sisl/orbital.py
@@ -132,8 +132,8 @@ class Orbital(object):
 
     def __repr__(self):
         if self.tag:
-            return f"<sisl.{self.__class__.__name__} R={self.R:.3f}, q0={self.q0}, tag={self.tag}>"
-        return f"<sisl.{self.__class__.__name__} R={self.R:.3f}, q0={self.q0}>"
+            return f"<{self.__module__}.{self.__class__.__name__} R={self.R:.3f}, q0={self.q0}, tag={self.tag}>"
+        return f"<{self.__module__}.{self.__class__.__name__} R={self.R:.3f}, q0={self.q0}>"
 
     def name(self, tex=False):
         """ Return a named specification of the orbital (`tag`) """
@@ -521,8 +521,8 @@ class SphericalOrbital(Orbital):
 
     def __repr__(self):
         if self.tag:
-            return f"<sisl.{self.__class__.__name__} l={self.l}, R={self.R:.3f}, q0={self.q0}, tag={self.tag}>"
-        return f"<sisl.{self.__class__.__name__} l={self.l}, R={self.R:.3f}, q0={self.q0}>"
+            return f"<{self.__module__}.{self.__class__.__name__} l={self.l}, R={self.R:.3f}, q0={self.q0}, tag={self.tag}>"
+        return f"<{self.__module__}.{self.__class__.__name__} l={self.l}, R={self.R:.3f}, q0={self.q0}>"
 
     def radial(self, r, is_radius=True):
         r""" Calculate the radial part of the wavefunction :math:`f(\mathbf R)`
@@ -968,8 +968,8 @@ class AtomicOrbital(Orbital):
 
     def __repr__(self):
         if self.tag:
-            return f"<sisl.{self.__class__.__name__} {self.name()} q0={self.q0}, tag={self.tag}>"
-        return f"<sisl.{self.__class__.__name__} {self.name()} q0={self.q0}>"
+            return f"<{self.__module__}.{self.__class__.__name__} {self.name()} q0={self.q0}, tag={self.tag}>"
+        return f"<{self.__module__}.{self.__class__.__name__} {self.name()} q0={self.q0}>"
 
     def set_radial(self, *args):
         r""" Update the internal radial function used as a :math:`f(|\mathbf r|)`

--- a/sisl/physics/sparse.py
+++ b/sisl/physics/sparse.py
@@ -109,7 +109,7 @@ class SparseOrbitalBZ(SparseOrbital):
 
     def __repr__(self):
         g = self.geometry
-        return f"<sisl.{self.__class__.__name__} na={g.na}, no={g.no}, nsc={g.nsc}, dim={self.dim}, nnz={self.nnz}>"
+        return f"<{self.__module__}.{self.__class__.__name__} na={g.na}, no={g.no}, nsc={g.nsc}, dim={self.dim}, nnz={self.nnz}>"
 
     @property
     def S(self):
@@ -688,7 +688,7 @@ class SparseOrbitalBZSpin(SparseOrbitalBZ):
             Spin.NONCOLINEAR: "noncolinear",
             Spin.SPINORBIT: "spinorbit"
             }.get(self.spin._kind, f"unkown({self.spin._kind})")
-        return f"<sisl.{self.__class__.__name__} na={g.na}, no={g.no}, nsc={g.nsc}, dim={self.dim}, nnz={self.nnz}, spin={spin}>"
+        return f"<{self.__module__}.{self.__class__.__name__} na={g.na}, no={g.no}, nsc={g.nsc}, dim={self.dim}, nnz={self.nnz}, spin={spin}>"
 
     def _Pk_unpolarized(self, k=(0, 0, 0), dtype=None, gauge='R', format='csr'):
         r""" Sparse matrix (``scipy.sparse.csr_matrix``) at `k`

--- a/sisl/physics/sparse.py
+++ b/sisl/physics/sparse.py
@@ -107,6 +107,10 @@ class SparseOrbitalBZ(SparseOrbital):
         s += str(self.geometry).replace('\n', '\n ')
         return s + '\n}'
 
+    def __repr__(self):
+        g = self.geometry
+        return f"<sisl.{self.__class__.__name__} na={g.na}, no={g.no}, nsc={g.nsc}, dim={self.dim}, nnz={self.nnz}>"
+
     @property
     def S(self):
         r""" Access the overlap elements associated with the sparse matrix """
@@ -675,6 +679,16 @@ class SparseOrbitalBZSpin(SparseOrbitalBZ):
         s += str(self.spin).replace('\n', '\n ') + ',\n '
         s += str(self.geometry).replace('\n', '\n ')
         return s + '\n}'
+
+    def __repr__(self):
+        g = self.geometry
+        spin = {
+            Spin.UNPOLARIZED: "unpolarized",
+            Spin.POLARIZED: "polarized",
+            Spin.NONCOLINEAR: "noncolinear",
+            Spin.SPINORBIT: "spinorbit"
+            }.get(self.spin._kind, f"unkown({self.spin._kind})")
+        return f"<sisl.{self.__class__.__name__} na={g.na}, no={g.no}, nsc={g.nsc}, dim={self.dim}, nnz={self.nnz}, spin={spin}>"
 
     def _Pk_unpolarized(self, k=(0, 0, 0), dtype=None, gauge='R', format='csr'):
         r""" Sparse matrix (``scipy.sparse.csr_matrix``) at `k`

--- a/sisl/sparse.py
+++ b/sisl/sparse.py
@@ -1464,6 +1464,9 @@ class SparseCSR(object):
         ints = self.shape[:] + (self.nnz,)
         return self.__class__.__name__ + '{{dim={2}, kind={kind},\n  rows: {0}, columns: {1},\n  non-zero: {3}\n}}'.format(*ints, kind=self.dkind)
 
+    def __repr__(self):
+        return f"<sisl.{self.__class__.__name__} shape={self.shape}, kind={self.dkind}, nnz={self.nnz}>"
+
     ###############################
     # Overload of math operations #
     ###############################

--- a/sisl/sparse.py
+++ b/sisl/sparse.py
@@ -1465,7 +1465,7 @@ class SparseCSR(object):
         return self.__class__.__name__ + '{{dim={2}, kind={kind},\n  rows: {0}, columns: {1},\n  non-zero: {3}\n}}'.format(*ints, kind=self.dkind)
 
     def __repr__(self):
-        return f"<sisl.{self.__class__.__name__} shape={self.shape}, kind={self.dkind}, nnz={self.nnz}>"
+        return f"<{self.__module__}.{self.__class__.__name__} shape={self.shape}, kind={self.dkind}, nnz={self.nnz}>"
 
     ###############################
     # Overload of math operations #

--- a/sisl/sparse_geometry.py
+++ b/sisl/sparse_geometry.py
@@ -218,6 +218,11 @@ class _SparseGeometry(object):
         s += str(self.geometry).replace('\n', '\n ')
         return s + '\n}'
 
+    def __repr__(self):
+        g = self.geometry
+        shape = 'x'.join(map(str, self._csr.shape[:-1]))
+        return f"<sisl.{self.__class__.__name__} shape={shape}, dim={self.dim}, nnz={self.nnz}, kind={self.dkind}>"
+
     def __getattr__(self, attr):
         """ Overload attributes from the hosting geometry
 

--- a/sisl/sparse_geometry.py
+++ b/sisl/sparse_geometry.py
@@ -220,8 +220,7 @@ class _SparseGeometry(object):
 
     def __repr__(self):
         g = self.geometry
-        shape = 'x'.join(map(str, self._csr.shape[:-1]))
-        return f"<sisl.{self.__class__.__name__} shape={shape}, dim={self.dim}, nnz={self.nnz}, kind={self.dkind}>"
+        return f"<{self.__module__}.{self.__class__.__name__} shape={self._csr.shape[:-1]}, dim={self.dim}, nnz={self.nnz}, kind={self.dkind}>"
 
     def __getattr__(self, attr):
         """ Overload attributes from the hosting geometry

--- a/sisl/supercell.py
+++ b/sisl/supercell.py
@@ -929,7 +929,7 @@ class SuperCell(object):
         r = lambda x: round(x, 3)  # rounding for display (shorter than fmt-string when numbers are already round)
         a, b, c = map(r, np.linalg.norm(self.cell, axis=1))
         alpha, beta, gamma = (r(self.angle(i, j)) for i, j in ((1, 2), (0, 2), (0, 1)))
-        return f"<sisl.{self.__class__.__name__} a={a}, b={b}, c={c}, α={alpha}, β={beta}, γ={gamma}, nsc={self.nsc}>"
+        return f"<{self.__module__}.{self.__class__.__name__} a={a}, b={b}, c={c}, α={alpha}, β={beta}, γ={gamma}, nsc={self.nsc}>"
 
     def __eq__(self, other):
         """ Equality check """

--- a/sisl/supercell.py
+++ b/sisl/supercell.py
@@ -925,6 +925,12 @@ class SuperCell(object):
         s = ',\n '.join(['ABC'[i] + '=[{:.3f}, {:.3f}, {:.3f}]'.format(*self.cell[i]) for i in (0, 1, 2)])
         return self.__class__.__name__ + ('{{nsc: [{:} {:} {:}],\n ' + s + ',\n}}').format(*self.nsc)
 
+    def __repr__(self):
+        r = lambda x: round(x, 3)  # rounding for display (shorter than fmt-string when numbers are already round)
+        a, b, c = map(r, np.linalg.norm(self.cell, axis=1))
+        alpha, beta, gamma = (r(self.angle(i, j)) for i, j in ((1, 2), (0, 2), (0, 1)))
+        return f"<sisl.{self.__class__.__name__} a={a}, b={b}, c={c}, α={alpha}, β={beta}, γ={gamma}, nsc={self.nsc}>"
+
     def __eq__(self, other):
         """ Equality check """
         return self.equal(other)


### PR DESCRIPTION
Although #148 is still open to some discussion, implementing a few `__repr__` functions seem like a small thing, and specifying what one wants almost amounts to writing the PR itself anyway. So here it is.

I hope the chosen functions are not too uncontroversial, I tried to only put the "most key" summarizing information in, ie. not include the full tree of information when it is stored in child objects.

Otherwise I can add whatever you think is missing.

The `SuperCell.__repr__` is where I add the most 'new' stuff. I thought that having cell lengths and angles were better summarizing information than the full vector coordinates (which can be obtained with `sc.cell` anyway).