### PR TITLE
enh: added fractional and coordinate categories

### DIFF
--- a/sisl/_category.py
+++ b/sisl/_category.py
@@ -10,6 +10,9 @@ __all__ += ["AndCategory", "OrCategory", "XOrCategory"]
 __all__ += ["InstanceCache"]
 
 
+_list_types = (tuple, list, np.ndarray)
+
+
 class InstanceCache:
     """ Wraps an instance to cache *all* results based on `functools.lru_cache`
 
@@ -205,7 +208,7 @@ class Category(metaclass=CategoryMeta):
 
     def __ne__(self, other):
         eq = self == other
-        if isinstance(eq, list):
+        if isinstance(eq, _list_types):
             return [not e for e in eq]
         return not eq
 
@@ -281,12 +284,13 @@ class NotCategory(GenericCategory):
         r""" Base method for queriyng whether an object is a certain category """
         cat = self._cat.categorize(*args, **kwargs)
 
+        _null = NullCategory()
         def check(cat):
             if isinstance(cat, NullCategory):
                 return self
-            return NullCategory()
+            return _null
 
-        if isinstance(cat, list):
+        if isinstance(cat, _list_types):
             return list(map(check, cat))
         return check(cat)
 
@@ -378,7 +382,7 @@ class OrCategory(CompositeCategory):
                 return b
             return a
 
-        if isinstance(catA, list):
+        if isinstance(catA, _list_types):
             return list(map(cmp, catA, catB))
         return cmp(catA, catB)
 
@@ -412,7 +416,7 @@ class AndCategory(CompositeCategory):
                 return b
             return self
 
-        if isinstance(catA, list):
+        if isinstance(catA, _list_types):
             return list(map(cmp, catA, catB))
         return cmp(catA, catB)
 
@@ -448,7 +452,7 @@ class XOrCategory(CompositeCategory):
             # is exclusive, so we return the NullCategory
             return NullCategory()
 
-        if isinstance(catA, list):
+        if isinstance(catA, _list_types):
             return list(map(cmp, catA, catB))
         return cmp(catA, catB)
 

--- a/sisl/_category.py
+++ b/sisl/_category.py
@@ -116,6 +116,32 @@ class Category(metaclass=CategoryMeta):
         self._name = name
 
     @classmethod
+    @abstractmethod
+    def is_class(cls, name):
+        r""" Query whether `name` matches the class name by removing a prefix `kw`
+
+        This is important to ensure that users match the full class name
+        by omitting the prefix returned from this method.
+
+        This is an abstract method to ensure sub-classes of `Category`
+        implements it.
+
+        For instance:
+
+        .. code::
+
+            class MyCategory(Category):
+
+                @classmethod
+                def is_class(cls, name):
+                     # strip "My" and do comparison
+                     return cl.__name__.lower()[2:] == name.lower()
+
+        would enable one to compare against the *base* category scheme.
+        """
+        pass
+
+    @classmethod
     def kw(cls, **kwargs):
         """ Create categories based on keywords
 
@@ -152,7 +178,7 @@ class Category(metaclass=CategoryMeta):
             lkey = key.lower()
             found = ''
             for name, cl in subcls.items():
-                if name.endswith(lkey):
+                if cl.is_class(name):
                     if found:
                         raise ValueError(f"{cls.__name__}.kw got a non-unique argument for category name:\n"
                                          f"    Searching for {name} and found matches {found} and {name}.")
@@ -233,10 +259,14 @@ class GenericCategory(Category):
     """Used to indicate that the category does not act on specific objects
 
     It serves to identify categories such as `NullCategory`, `NotCategory`
-    and composite categories and distinguish them from categories that have
+    and `CompositeCategory` and distinguish them from categories that have
     a specific object in which they act.
     """
-    pass
+    @classmethod
+    def is_class(cls, name):
+        # never allow one to match a generic class
+        # I.e. you can't instantiate a Null/Not/And/Or/XOr category by name
+        return False
 
 
 @set_module("sisl.category")

--- a/sisl/_category.py
+++ b/sisl/_category.py
@@ -178,7 +178,7 @@ class Category(metaclass=CategoryMeta):
             lkey = key.lower()
             found = ''
             for name, cl in subcls.items():
