### PR TITLE
Make parent categories callable and avoid their instantiation

### DIFF
--- a/sisl/_category.py
+++ b/sisl/_category.py
@@ -61,14 +61,15 @@ class InstanceCache:
         object.__setattr__(self, name, attr)
         return attr
 
+
 class CategoryMeta(ABCMeta):
 
     def __call__(cls, *args, **kwargs):
-
         try:
             return super().__call__(*args, **kwargs)
         except TypeError:
             return cls.kw(**kwargs)
+
 
 @set_module("sisl.category")
 class Category(metaclass=CategoryMeta):

--- a/sisl/_category.py
+++ b/sisl/_category.py
@@ -61,9 +61,17 @@ class InstanceCache:
         object.__setattr__(self, name, attr)
         return attr
 
+class CategoryMeta(ABCMeta):
+
+    def __call__(cls, *args, **kwargs):
+
+        try:
+            return super().__call__(*args, **kwargs)
+        except TypeError:
+            return cls.kw(**kwargs)
 
 @set_module("sisl.category")
-class Category(metaclass=ABCMeta):
+class Category(metaclass=CategoryMeta):
     r""" A category """
     __slots__ = ("_name", "_wrapper")
 

--- a/sisl/_category.py
+++ b/sisl/_category.py
@@ -63,12 +63,33 @@ class InstanceCache:
 
 
 class CategoryMeta(ABCMeta):
+    """
+    Metaclass that defines how category classes should behave.
+    """
 
     def __call__(cls, *args, **kwargs):
+        """
+        If a category class is called, we will attempt to instantiate it.
+
+        However, it may be that this is a parent class (e.g. `AtomCategory`)
+        that does not make sense to instantiate. Since this classes are abstract,
+        they will raise an error that we will use to build the categories that the user
+        requested.
+
+        Examples
+        -----------
+
+        >>> AtomZ(6) # returns an AtomZ category with the Z parameter set to 6
+        >>> AtomCategory(Z=6) # returns exactly the same since it uses `AtomCategory.kw`
+        """
         try:
             return super().__call__(*args, **kwargs)
-        except TypeError:
-            return cls.kw(**kwargs)
+        except TypeError as e:
+            if len(args) == 0:
+                return cls.kw(**kwargs)
+            # If args were provided, the user probably didn't want to use the category builder,
+            # so we are going to let the exception be raised
+            raise e
 
 
 @set_module("sisl.category")

--- a/sisl/tests/test_category.py
+++ b/sisl/tests/test_category.py
@@ -1,0 +1,8 @@
+from sisl.geom import AtomCategory
+
+def test_geom_category_kw_and_call():
+    # Check that categories can be built indistinctively using the kw builder
+    # or directly calling them.
+    cat1 = AtomCategory.kw(odd={})
+    cat2 = AtomCategory(odd={})
+    assert cat1 == cat2


### PR DESCRIPTION
Following the discussion in https://github.com/zerothi/sisl/pull/253, this makes `AtomCategory(Z=6)` equivalent to `AtomCategory.kw(Z=6)`.
