### PR TITLE
Making sure siles are pickleable

### DIFF
--- a/sisl/io/sile.py
+++ b/sisl/io/sile.py
@@ -425,6 +425,16 @@ class BaseSile:
             raise AttributeError(f"The filehandle for {self.file} has not been opened yet...")
         return getattr(self.fh, name)
 
+    def __getstate__(self):
+        """This method and __setstate__ avoid errors when pickling siles"""
+
+        return self.__dict__ 
+
+    def __setstate__(self, state):
+        """This method and __getstate__ avoid errors when pickling siles"""
+            
+        self.__dict__ = state
+
     @classmethod
     def _ArgumentParser_args_single(cls):
         """ Default arguments for the Sile """

--- a/sisl/io/sile.py
+++ b/sisl/io/sile.py
@@ -427,12 +427,10 @@ class BaseSile:
 
     def __getstate__(self):
         """This method and __setstate__ avoid errors when pickling siles"""
-
         return self.__dict__ 
 
     def __setstate__(self, state):
-        """This method and __getstate__ avoid errors when pickling siles"""
-            
+        """This method and __getstate__ avoid errors when pickling siles""" 
         self.__dict__ = state
 
     @classmethod

--- a/sisl/io/tests/test_sile.py
+++ b/sisl/io/tests/test_sile.py
@@ -1,29 +1,33 @@
 from pathlib import Path
-import pickle
 import pytest
 import tempfile
 
 import sisl
 from sisl.io.sile import __siles
 
+@pytest.fixture(params=["pickle", "dill"])
+def pickle_module(request):
+    return request.param
 
 @pytest.fixture(params=__siles)
 def sile(request):
     sile_cls = request.param
 
-    return sile_cls("test")
+    return sile_cls("test", _open=False)
 
-def test_pickling(sile):
 
+def test_pickling(sile, pickle_module):
+
+    pickle_module = pytest.importorskip(pickle_module)
     tmp_file = tempfile.NamedTemporaryFile(delete=False)
     error = None
 
     try:
         with open(tmp_file.name, "wb") as fh:
-            pickle.dump(sile, fh)
+            pickle_module.dump(sile, fh)
 
         with open(tmp_file.name, "rb") as fh:
-            loaded_sile = pickle.load(fh)
+            loaded_sile = pickle_module.load(fh)
     except Exception as e:
         error = e
 

--- a/sisl/io/tests/test_sile.py
+++ b/sisl/io/tests/test_sile.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import pickle
+import pytest
+import tempfile
+
+import sisl
+from sisl.io.sile import __siles
+
+
+@pytest.fixture(params=__siles)
+def sile(request):
+    sile_cls = request.param
+
+    return sile_cls("test")
+
+def test_pickling(sile):
+
+    tmp_file = tempfile.NamedTemporaryFile(delete=False)
+    error = None
+
+    try:
+        with open(tmp_file.name, "wb") as fh:
+            pickle.dump(sile, fh)
+
+        with open(tmp_file.name, "rb") as fh:
+            loaded_sile = pickle.load(fh)
+    except Exception as e:
+        error = e
+
+    Path(tmp_file.name).unlink()
+
+    if error is not None:
+        raise error
+
+    


### PR DESCRIPTION
I have two questions:
- Regarding tests: In the visualization module, I define a `BasePlotTester` class that I then use for each specific class. For example, where I want to test the bands plot, I define `BandsPlotTester(BasePlotTester)`. In this way I make sure that the basics are tested across all specific plots without having to rewrite the code. It makes me feel quite confident that plots work. Is this bad practice? I'm asking because the same could be done for siles, and by just adding a test in the `BaseSileTester` we would make sure that all siles are pickleable, for example.

- Do you want to use this PR to make sure all classes (not only siles) are pickleable so that we don't need to worry anymore?