-                if cl.is_class(name):
+                if cl.is_class(key):
                     if found:
                         raise ValueError(f"{cls.__name__}.kw got a non-unique argument for category name:\n"
                                          f"    Searching for {name} and found matches {found} and {name}.")

--- a/sisl/geom/category/__init__.py
+++ b/sisl/geom/category/__init__.py
@@ -1,3 +1,5 @@
 from .base import *
 from ._neighbours import *
 from ._kind import *
+from ._coord import *
+

--- a/sisl/geom/category/__init__.py
+++ b/sisl/geom/category/__init__.py
@@ -2,4 +2,3 @@ from .base import *
 from ._neighbours import *
 from ._kind import *
 from ._coord import *
-

--- a/sisl/geom/category/_coord.py
+++ b/sisl/geom/category/_coord.py
@@ -1,0 +1,231 @@
+from functools import partial, wraps
+import operator
+from numbers import Integral
+
+import numpy as np
+from numpy import dot, fabs, where
+
+from sisl._internal import set_module, singledispatchmethod
+from sisl._help import isiterable
+from sisl.utils.misc import direction
+from sisl.shape import *
+from sisl.supercell import SuperCell, SuperCellChild
+from sisl._supercell import cell_invert
+import sisl._array as _a
+from .base import AtomCategory, NullCategory, _sanitize_loop
+
+
+__all__ = ["AtomFracSite", "AtomCoordinate"]
+
+
+@set_module("sisl.geom")
+class AtomFracSite(AtomCategory):
+    r""" Classify atoms based on fractional sites for a given supercell
+
+    Match atomic coordinates based on the fractional positions.
+
+    Parameters
+    ----------
+    sc : SuperCell, SuperCellChild or argument to SuperCell
+       an object that defines the lattice vectors (will be passed through to `SuperCell`
+       if not an object instance of `SuperCell` or `SuperCellChild`
+    atol : float, optional
+       the absolute tolerance (in Ang) to check whether the site is an integer
+       site.
+    offset : array_like, optional
+       an offset made to the geometry coordinates before calculating the fractional
+       coordinates according to `sc`
+    foffset : array_like, optional
+       fractional offset of the fractional coordinates, this allows to select sub-regions
+       in the `sc` lattice vectors.
+
+    Examples
+    --------
+    >>> gr = graphene() * (4, 5, 1)
+    >>> A_site = AtomFracSite(graphene())
+    >>> B_site = AtomFracSite(graphene(), foffset=(-1/3, -1/3, 0))
+    >>> cat = (A_site | B_site).categorize(gr)
+    >>> for ia, c in enumerate(cat):
+    ...    if ia % 2 == 0:
+    ...        assert c == A_site
+    ...    else:
+    ...        assert c == B_site
+    """
+    __slots__ = (f"_{a}" for a in ("cell", "icell", "length", "atol", "offset", "foffset"))
+
+    def __init__(self, sc, atol=1.e-5, offset=(0., 0., 0.), foffset=(0., 0., 0.)):
+        if isinstance(sc, SuperCellChild):
+            sc = sc.sc
+        elif not isinstance(sc, SuperCell):
+            sc = SuperCell(sc)
+
+        # Unit-cell to fractionalize
+        self._cell = sc.cell.copy()
+        # lengths of lattice vectors
+        self._length = sc.length.copy().reshape(1, 3)
+        # inverse cell (for fractional coordinate calculations)
+        self._icell = cell_invert(self._cell)
+        # absolute tolerance [Ang]
+        self._atol = atol
+        # offset of coordinates before calculating the fractional coordinates
+        self._offset = _a.arrayd(offset).reshape(1, 3)
+        # fractional offset before comparing to the integer part of the fractional coordinate
+        self._foffset = _a.arrayd(foffset).reshape(1, 3)
+
+        super().__init__(f"fracsite(atol={self._atol}, offset={self._offset}, foffset={self._foffset})")
+
+    def categorize(self, geometry, atoms=None):
+        # _sanitize_loop will ensure that atoms will always be an integer
+        if atoms is None:
+            fxyz = dot(geometry.xyz + self._offset, self._icell.T) + self._foffset
+        else:
+            fxyz = dot(geometry.xyz[atoms].reshape(-1, 3) + self._offset,
+                       self._icell.T) + self._foffset
+        # Find fractional indices that match to an integer of the passed cell
+        # We multiply with the length of the cell to get an error in Ang
+        ret = where(np.fabs((fxyz - np.rint(fxyz))*self._length).max(1) <= self._atol,
+                    self, NullCategory()).tolist()
+        if isinstance(atoms, Integral):
+            ret = ret[0]
+        return ret
+
+    def __eq__(self, other):
+        if self.__class__ is other.__class__:
+            for s, o in map(lambda a: (getattr(self, f"_{a}"), getattr(other, f"_{a}")),
+                            ("cell", "icell", "atol", "offset", "foffset")):
+                if not np.allclose(s, o):
+                    return False
+            return True
+        return False
+
+
+@set_module("sisl.geom")
+class AtomCoordinate(AtomCategory):
+    r""" Classify atoms based on coordinates
+
+    Parameters
+    ----------
+    *args : Shape
+       any shape that implements `Shape.within`
+    **kwargs: 
+       keys are operator specifications and values are
+       used in those specifications.
+       The keys are split into 3 sections
+       ``<options>_<direction>_<operator>``  
+       - ``options`` are made of combinations of ``['a', 'f']``
+         i.e. ``"af"``, ``"f"`` or ``"a"`` are all valid.
+         An ``a`` takes the absolute value, ``f`` means a fractional
+         coordinate. This part is optional.
+       - ``direction`` is anything that gets parsed in `sisl.utils.misc.direction`
+         either one of ``{0, "X", "x", "a", 1, "Y", "y", "b", 2, "Z", "z", "c"}``.
+       - ``operator`` is a name for an operator defined in the `operator` module.
+         
+       For instance `a_z_lt=3.` will be equivalent to the
+       boolean operation ``np.fabs(geometry.xyz[:, 2]) < 3.``.
+
+       Optionally one need not specify the operator in which case one should
+       provide an argument of two values.
+
+       For instance `c=(3., 6.)` will be equivalent to the
+       boolean operation ``3. <= geometry.xyz[:, 2]) <= 6.``.
+    """
+    __slots__ = ("_coord_check",)
+
+    def __init__(self, *args, **kwargs):
+
+        def create1(is_frac, is_abs, op, d):
+            if is_abs:
+                @wraps(op)
+                def func(a, b):
+                    return op(np.fabs(a))
+            else:
+                @wraps(op)
+                def func(a, b):
+                    return op(a)
+            return is_frac, func, d, None
+
+        def create2(is_frac, is_abs, op, d, val):
+            if is_abs:
+                @wraps(op)
+                def func(a, b):
+                    return op(np.fabs(a), b)
+            else:
+                @wraps(op)
+                def func(a, b):
+                    return op(a, b)
+            return is_frac, func, d, val
+
+        coord_ops = []
+
+        # For each *args we expect this to be a shape
+        for arg in args:
+            if not isinstance(arg, Shape):
+                raise ValueError(f"{self.__class__.__name__} requires non-keyword arguments "
+                                 f"to be of type Shape {type(arg)}.")
+
+            coord_ops.append(create1(False, False, arg.within, (0, 1, 2)))
+
+        for key, value in kwargs.items():
+            value = np.array(value)
+
+            # Parse key for to get values
+            # The key must have this specification:
+            # [fa]_"dir"_"op"
+            spec = ""
+            if key.count("_") == 2:
+                spec, sdir, op = key.split("_")
+            elif key.count("_") == 1:
+                if value.size == 2:
+                    spec, sdir = key.split("_")
+                else:
+                    sdir, op = key.split("_")
+            elif value.size == 2:
+                sdir = key
+            else:
+                raise ValueError(f"{self.__class__.__name__} could not determine the operations for {key}={value}.\n"
+                                 f"{key} must be on the form [fa]_<dir>_<operator>")
+
+            # parse options
+            is_abs = "a" in spec
+            is_frac = "f" in spec
+            # Convert to integer axis
+            sdir = direction(sdir)
+
+            # Now we are ready to build our scheme
+            if value.size == 2:
+                # do it twice
+                coord_ops.append(create2(is_frac, is_abs, operator.ge, sdir, value[0]))
+                coord_ops.append(create2(is_frac, is_abs, operator.le, sdir, value[1]))
+            else:
+                coord_ops.append(create2(is_frac, is_abs, getattr(operator, op), sdir, value))
+
+        self._coord_check = coord_ops
+        super().__init__("coord")
+
+    def categorize(self, geometry, atoms=None):
+        if atoms is None:
+            xyz = geometry.xyz
+            fxyz = geometry.fxyz
+        else:
+            xyz = geometry.xyz[atoms]
+            fxyz = geometry.fxyz[atoms]
+        def call(frac, func, d, val):
+            if frac:
+                return func(fxyz[..., d], val)
+            return func(xyz[..., d], val)
+
+        and_reduce = np.logical_and.reduce
+        ret = where(and_reduce([call(*four) for four in self._coord_check]),
+                    self, NullCategory()).tolist()
+        if isinstance(atoms, Integral):
+            ret = ret[0]
+        return ret
+
+    def __eq__(self, other):
+        if self.__class__ is other.__class__:
+            if len(self._coord_check) == len(other._coord_check):
+                for s4 in self._coord_check:
+                    if s4 not in other._coord_check:
+                        return False
+                return True
+        return False

