### PR TITLE
enh: enabled reading VASP OUTCAR files

### DIFF
--- a/sisl/io/__init__.py
+++ b/sisl/io/__init__.py
@@ -208,6 +208,7 @@ VASP (:mod:`~sisl.io.vasp`)
    eigenvalSileVASP
    chgSileVASP
    locpotSileVASP
+   outSileVASP
 
 
 .. _toc-io-wannier90:

--- a/sisl/io/vasp/__init__.py
+++ b/sisl/io/vasp/__init__.py
@@ -16,6 +16,7 @@ VASP files.
    eigenvalSileVASP
    chgSileVASP
    locpotSileVASP
+   outSileVASP
 
 """
 from .sile import *
@@ -24,6 +25,7 @@ from .eigenval import *
 from .doscar import *
 from .chg import *
 from .locpot import *
+from .out import *
 
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/sisl/io/vasp/out.py
+++ b/sisl/io/vasp/out.py
@@ -1,0 +1,79 @@
+import numpy as np
+
+# Import sile objects
+from .sile import SileVASP
+from ..sile import add_sile, sile_fh_open
+
+from sisl._internal import set_module
+
+
+__all__ = ['outSileVASP']
+
+
+@set_module("sisl.io.vasp")
+class outSileVASP(SileVASP):
+    """ OUTCAR VASP file """
+
+    _file_read = False
+    _job_completed = False
+    _cpu_time = None
+    _accuracy_reached = False
+    _energy = []
+
+    def _read(self):
+        itt = iter(self)
+        for line in itt:
+            # job completion
+            if 'General timing and accounting' in line:
+                self._job_completed = True
+                line = next(itt)
+                line = next(itt)
+                line = next(itt)
+                self._cpu_time = float(line.split()[5])
+            # relaxation finished
+            if 'reached required accuracy' in line:
+                self._accuracy_reached = True
+            # energy output
+            if 'free  energy   TOTEN  =' in line:
+                free_energy = float(line.split()[4])
+                line = next(itt) # read blank line
+                line = next(itt) # energy(sigma->0) line
+                esigma0 = float(line.split()[6])
+                self._energy.append([free_energy, esigma0])
+        _file_read = True
+
+    @property
+    def job_completed(self):
+        """ True if the line "General timing and accounting" was found. """
+        return self._job_completed
+
+    @property
+    def cpu_time(self):
+        """ Returns the consumed cpu time (in seconds). """
+        return self._cpu_time
+
+    @property
+    def accuracy_reached(self):
+        """ True if the line "reached required accuracy" was found. """
+        return self._accuracy_reached
+
+    @sile_fh_open()
+    def read_energy(self, all=False):
+        """ Reads the free energy and energy(sigma->0) in units of eV
+
+        Parameters
+        ----------
+        all: bool, optional                                                                                                                                                                                                  return a list of energies from each step
+
+        Returns
+        -------
+        list or numpy.ndarray
+        """
+        if not self._file_read:
+            self._read()
+        if all:
+            return np.array(self._energy)
+        else:
+            return self._energy[-1]
+
+add_sile('OUTCAR', outSileVASP, gzip=True)

--- a/sisl/io/vasp/out.py
+++ b/sisl/io/vasp/out.py
@@ -40,7 +40,7 @@ class outSileVASP(SileVASP):
                 line = next(itt) # energy(sigma->0) line
                 esigma0 = float(line.split()[6])
                 self._energy.append([free_energy, esigma0])
-        _file_read = True
+        self._file_read = True
 
     @property
     def job_completed(self):


### PR DESCRIPTION
This functionality enables the VASP user to 
* get the total energy (free energy as well as the energy extrapolated to sigma->0)
* get the cpu time consumed
* determine if the job terminated correctly
* determine if the relaxation accuracy criterion was met 

I tested this with version VASP 5.4.4.