### PR TITLE
Use sorted assumption in list_index_le (optimizes o2a)

### DIFF
--- a/sisl/_indices.pyx
+++ b/sisl/_indices.pyx
@@ -610,9 +610,19 @@ def list_index_le(np.ndarray[np.int32_t, ndim=1, mode='c'] a, np.ndarray[np.int3
 cdef inline void _list_index_le(const int[::1] a, const int[::1] b, int[::1] c) nogil:
     cdef int na = a.shape[0]
     cdef int nb = b.shape[0]
+    cdef int ai = 0
+    cdef int lasta = -1
+    cdef int lastc = 0
 
     for ia in range(na):
-        for ib in range(nb):
-            if a[ia] <= b[ib]:
+        ai = a[ia]
+        if ai > lasta:
+            start = lastc
+        else:
+            start = 0
+        lasta = ai
+        for ib in range(start, nb):
+            if ai <= b[ib]:
                 c[ia] = ib
+                lastc = ib
                 break


### PR DESCRIPTION
I have been loading bond currents for fairly large systems (~70K orbitals in UC). This takes several minutes.
Or as it turned out, in fact it was the conversion from orbitals to atoms via `o2a` that was slow.

I found that `list_index_le`, called inside `o2a`, says it assumes `b` is sorted, but doesn't make use of this assumption.
I've implemented such an optimization and it cuts the time it takes to calculate my bond currents from several minutes to 8.6 seconds.

It enables faster iteration when one is making plots in scripts, without having to resort to some two-stage process with cached plot data :)