--- a/sisl/geom/category/_coord.py
+++ b/sisl/geom/category/_coord.py
@@ -166,6 +166,7 @@ class AtomXYZ(AtomCategory):
             coord_ops.append(create1(False, False, arg.within, (0, 1, 2)))
 
         for key, value in kwargs.items():
+            # will allow us to do value.size
             value = np.array(value)
 
             # Parse key for to get values
@@ -185,12 +186,6 @@ class AtomXYZ(AtomCategory):
                 raise ValueError(f"{self.__class__.__name__} could not determine the operations for {key}={value}.\n"
                                  f"{key} must be on the form [fa]_<dir>_<operator>")
 
-            if value.size == 2:
-                if value[0] is None:
-                    value[0] = -np.inf
-                if value[1] is None:
-                    value[1] = np.inf
-
             # parse options
             is_abs = "a" in spec
             is_frac = "f" in spec
@@ -200,8 +195,10 @@ class AtomXYZ(AtomCategory):
             # Now we are ready to build our scheme
             if value.size == 2:
                 # do it twice
-                coord_ops.append(create2(is_frac, is_abs, operator.ge, sdir, value[0]))
-                coord_ops.append(create2(is_frac, is_abs, operator.le, sdir, value[1]))
+                if not value[0] is None:
+                    coord_ops.append(create2(is_frac, is_abs, operator.ge, sdir, value[0]))
+                if not value[1] is None:
+                    coord_ops.append(create2(is_frac, is_abs, operator.le, sdir, value[1]))
             else:
                 coord_ops.append(create2(is_frac, is_abs, getattr(operator, op), sdir, value))
 

