### PR TITLE
RealspaceSI: Using unfold=(1,1,1) no longer overwrites nsc on Hsurface

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,9 @@
 - Ensured ghost atoms in Siesta are handled with separate
 	class, AtomGhost, #249
 
+- Using `si.RealspaceSI` with `unfold=(1,1,1)` no longer results in `nsc` on
+    the given surface hamiltonian being set to `(1,1,1)`.
+
 - Added calculation of isosurfaces, #246
 
 - Added `sisl.WideBandSE` for self-energies with constant

--- a/sisl/physics/self_energy.py
+++ b/sisl/physics/self_energy.py
@@ -1286,6 +1286,8 @@ class RealSpaceSI(SelfEnergy):
         correspond to the `self.surface` object, always!
         """
         P0 = self.surface
+        if np.all(self._unfold == 1):
+            P0 = P0.copy()
         for ax in range(3):
             if self._unfold[ax] == 1:
                 continue
@@ -1321,6 +1323,8 @@ class RealSpaceSI(SelfEnergy):
         PC_k = self.semi.spgeom0
         PC_semi = self.semi.spgeom1
         PC = self.surface
+        if np.all(self._unfold == 1):
+            PC = PC.copy()
         for ax in range(3):
             if self._unfold[ax] == 1:
                 continue


### PR DESCRIPTION
As the title says, a surface hamiltonian would effectively be destroyed in `RealSpaceSI` when using `unfold=(1,1,1)`, because no copy-operations were performed before setting nsc in a few methods in that case. This is probably a kind of unusual value to use for `unfold`, so hopefully noone was affected. `RealSpaceSE` is not affected because it always uses a tile operation in the semi-infinite direction in its corresponding methods.

- [ ❌ ] Closes #xxxx
 - [ ❌ ] Tests added
 - [ ❌ ] Documentation for functionality
 - [ ✔️ ] User visible changes (including notable bug fixes) are documented in `CHANGELOG`
