### PR TITLE
f-string was not printing variable value due to missing f

### DIFF
--- a/sisl/io/tbtrans/_cdf.py
+++ b/sisl/io/tbtrans/_cdf.py
@@ -171,10 +171,10 @@ class _ncSileTBtrans(SileCDFTBtrans):
         ret_E = self.E[idxE]
         if abs(ret_E - E) > 5e-3:
             warn(f"{self.__class__.__name__} requesting energy "
-                 "{E:.5f} eV, found {ret_E:.5f} eV as the closest energy!")
+                 f"{E:.5f} eV, found {ret_E:.5f} eV as the closest energy!")
         elif abs(ret_E - E) > 1e-3:
             info(f"{self.__class__.__name__} requesting energy "
-                 "{E:.5f} eV, found {ret_E:.5f} eV as the closest energy!")
+                 f"{E:.5f} eV, found {ret_E:.5f} eV as the closest energy!")
         return idxE
 
     def kindex(self, k):
@@ -530,5 +530,5 @@ class _devncSileTBtrans(_ncSileTBtrans):
         d = len(orbitals) - len(porb)
         if d != 0:
             warn(f"{self.__class__.__name__}.o2p requesting an orbital outside the device region, "
-                 "{d} orbitals will be removed from the returned list")
+                 f"{d} orbitals will be removed from the returned list")
         return porb


### PR DESCRIPTION
An `f` was missing before the string to make it an f-string, so no value was being printed. Now it should print the information with the correct value of the variables.