--- a/sisl/geom/category/_coord.py
+++ b/sisl/geom/category/_coord.py
@@ -15,7 +15,7 @@ import sisl._array as _a
 from .base import AtomCategory, NullCategory, _sanitize_loop
 
 
-__all__ = ["AtomFracSite", "AtomCoordinate"]
+__all__ = ["AtomFracSite", "AtomXYZ"]
 
 
 @set_module("sisl.geom")
@@ -100,7 +100,7 @@ class AtomFracSite(AtomCategory):
 
 
 @set_module("sisl.geom")
-class AtomCoordinate(AtomCategory):
+class AtomXYZ(AtomCategory):
     r""" Classify atoms based on coordinates
 
     Parameters
@@ -184,6 +184,12 @@ class AtomCoordinate(AtomCategory):
             else:
                 raise ValueError(f"{self.__class__.__name__} could not determine the operations for {key}={value}.\n"
                                  f"{key} must be on the form [fa]_<dir>_<operator>")
+
+            if value.size == 2:
+                if value[0] is None:
+                    value[0] = -np.inf
+                if value[1] is None:
+                    value[1] = np.inf
 
             # parse options
             is_abs = "a" in spec

--- a/sisl/geom/category/_coord.py
+++ b/sisl/geom/category/_coord.py
@@ -119,7 +119,7 @@ class AtomXYZ(AtomCategory):
        - ``direction`` is anything that gets parsed in `sisl.utils.misc.direction`
          either one of ``{0, "X", "x", "a", 1, "Y", "y", "b", 2, "Z", "z", "c"}``.
        - ``operator`` is a name for an operator defined in the `operator` module.
-         
+
        For instance `a_z_lt=3.` will be equivalent to the
        boolean operation ``np.fabs(geometry.xyz[:, 2]) < 3.``.
 

--- a/sisl/geom/category/_kind.py
+++ b/sisl/geom/category/_kind.py
@@ -1,11 +1,16 @@
+from functools import reduce, partial, wraps
+import operator as op
+from numbers import Integral
+
 import numpy as np
+from numpy import dot
 
 from sisl._internal import set_module, singledispatchmethod
 from sisl._help import isiterable
 from .base import AtomCategory, NullCategory, _sanitize_loop
 
 
-__all__ = ["AtomZ", "AtomOdd", "AtomEven"]
+__all__ = ["AtomZ", "AtomIndex", "AtomOdd", "AtomEven"]
 
 
 @set_module("sisl.geom")
@@ -45,25 +50,103 @@ class AtomZ(AtomCategory):
 
 
 @set_module("sisl.geom")
-class AtomOdd(AtomCategory):
-    r""" Classify atoms based on indices (odd in this case)"""
-    __slots__ = []
+class AtomIndex(AtomCategory):
+    r""" Classify atoms based on indices
 
