### PR TITLE
Method to calculate grid isosurfaces

### DIFF
--- a/sisl/grid.py
+++ b/sisl/grid.py
@@ -180,6 +180,68 @@ class Grid(SuperCellChild):
         # Apply the scipy.ndimage.zoom function and return a new grid
         return self.apply(ndimage_zoom, zoom_factors, mode=mode, order=order, **kwargs)
 
+    def isosurface(self, level=None, step_size=1, **kwargs):
+        """Calculates the isosurface for a given value.
+        
+        It uses skimage.measure.marching_cubes, so you need to have scikit-image installed.
+
+        Parameters
+        ----------
+        level: float
+            contour value to search for isosurfaces in the grid. 
+            If not given or None, the average of the min and max of the grid is used.
+        step_size: int
+            step size in voxels. Larger steps yield faster but coarser results. 
+            The result will always be topologically correct though.
+        **kwargs:
+            optional arguments passed directly to `skimage.measure.marching_cubes`
+            for the calculation of isosurfaces.
+        
+        Returns
+        ----------
+        numpy array of shape (V, 3)
+            Verts. Spatial coordinates for V unique mesh vertices.
+
+        numpy array of shape (n_faces, 3)
+            Faces. Define triangular faces via referencing vertex indices from verts. 
+            This algorithm specifically outputs triangles, so each face has exactly three indices.
+
+        numpy array of shape (V, 3)
+            Normals. The normal direction at each vertex, as calculated from the data.
+
+        numpy array of shape (V, 3)
+            Values. Gives a measure for the maximum value of the data in the local region near each vertex. 
+            This can be used by visualization tools to apply a colormap to the mesh.
+
+        See Also
+        --------
+        skimage.measure.marching_cubes : method used for interpolation
+        
+        """
+        try:
+            import skimage.measure
+        except:
+            raise ModuleNotFoundError("You need to have scikit-image installed in order to calculate isosurfaces.")
+
+        # Run the marching cubes algorithm to calculate the vertices and faces
+        # of the requested isosurface.
+        verts, *returns = skimage.measure.marching_cubes(
+            self.grid, level=level, spacing=fnorm(self.dcell), step_size=step_size, **kwargs
+        )
+
+        # Define the transformation matrix to get the real vertices
+        # This is because skimage calculates the vertices as if it was an orthogonal cell
+        T = self.cell/fnorm(self.cell).T
+
+        # Check that the transformation matrix is definite positive
+        if np.linalg.det(T) < 0:
+            T[:, 2] = -T[:, 2]  # change the orientation of the third vector
+
+        # Apply the transformation and get the real coordinates of the vertices
+        verts = (np.dot(T, verts.T)).T
+
+        return (verts, *returns)
+
     def smooth(self, r=0.7, method="gaussian", mode="wrap", **kwargs):
         """
         Make a smoother grid by applying a filter.

--- a/sisl/grid.py
+++ b/sisl/grid.py
@@ -180,23 +180,23 @@ class Grid(SuperCellChild):
         # Apply the scipy.ndimage.zoom function and return a new grid
         return self.apply(ndimage_zoom, zoom_factors, mode=mode, order=order, **kwargs)
 
-    def isosurface(self, level=None, step_size=1, **kwargs):
+    def isosurface(self, level, step_size=1, **kwargs):
         """Calculates the isosurface for a given value.
-        
-        It uses skimage.measure.marching_cubes, so you need to have scikit-image installed.
+
+        It uses `skimage.measure.marching_cubes`, so you need to have scikit-image installed.
 
         Parameters
         ----------
         level: float
             contour value to search for isosurfaces in the grid. 
             If not given or None, the average of the min and max of the grid is used.
-        step_size: int
+        step_size: int, optional
             step size in voxels. Larger steps yield faster but coarser results. 
             The result will always be topologically correct though.
         **kwargs:
             optional arguments passed directly to `skimage.measure.marching_cubes`
             for the calculation of isosurfaces.
-        
+
         Returns
         ----------
         numpy array of shape (V, 3)
@@ -215,13 +215,15 @@ class Grid(SuperCellChild):
 
         See Also
         --------
