### PR TITLE
maint: remove ending blank line when writing xyz-files

### DIFF
--- a/sisl/io/xyz.py
+++ b/sisl/io/xyz.py
@@ -68,8 +68,6 @@ class xyzSile(Sile):
         for ia, a, _ in geom.iter_species():
             s = {'fa': 'Ds'}.get(a.symbol, a.symbol)
             self._write(fmt_str.format(s, *geom.xyz[ia, :]))
-        # Add a single new line
-        self._write('\n')
 
     def _r_geometry_sisl(self, na, header, sp, xyz):
         """ Read the geometry as though it was created with sisl """


### PR DESCRIPTION
`sisl` writes an unnecessary blank line at the end of each `xyz` file.

I think in most cases this probably doesn't matter much, but I have encountered the following situation where it is actually unwanted: Sometimes I concatenate several snapshot `xyz` files into into a single sequence `xyz` file for easy visualization/inspection with `xcrysden`, e.g., 
```
cat snapshot*xyz > sequence.xyz
xcrysden --xyz sequence.xyz
```
However, this fails unless those extra blank lines written by `sisl` are removed. `xcrysden` expects exactly `N+2` lines per geometry.