-    def __init__(self):
-        super().__init__("odd")
+    Parameters
+    ----------
+    *args : int or list of int
+       each value will be equivalent to ``in=set(args)``
+    **kwargs : key, value
+       if key is a function it must accept two values ``value, atom``
+       where ``value`` is the value on this command. The function should
+       return anything that can be interpreted as a True/False.
+       Multiple ``key`` equates to an `and` statement.
+
+    Examples
+    --------
+    >>> aidx = AtomIndex(1, 4, 5)
+    >>> geom.sub(aidx) == geom.sub([1, 4, 5])
+    >>> aidx = AtomIndex(mod=2) # odd indices
+    >>> geom.sub(aidx) == geom.sub(range(1, len(geom), 2))
+    >>> aidx = ~AtomIndex(mod=2) # even indices
+    >>> geom.sub(aidx) == geom.sub(range(0, len(geom), 2))
+    >>> aidx = ~AtomIndex(mod=3) # every 3rd atom
+    >>> geom.sub(aidx) == geom.sub(range(0, len(geom), 3))
+    >>> aidx = AtomIndex(mod=3) # [1, 2, 4, 5, ...]: range(na) - range(0, na, 3)
+    >>> geom.sub(aidx) == geom.sub(range(0, len(geom), 3))
+    """
+    __slots__ = ("_op_val",)
+
+    def __init__(self, *args, **kwargs):
+        idx = set()
+        for arg in args:
+            if isinstance(arg, Integral):
+                idx.add(arg)
+            else:
+                idx.update(arg)
+        for key_a in ["eq", "in", "contains"]:
+            for key in [key_a, f"__{key_a}__"]:
+                arg = kwargs.pop(key, set())
+                if isinstance(arg, Integral):
+                    idx.add(arg)
+                else:
+                    idx.update(arg)
+
+        # Now create the list of operators
+        def wrap_func(func):
+            @wraps(func)
+            def make_partial(a, b):
+                """ Wrapper to make partial useful """
+                if isinstance(b, Integral):
+                    return op.truth(func(a, b))
+                is_true = True
+                for ib in b:
+                    is_true = is_true and func(a, ib)
+                return is_true
+            return make_partial
+
+        if len(idx) == 0:
+            operator = []
+        else:
+            @wraps(op.contains)
+            def func_wrap(a, b):
+                return op.contains(b, a)
+            operator.append((func_wrap, b))
+
+        for func, value in kwargs.items():
+            if callable(func):
+                # it has to be called like this:
+                #   func(atom, value)
+                # this makes it easier to handle stuff
+                operator.append((wrap_func(func), value))
+            else:
+                # Certain attributes cannot be directly found (and => and_)
+                try:
+                    attr_op = getattr(op, func)
+                except AttributeError:
+                    attr_op = getattr(op, f"{func}_")
+                operator.append((wrap_func(attr_op), value))
+
+        # Create string
+        self._op_val = operator
+        super().__init__(" & ".join(map(lambda f, b: f"{f.__name__}[{b}]", *zip(*self._op_val))))
 
     @_sanitize_loop
     def categorize(self, geometry, atoms=None):
         # _sanitize_loop will ensure that atoms will always be an integer
-        if atoms % 2 == 1:
+        if reduce(op.and_, (f(atoms, b) for f, b in self._op_val), True):
             return self
         return NullCategory()
 
     def __eq__(self, other):
-        return self.__class__ is other.__class__
+        if self.__class__ is other.__class__:
+            if len(self._op_val) == len(other._op_val):
+                # Check they are the same
+                return reduce(op.and_, (op_val in other._op_val for op_val in self._op_val), True)
+        return False
 
 
-@set_module("sisl.geom")
 class AtomEven(AtomCategory):
     r""" Classify atoms based on indices (even in this case)"""
     __slots__ = []
@@ -75,6 +158,25 @@ class AtomEven(AtomCategory):
     def categorize(self, geometry, atoms):
         # _sanitize_loop will ensure that atoms will always be an integer
         if atoms % 2 == 0:
+            return self
+        return NullCategory()
+
+    def __eq__(self, other):
+        return self.__class__ is other.__class__
+
+
+@set_module("sisl.geom")
+class AtomOdd(AtomCategory):
+    r""" Classify atoms based on indices (odd in this case)"""
+    __slots__ = []
+
+    def __init__(self):
+        super().__init__("odd")
+
+    @_sanitize_loop
+    def categorize(self, geometry, atoms):
+        # _sanitize_loop will ensure that atoms will always be an integer
+        if atoms % 2 == 1:
             return self
         return NullCategory()
 

--- a/sisl/geom/category/_neighbours.py
+++ b/sisl/geom/category/_neighbours.py
@@ -13,7 +13,6 @@ __all__ = ["AtomNeighbours"]
 class AtomNeighbours(AtomCategory):
     r""" Classify atoms based on number of neighbours
 
