### PR TITLE
Fdf's _r_grid_bin was using get_sile_class without importing it

### DIFF
--- a/sisl/io/siesta/fdf.py
+++ b/sisl/io/siesta/fdf.py
@@ -5,7 +5,7 @@ import scipy as sp
 from os.path import isfile
 import itertools as itools
 
-from ..sile import add_sile, sile_fh_open, sile_raise_write, SileError
+from ..sile import add_sile, get_sile_class, sile_fh_open, sile_raise_write, SileError
 from .sile import SileSiesta
 from .._help import *
 


### PR DESCRIPTION
There was a bug and `fdf_sile.read_grid("VT")` did not work.

I don't know how to add tests for `fdf_sile.read_grid()`, but it would probably be needed, because this is the second time I've found it fails :)