### PR TITLE
bug: skewed isosurfaces were not properly calculated

### DIFF
--- a/sisl/grid.py
+++ b/sisl/grid.py
@@ -227,19 +227,12 @@ class Grid(SuperCellChild):
         # Run the marching cubes algorithm to calculate the vertices and faces
         # of the requested isosurface.
         verts, *returns = skimage.measure.marching_cubes(
-            self.grid, level=level, spacing=fnorm(self.dcell), step_size=step_size, **kwargs
+            self.grid, level=level, spacing=1/np.array(self.shape), step_size=step_size, **kwargs
         )
 
-        # Define the transformation matrix to get the real vertices
-        # This is because skimage calculates the vertices as if it was an orthogonal cell
-        T = self.cell / fnorm(self.cell).reshape(3, 1)
-
-        # Check that the transformation matrix is definite positive
-        if np.linalg.det(T) < 0:
-            T[:, 2] = -T[:, 2]  # change the orientation of the third vector
-
-        # Apply the transformation and get the real coordinates of the vertices
-        verts = T.dot(verts.T).T
+        # The verts cordinates are in fractional coordinates. Therefore, we need to use
+        # the cell vectors to get the actual xyz coordinates
+        verts = verts.dot(self.cell)
 
         return (verts, *returns)
 


### PR DESCRIPTION
Skewed isosurfaces were still not properly calculated. It was easier to do it good than to do it bad (see how simple the code is now). Sorry :)

Visual proof that it works now by overlapping a RHO file with its geometry:

With the old implementation:

![newplot - 2020-09-18T152305 452](https://user-images.githubusercontent.com/42074085/93602850-7da31480-f9c3-11ea-9632-fdca1a265d07.png)

With the new implementation:

![newplot - 2020-09-18T152114 542](https://user-images.githubusercontent.com/42074085/93602864-85fb4f80-f9c3-11ea-83bf-2ef957428dc9.png)