-
     Parameters
     ----------
     min : int, optional
@@ -89,7 +88,7 @@ class AtomNeighbours(AtomCategory):
 
     @_sanitize_loop
     def categorize(self, geometry, atoms=None):
-        """ Check that number of neighbours are matching """
+        """ Check if geometry and atoms matches the neighbour criteria """
         idx, rij = geometry.close(atoms, R=self.R(geometry.atoms[atoms]), ret_rij=True)
         idx, rij = idx[1], rij[1]
         if len(idx) < self._min:

--- a/sisl/geom/category/tests/test_geom_category.py
+++ b/sisl/geom/category/tests/test_geom_category.py
@@ -94,7 +94,7 @@ def test_geom_category_frac_site():
     mid_layer = np.average(hBN_gr.xyz[:, 2])
 
     A_site = AtomFracSite(graphene())
-    bottom = AtomCoordinate(z_lt=mid_layer, z=(-10, mid_layer))
+    bottom = AtomXYZ(z_lt=mid_layer, z=(None, mid_layer))
     top = ~bottom
 
     bottom_A = A_site & bottom
@@ -132,7 +132,7 @@ def test_geom_category_shape():
     mid_layer = np.average(hBN_gr.xyz[:, 2])
 
     A_site = AtomFracSite(graphene())
-    bottom = AtomCoordinate(Cuboid([10000, 10000, mid_layer], [-100, -100, 0]))
+    bottom = AtomXYZ(Cuboid([10000, 10000, mid_layer], [-100, -100, 0]))
     top = ~bottom
 
     bottom_A = A_site & bottom

--- a/sisl/geom/category/tests/test_geom_category.py
+++ b/sisl/geom/category/tests/test_geom_category.py
@@ -9,6 +9,14 @@ from sisl.geom import *
 pytestmark = [pytest.mark.geom, pytest.mark.category, pytest.mark.geom_category]
 
 
