### PR TITLE
Optimize ufunc operation between SparseCSR objects

### DIFF
--- a/sisl/_indices.pyx
+++ b/sisl/_indices.pyx
@@ -164,6 +164,9 @@ cdef void _indices_sorted_arrays(
         elif csearch > cvalue:
             idx[j] = -1
             j += 1
+    i = j
+    for j in range(i, n_value):
+        idx[j] = -1
 
 
 @cython.boundscheck(False)

--- a/sisl/_indices.pyx
+++ b/sisl/_indices.pyx
@@ -135,11 +135,9 @@ cdef void _indices(const int n_search, const int[::1] search,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.initializedcheck(False)
-cdef void _indices_sorted_arrays(
-    const int n_search, const int[::1] search,
-    const int n_value, const int[::1] value,
-    const int offset, int[::1] idx
-    ) nogil:
+cdef void _indices_sorted_arrays(const int n_search, const int[::1] search,
+                                 const int n_value, const int[::1] value,
+                                 const int offset, int[::1] idx) nogil:
     cdef Py_ssize_t i, j
     cdef int cvalue, csearch
 
@@ -149,7 +147,7 @@ cdef void _indices_sorted_arrays(
     elif n_search == 0:
         for j in range(n_value):
             idx[j] = -1
-        pass
+        return
 
     i = 0
     j = 0

--- a/sisl/_indices.pyx
+++ b/sisl/_indices.pyx
@@ -155,7 +155,7 @@ cdef void _indices_sorted_arrays(
     j = 0
     while (i < n_search) and (j < n_value):
         csearch = search[i]
-        cvalue = search[j]
+        cvalue = value[j]
         if csearch == cvalue:
             idx[j] = i + offset
             j += 1
@@ -164,8 +164,7 @@ cdef void _indices_sorted_arrays(
         elif csearch > cvalue:
             idx[j] = -1
             j += 1
-    i = j
-    for j in range(i, n_value):
+    for j in range(j, n_value):
         idx[j] = -1
 
 

--- a/sisl/sparse.py
+++ b/sisl/sparse.py
@@ -293,9 +293,7 @@ class SparseCSR(NDArrayOperatorsMixin):
             out_col.append(np.unique(concatenate(row_cols)))
         # Put into the output
         out.ncol = _a.arrayi([len(cols) for cols in out_col])
-        out.ptr = _a.emptyi(out.ncol.size + 1)
-        out.ptr[0] = 0
-        _a.cumsumi(out.ncol, out=out.ptr[1:])
+        out.ptr = _ncol_to_indptr(out.ncol)
         out.col = concatenate(out_col)
         out._nnz = len(out.col)
         out._D = full([out._nnz, out.dim], value, dtype=dtype)

--- a/sisl/sparse.py
+++ b/sisl/sparse.py
@@ -296,7 +296,7 @@ class SparseCSR(NDArrayOperatorsMixin):
         _a.cumsumi(out.ncol, out=out.ptr[1:])
         out.col = concatenate(out_col)
         out._nnz = len(out.col)
-        out._D = full((out._nnz, out.dim), value, dtype=dtype)
+        out._D = full([out._nnz, out.dim], value, dtype=dtype)
         return out
 
     def diagonal(self):

--- a/sisl/sparse.py
+++ b/sisl/sparse.py
@@ -291,7 +291,9 @@ class SparseCSR(NDArrayOperatorsMixin):
             out_col.append(np.unique(concatenate(row_cols)))
         # Put into the output
         out.ncol = _a.arrayi([len(cols) for cols in out_col])
-        out.ptr = insert(_a.cumsumi(out.ncol), 0, 0)
+        out.ptr = _a.emptyi(out.ncol.size + 1)
+        out.ptr[0] = 0
+        _a.cumsumi(out.ncol, out=out.ptr[1:])
         out.col = concatenate(out_col)
         out._nnz = len(out.col)
         out._D = full((out._nnz, out.dim), value, dtype=dtype)


### PR DESCRIPTION
This change speeds up sp-sp operations significantly. On my computer for a particular (large) hamiltonian, a simple `H+H` goes from 6 minutes to 20 seconds. It's still not as fast as `H.tocsr()+H.tocsr()` though, but I think it's a good speedup regardless.

Edit: After some further commits, the before-mentioned time of 6 minutes is now down to 5 seconds. 