-        skimage.measure.marching_cubes : method used for interpolation
-        
+        skimage.measure.marching_cubes : method used to calculate the isosurface.
+
         """
         try:
             import skimage.measure
-        except:
-            raise ModuleNotFoundError("You need to have scikit-image installed in order to calculate isosurfaces.")
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                f"{self.__class__.__name__}.isosurface requires scikit-image to be installed"
+            )
 
         # Run the marching cubes algorithm to calculate the vertices and faces
         # of the requested isosurface.
@@ -231,14 +233,14 @@ class Grid(SuperCellChild):
 
         # Define the transformation matrix to get the real vertices
         # This is because skimage calculates the vertices as if it was an orthogonal cell
-        T = self.cell/fnorm(self.cell).T
+        T = self.cell / fnorm(self.cell).T
 
         # Check that the transformation matrix is definite positive
         if np.linalg.det(T) < 0:
             T[:, 2] = -T[:, 2]  # change the orientation of the third vector
 
         # Apply the transformation and get the real coordinates of the vertices
-        verts = (np.dot(T, verts.T)).T
+        verts = T.dot(verts.T).T
 
         return (verts, *returns)
 

--- a/sisl/tests/test_grid.py
+++ b/sisl/tests/test_grid.py
@@ -182,6 +182,21 @@ class TestGrid:
         # grid... Perhaps this is ok, but not good... :(
         assert np.allclose(setup.g.sum(2).grid, g1.grid)
 
+    def test_isosurface(self, setup):
+
+        # Build an empty grid
+        grid = sisl.Grid(0.1, sc=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+        # Fill it with some values that have a clear isosurface
+        grid.grid = np.tile([1, 2, 3, 4, 5, 4, 3, 2, 1, 0], 100).reshape(10, 10, 10)
+
+        # Calculate the isosurface for the value of 2.5
+        verts, *returns = grid.isosurface(2.5)
+
+        # The third dimension should contain only two coordinates
+        # [1, 2, (HERE) 3, 4, 5, 4, 3, (HERE) 2, 1, 0]
+        assert np.unique(verts[:, 2]).shape == (2,)
+
     def test_smooth_gaussian(self, setup):
         g = Grid(0.1, sc=[[2, 0, 0], [0, 2, 0], [0, 0, 2]])
         g[10, 10, 10] = 1

--- a/sisl/tests/test_grid.py
+++ b/sisl/tests/test_grid.py
@@ -185,7 +185,7 @@ class TestGrid:
     def test_isosurface(self, setup):
 
         # Build an empty grid
-        grid = sisl.Grid(0.1, sc=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        grid = Grid(0.1, sc=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
         # Fill it with some values that have a clear isosurface
         grid.grid = np.tile([1, 2, 3, 4, 5, 4, 3, 2, 1, 0], 100).reshape(10, 10, 10)

--- a/sisl/tests/test_grid.py
+++ b/sisl/tests/test_grid.py
@@ -197,6 +197,16 @@ class TestGrid:
         # [1, 2, (HERE) 3, 4, 5, 4, 3, (HERE) 2, 1, 0]
         assert np.unique(verts[:, 2]).shape == (2,)
 
+        # If the grid is non-orthogonal, there should be 20 unique values
+        # (10 for each (HERE))
+        grid = Grid(0.1, sc=[[1, 0, 0], [0, 1, 0], [0, 2, 1]])
+        
+        grid.grid = np.tile([1, 2, 3, 4, 5, 4, 3, 2, 1, 0], 100).reshape(10, 10, 10)
+
+        verts, *returns = grid.isosurface(2.5)
+
+        assert np.unique(verts[:, 2]).shape == (20,)
+
     def test_smooth_gaussian(self, setup):
         g = Grid(0.1, sc=[[2, 0, 0], [0, 2, 0], [0, 0, 2]])
         g[10, 10, 10] = 1

--- a/sisl/tests/test_grid.py
+++ b/sisl/tests/test_grid.py
@@ -182,7 +182,9 @@ class TestGrid:
         # grid... Perhaps this is ok, but not good... :(
         assert np.allclose(setup.g.sum(2).grid, g1.grid)
 
-    def test_isosurface(self, setup):
+    def test_isosurface_orthogonal(self, setup):
+
+        pytest.importorskip("skimage", reason="scikit-image not available")
 
         # Build an empty grid
         grid = Grid(0.1, sc=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
@@ -197,10 +199,14 @@ class TestGrid:
         # [1, 2, (HERE) 3, 4, 5, 4, 3, (HERE) 2, 1, 0]
         assert np.unique(verts[:, 2]).shape == (2,)
 
+    def test_isosurface_non_orthogonal(self, setup):
+
+        pytest.importorskip("skimage", reason="scikit-image not available")
+
         # If the grid is non-orthogonal, there should be 20 unique values
-        # (10 for each (HERE))
+        # (10 for each (HERE), see test_isosurface_orthogonal)
         grid = Grid(0.1, sc=[[1, 0, 0], [0, 1, 0], [0, 2, 1]])
-        
+
         grid.grid = np.tile([1, 2, 3, 4, 5, 4, 3, 2, 1, 0], 100).reshape(10, 10, 10)
 
         verts, *returns = grid.isosurface(2.5)


### PR DESCRIPTION
When plotting grids with plotly I had the problem that non-orthogonal grids didn't make sense because there was no way to indicate the vectors of the cell.

I submitted an issue in plotly and they proposed a workaround, which is to calculate the isosurfaces first with `skimage.measure.marching_cubes` and then apply a transformation to the vertices to get their real coordinates taking into account the cell vectors.

I thought that maybe this is useful for other cases, not only for the plotly visualization module. This would definitely be useful for representing the grids in blender (because it gives you all that you need to build a 3d mesh), and maybe for someone who wants to do some quantitative analysis with isosurfaces (I'm not sure when would this be useful).

If you think it is worth it to include this in the `Grid` class I will write some tests for it. Otherwise I will just do the isosurface calculation in the visualization module.

Cheers!