+def test_geom_category_kw_and_call():
+    # Check that categories can be built indistinctively using the kw builder
+    # or directly calling them.
+    cat1 = AtomCategory.kw(odd={})
+    cat2 = AtomCategory(odd={})
+    assert cat1 == cat2
+
+
 def test_geom_category():
     hBN = honeycomb(1.42, [Atom(5, R=1.43), Atom(7, R=1.43)]) * (10, 11, 1)
 

--- a/sisl/geom/category/tests/test_geom_category.py
+++ b/sisl/geom/category/tests/test_geom_category.py
@@ -148,3 +148,26 @@ def test_geom_category_shape():
         else:
             assert False
     assert cnull == len(hBN_gr) // 4 * 3
+
+
+def test_geom_category_xyz_none():
+    hBN_gr = bilayer(1.42, Atom[5, 7], Atom[6]) * (4, 5, 1)
+    mid_layer = np.average(hBN_gr.xyz[:, 2])
+
+    A_site = AtomFracSite(graphene())
+    bottom = AtomXYZ(z=(None, mid_layer))
+    top = AtomXYZ(z=(mid_layer, None))
+
+    bottom_A = A_site & bottom
+    top_A = A_site & top
+
+    cat = (bottom_A | top_A).categorize(hBN_gr)
+    cnull = 0
+    for i, c in enumerate(cat):
+        if c == NullCategory():
+            cnull += 1
+        elif hBN_gr.xyz[i, 2] < mid_layer:
+            assert c == bottom_A
+        else:
+            assert False
+    assert cnull == len(hBN_gr) // 4 * 3

--- a/sisl/geom/category/tests/test_geom_category.py
+++ b/sisl/geom/category/tests/test_geom_category.py
@@ -1,6 +1,8 @@
 import pytest
 
-from sisl import Atom, PeriodicTable
+import numpy as np
+
+from sisl import Atom, PeriodicTable, Cuboid
 from sisl.geom import *
 
 
@@ -66,3 +68,83 @@ def test_geom_category_even_odd():
             assert c == even
         else:
             assert c == odd
+
+
+def test_geom_category_index():
+    hBN = honeycomb(1.42, Atom[5, 7]) * (4, 5, 1)
+
+    odd = AtomIndex(mod=2)
+    even = ~odd
+    str(odd)
+    str(even)
+
+    assert odd != even
+    assert even != odd
+
+    cat = (odd | even).categorize(hBN)
+    for i, c in enumerate(cat):
+        if i % 2 == 0:
+            assert c == even
+        else:
+            assert c == odd
+
+
+def test_geom_category_frac_site():
+    hBN_gr = bilayer(1.42, Atom[5, 7], Atom[6]) * (4, 5, 1)
+    mid_layer = np.average(hBN_gr.xyz[:, 2])
+
+    A_site = AtomFracSite(graphene())
+    bottom = AtomCoordinate(z_lt=mid_layer, z=(-10, mid_layer))
+    top = ~bottom
+
+    bottom_A = A_site & bottom
+    top_A = A_site & top
+
+    cat = (bottom_A | top_A).categorize(hBN_gr)
+    str(cat)
+    cnull = 0
+    for i, c in enumerate(cat):
+        if c == NullCategory():
+            cnull += 1
+        elif hBN_gr.xyz[i, 2] < mid_layer:
+            assert c == bottom_A
+        else:
+            assert False
+    assert cnull == len(hBN_gr) // 4 * 3
+
+
+def test_geom_category_frac_A_B_site():
+    gr = graphene() * (4, 5, 1)
+
+    A_site = AtomFracSite(graphene())
+    B_site = AtomFracSite(graphene(), foffset=(-1/3, -1/3, 0))
+
+    cat = (A_site | B_site).categorize(gr)
+    for i, c in enumerate(cat):
+        if i % 2 == 0:
+            assert c == A_site
+        else:
+            assert c == B_site
+
+
+def test_geom_category_shape():
+    hBN_gr = bilayer(1.42, Atom[5, 7], Atom[6]) * (4, 5, 1)
+    mid_layer = np.average(hBN_gr.xyz[:, 2])
+
+    A_site = AtomFracSite(graphene())
+    bottom = AtomCoordinate(Cuboid([10000, 10000, mid_layer], [-100, -100, 0]))
+    top = ~bottom
+
+    bottom_A = A_site & bottom
+    top_A = A_site & top
+
+    cat = (bottom_A | top_A).categorize(hBN_gr)
+    cnull = 0
+    for i, c in enumerate(cat):
+        if c == NullCategory():
+            cnull += 1
+        elif hBN_gr.xyz[i, 2] < mid_layer:
+            assert c == bottom_A
+        else:
+            assert False
+    assert cnull == len(hBN_gr) // 4 * 3

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -39,6 +39,11 @@ __all__ = ['Geometry', 'sgeom']
 class AtomCategory(Category):
     __slots__ = tuple()
 
