### PR TITLE
Fixed reading geometries in .AXSF-files

### DIFF
--- a/sisl/io/tests/test_object.py
+++ b/sisl/io/tests/test_object.py
@@ -19,6 +19,11 @@ gs = get_sile
 gsc = get_sile_class
 
 
+sile_geom_write_instantiation_args = {
+    axsfSile: dict(count=1),
+}
+
+
 def _my_intersect(a, b):
     a = get_siles(a)
     b = set(get_siles(b))
@@ -237,7 +242,8 @@ class TestObject:
         if issubclass(sile, (_ncSileTBtrans, deltancSileTBtrans)):
             return
         # Write
-        sile(f, mode="w").write_geometry(G)
+        kwargs = sile_geom_write_instantiation_args.get(sile, {})
+        sile(f, mode="w", **kwargs).write_geometry(G)
         # Read 1
         try:
             g = sile(f, mode="r").read_geometry()

--- a/sisl/io/tests/test_object.py
+++ b/sisl/io/tests/test_object.py
@@ -19,11 +19,6 @@ gs = get_sile
 gsc = get_sile_class
 
 
-sile_geom_write_instantiation_args = {
-    axsfSile: dict(count=1),
-}
-
-
 def _my_intersect(a, b):
     a = get_siles(a)
     b = set(get_siles(b))
@@ -242,8 +237,7 @@ class TestObject:
         if issubclass(sile, (_ncSileTBtrans, deltancSileTBtrans)):
             return
         # Write
-        kwargs = sile_geom_write_instantiation_args.get(sile, {})
-        sile(f, mode="w", **kwargs).write_geometry(G)
+        sile(f, mode="w").write_geometry(G)
         # Read 1
         try:
             g = sile(f, mode="r").read_geometry()

--- a/sisl/io/tests/test_xsf.py
+++ b/sisl/io/tests/test_xsf.py
@@ -6,7 +6,7 @@ import numpy as np
 from itertools import zip_longest
 
 
-pytestmark = pytest.mark.io
+pytestmark = [pytest.mark.io, pytest.mark.xsf]
 _dir = osp.join('sisl', 'io')
 
 
@@ -49,7 +49,7 @@ def test_axsf_geoms(sisl_tmp):
     geom = Geometry(np.random.rand(10, 3), np.random.randint(1, 70, 10), sc=[10, 10, 10, 45, 60, 90])
     geoms = [geom.move((i/10, i/10, i/10)) for i in range(3)]
 
-    with axsfSile(f, "w", count=3) as s:
+    with axsfSile(f, "w", steps=3) as s:
         for i in range(3):
             s.write_geometry(geoms[i])
 
@@ -69,12 +69,7 @@ def test_axsf_geoms(sisl_tmp):
         assert all(g.equal(rg) for g, rg in zip_longest(geoms[:3], rgeoms))
 
     with axsfSile(f) as s:
-        rgeoms = s.read_geometry(index=None, one_geometry=True)
-        assert isinstance(rgeoms, Geometry)
-        assert geoms[0].equal(rgeoms)
-
-    with axsfSile(f) as s:
-        rgeoms, rdata = s.read_geometry(index=None, load_data=True)
+        rgeoms, rdata = s.read_geometry(index=None, ret_data=True)
         assert all(g.equal(rg) for g, rg in zip_longest(geoms, rgeoms))
         assert rdata.shape == (3, 10, 0)
 
@@ -85,21 +80,16 @@ def test_axsf_data(sisl_tmp):
     geoms = [geom.move((i/10, i/10, i/10)) for i in range(3)]
     data = np.random.rand(3, 10, 3)
 
-    with axsfSile(f, "w", count=3) as s:
+    with axsfSile(f, "w", steps=3) as s:
         for i in range(3):
             s.write_geometry(geoms[i], data=data[i])
 
     with axsfSile(f) as s:
-        rgeoms, rdata = s.read_geometry(index=None, one_geometry=False, load_data=True)
+        rgeoms, rdata = s.read_geometry(index=None, ret_data=True)
         assert all(g.equal(rg) for g, rg in zip_longest(geoms, rgeoms))
         assert np.allclose(rdata, data)
 
     with axsfSile(f) as s:
-        rgeoms, rdata = s.read_geometry(index=(1, 2), one_geometry=True, load_data=True)
-        assert geoms[1].equal(rgeoms)
-        assert np.allclose(rdata, data[[1, 2], :, :])
-
-    with axsfSile(f) as s:
-        rgeoms, rdata = s.read_geometry(index=0, one_geometry=False, load_data=True)
+        rgeoms, rdata = s.read_geometry(index=0, ret_data=True)
         assert geoms[0].equal(rgeoms)
         assert np.allclose(rdata, data[0, :, :])

--- a/sisl/io/tests/test_xsf.py
+++ b/sisl/io/tests/test_xsf.py
@@ -3,6 +3,7 @@ import os.path as osp
 from sisl import Geometry, Atom, Grid
 from sisl.io.xsf import *
 import numpy as np
+from itertools import zip_longest
 
 
 pytestmark = pytest.mark.io
@@ -41,3 +42,64 @@ def test_imaginary(sisl_tmp):
     grid.grid = np.random.rand(*grid.shape) + 1j*np.random.rand(*grid.shape)
     grid.write(f)
     assert not grid.geometry is None
+
+
+def test_axsf_geoms(sisl_tmp):
+    f = sisl_tmp('multigeom.axsf', _dir)
+    geom = Geometry(np.random.rand(10, 3), np.random.randint(1, 70, 10), sc=[10, 10, 10, 45, 60, 90])
+    geoms = [geom.move((i/10, i/10, i/10)) for i in range(3)]
+
+    with axsfSile(f, "w", count=3) as s:
+        for i in range(3):
+            s.write_geometry(geoms[i])
+
+    with axsfSile(f) as s:
+        rgeoms = s.read_geometry(index=(0, 2))
+        assert all(isinstance(rg, Geometry) for rg in rgeoms)
+        assert all(g.equal(rg) for g, rg in zip_longest([geoms[0], geoms[2]], rgeoms))
+
+    with axsfSile(f) as s:
+        rgeoms = s.read_geometry(index=1)
+        assert isinstance(rgeoms, Geometry)
+        assert geoms[1].equal(rgeoms)
+
+    with axsfSile(f) as s:
+        rgeoms = s.read_geometry(index=None)
+        assert all(isinstance(rg, Geometry) for rg in rgeoms)
+        assert all(g.equal(rg) for g, rg in zip_longest(geoms[:3], rgeoms))
+
+    with axsfSile(f) as s:
+        rgeoms = s.read_geometry(index=None, one_geometry=True)
+        assert isinstance(rgeoms, Geometry)
+        assert geoms[0].equal(rgeoms)
+
+    with axsfSile(f) as s:
+        rgeoms, rdata = s.read_geometry(index=None, load_data=True)
+        assert all(g.equal(rg) for g, rg in zip_longest(geoms, rgeoms))
+        assert rdata.shape == (3, 10, 0)
+
+
+def test_axsf_data(sisl_tmp):
+    f = sisl_tmp('multigeom.axsf', _dir)
+    geom = Geometry(np.random.rand(10, 3), np.random.randint(1, 70, 10), sc=[10, 10, 10, 45, 60, 90])
+    geoms = [geom.move((i/10, i/10, i/10)) for i in range(3)]
+    data = np.random.rand(3, 10, 3)
+
+    with axsfSile(f, "w", count=3) as s:
+        for i in range(3):
+            s.write_geometry(geoms[i], data=data[i])
+
+    with axsfSile(f) as s:
+        rgeoms, rdata = s.read_geometry(index=None, one_geometry=False, load_data=True)
+        assert all(g.equal(rg) for g, rg in zip_longest(geoms, rgeoms))
+        assert np.allclose(rdata, data)
+
+    with axsfSile(f) as s:
+        rgeoms, rdata = s.read_geometry(index=(1, 2), one_geometry=True, load_data=True)
+        assert geoms[1].equal(rgeoms)
+        assert np.allclose(rdata, data[[1, 2], :, :])
+
+    with axsfSile(f) as s:
+        rgeoms, rdata = s.read_geometry(index=0, one_geometry=False, load_data=True)
+        assert geoms[0].equal(rgeoms)
+        assert np.allclose(rdata, data[0, :, :])


### PR DESCRIPTION
Reading axsf-files didn't really work before, as sisl would read the entire file and put all of the steps into one big geometry.

I rewrote the parsing code and changed the call signature for `axsfSile.read_geometry` (but kept the one for `xsfSile.read_geometry`) to help with reading many geometries in large axsfs. It shouldnt matter that I changed it, wrt compat, because it didn't really work before anyway.

 - [x] Tests added
 - [x] Documentation for functionality
