### PR TITLE
Expose getting orbital params from name

### DIFF
--- a/sisl/orbital.py
+++ b/sisl/orbital.py
@@ -773,20 +773,7 @@ class AtomicOrbital(Orbital):
                 # String specification of the atomic orbital
                 s = args.pop(0)
 
-                n, l, m, Z, P = self.orb_name_to_params(s, force_n=True, n=n, l=l, m=m, Z=Z, P=P)
-
-                # Now we should figure out how the spherical orbital
-                # has been passed.
-                # There are two options:
-                #  1. The radial function is passed as two arrays: r, f
-                #  2. The SphericalOrbital-class is passed which already contains
-                #     the relevant information.
-                # Figure out if it is a sphericalorbital
-                if len(args) > 0:
-                    if isinstance(args[0], SphericalOrbital):
-                        self.orb = args.pop(0)
-                    else:
-                        self.orb = SphericalOrbital(l, args.pop(0))
+                n, l, m, Z, P = self.orb_name_to_params(s, force_n=True, n=n, l=l, m=m, Z=Z, P=kwargs.get('P'))
             else:
 
                 # Arguments *have* to be
@@ -810,13 +797,6 @@ class AtomicOrbital(Orbital):
                     if isinstance(args[0], bool):
                         P = args.pop(0)
 
-                # Figure out if it is a sphericalorbital
-                if len(args) > 0:
-                    if isinstance(args[0], SphericalOrbital):
-                        self.orb = args.pop(0)
-                    else:
-                        self.orb = SphericalOrbital(l, args.pop(0))
-
         # Still if n is None, we assign the default (lowest) quantum number
         if n is None:
             n = l + 1
@@ -833,13 +813,19 @@ class AtomicOrbital(Orbital):
         if abs(self.m) > self.l:
             raise ValueError(self.__class__.__name__ + ' requires |m| <= l.')
 
-        # Retrieve user-passed spherical orbital
-        s = kwargs.get('spherical', None)
-
+        # Now we should figure out how the spherical orbital
+        # has been passed.
+        # There are two options:
+        #  1. The radial function is passed as two arrays: r, f
+        #  2. The SphericalOrbital-class is passed which already contains
+        #     the relevant information.
+        # Figure out if it is a sphericalorbital
+        s = kwargs.get('spherical') 
         if s is None:
-            # Expect the orbital to already be set
-            pass
-        elif isinstance(s, Orbital):
+            if len(args) > 0:
+                s = args.pop(0)
+
+        if isinstance(s, SphericalOrbital) or s is None:
             self.orb = s
         else:
             self.orb = SphericalOrbital(l, s)
@@ -882,8 +868,9 @@ class AtomicOrbital(Orbital):
                 'gz3x': 1, 'gz2(x2-y2)': 2, 'gzx(x2-3y2)': 3, 'gx4+y4': 4,
         }
 
-        # First remove a P for polarization
-        P = 'P' in orb_name
+        if P is None:
+            # First remove a P for polarization
+            P = 'P' in orb_name 
         orb_name = orb_name.replace('P', '')
 
         # Try and figure out the input

--- a/sisl/orbital.py
+++ b/sisl/orbital.py
@@ -820,7 +820,7 @@ class AtomicOrbital(Orbital):
         #  2. The SphericalOrbital-class is passed which already contains
         #     the relevant information.
         # Figure out if it is a sphericalorbital
-        s = kwargs.get('spherical') 
+        s = kwargs.get('spherical')
         if s is None:
             if len(args) > 0:
                 s = args.pop(0)
@@ -836,7 +836,7 @@ class AtomicOrbital(Orbital):
             self.orb = Orbital(self.R)
 
         self.R = self.orb.R
-    
+
     @staticmethod
     def orb_name_to_params(orb_name, force_n=False, n=None, l=None, m=None, Z=None, P=None):
         """
@@ -870,7 +870,7 @@ class AtomicOrbital(Orbital):
 
         if P is None:
             # First remove a P for polarization
-            P = 'P' in orb_name 
+            P = 'P' in orb_name
         orb_name = orb_name.replace('P', '')
 
         # Try and figure out the input

--- a/sisl/tests/test_orbital.py
+++ b/sisl/tests/test_orbital.py
@@ -287,6 +287,9 @@ class Test_atomicorbital:
         a.append(AtomicOrbital('pzP', f))
         a.append(AtomicOrbital('pzP', rf))
         a.append(AtomicOrbital('2pzP', rf))
+        a.append(AtomicOrbital('2', rf, l=1, m=0, Z=1, P=True))
+        a.append(AtomicOrbital('2p', m=0, Z=1, P=True, spherical=f))
+        a.append(AtomicOrbital('2p', "dummy",  m=0, Z=1, P=True, spherical=rf))
         for i in range(len(a) - 1):
             for j in range(i+1, len(a)):
                 assert a[i] == a[j] and a[i].equal(a[j], psi=True, radial=True)


### PR DESCRIPTION
I exposed the convertion from orbital name to `n, l, m, Z, P` as an static method. This can be very convenient for the visualization module (and maybe other cases) and does not disturb the functionality of `AtomicOrbital` (it passes all tests and does not add extra computation). It also adds some possibilities like providing part of the parameters as a string and the rest as kwargs:

```python
from sisl import AtomicOrbital

AtomicOrbital("3p", m=0, P=True)
AtomicOrbital("3", l=2, m=1, Z=2)
AtomicOrbital("3dZ2", m=1)
```
Also, I think there was some 3-fold repeated code regarding the setup of spherical orbital, so I condensed it all in one go. It passes all tests so I guess it is correct.

Can this go in so that the visualization module can act magically? :)