+    @classmethod
+    def is_class(cls, name):
+        # Strip off `Atom`
+        return cls.__name__.lower()[4:] == name.lower()
+
 
 @set_module("sisl")
 class Geometry(SuperCellChild):

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -42,7 +42,7 @@ class AtomCategory(Category):
     @classmethod
     def is_class(cls, name):
         # Strip off `Atom`
-        return cls.__name__.lower()[4:] == name.lower()
+        return cls.__name__[4:].lower() == name.lower()
 
 
 @set_module("sisl")

--- a/sisl/tests/test_category.py
+++ b/sisl/tests/test_category.py
@@ -1,8 +1,0 @@
-from sisl.geom import AtomCategory
-
-def test_geom_category_kw_and_call():
-    # Check that categories can be built indistinctively using the kw builder
-    # or directly calling them.
-    cat1 = AtomCategory.kw(odd={})
-    cat2 = AtomCategory(odd={})
-    assert cat1 == cat2

--- a/sisl/tests/test_geometry.py
+++ b/sisl/tests/test_geometry.py
@@ -1423,6 +1423,8 @@ def test_geometry_sort_fail_keyword():
         sisl_geom.bilayer().sort(not_found_keyword=True)
 
 
+@pytest.mark.category
+@pytest.mark.geom_category
 def test_geometry_sanitize_atom():
     bi = sisl_geom.bilayer(bottom_atoms=Atom[6], top_atoms=(Atom[5], Atom[7])).tile(2, 0).repeat(2, 1)
     C_idx = (bi.atoms.Z == 6).nonzero()[0]

--- a/sisl/utils/misc.py
+++ b/sisl/utils/misc.py
@@ -152,7 +152,6 @@ def direction(d):
     d : {0, "x", "a", 1, "y", "b", 2, "z", "c"}
        returns the integer that corresponds to the coordinate index (strings are
        lower-cased).
-       If it is an integer, it is returned *as is*.
 
     Returns
     -------


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Documentation for functionality

@pfebrer96 @jonaslb @sofiasanz @tfrederiksen please check out this new categories stuff for site categories.

It enables one to search for specific sites via coordinates or via fractional coordinates.

Here are two tests:
```python
def test_geom_category_frac_site():
    hBN_gr = bilayer(1.42, Atom[5, 7], Atom[6]) * (4, 5, 1)
    mid_layer = np.average(hBN_gr.xyz[:, 2])

    A_site = AtomFracSite(graphene())
    bottom = AtomCoordinate(z_lt=mid_layer, z=(-10, mid_layer))
    top = ~bottom

    bottom_A = A_site & bottom
    top_A = A_site & top

    cat = (bottom_A | top_A).categorize(hBN_gr)
    str(cat)
    cnull = 0
    for i, c in enumerate(cat):
        if c == NullCategory():
            cnull += 1
        elif hBN_gr.xyz[i, 2] < mid_layer:
            assert c == bottom_A
        else:
            assert False
    assert cnull == len(hBN_gr) // 4 * 3

def test_geom_category_frac_A_B_site():
    gr = graphene() * (4, 5, 1)

    A_site = AtomFracSite(graphene())
    B_site = AtomFracSite(graphene(), foffset=(-1/3, -1/3, 0))

    cat = (A_site | B_site).categorize(gr)
    for i, c in enumerate(cat):
        if i % 2 == 0:
            assert c == A_site
        else:
            assert c == B_site
```
This allows one to distinguish between different sites.

Please let me know if something could be changed! :)