### PR TITLE
Added GUI build as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "files"]
 	path = files
 	url = https://github.com/zerothi/sisl-files.git
+[submodule "sislGUI-build"]
+	path = sisl/viz/plotly/gui/build
+	url = https://github.com/pfebrer/sislGUI.git
+	branch = build


### PR DESCRIPTION
I changed the hosting of the GUI online from firebase to github pages (still using the same domain, https://sisl-siesta.xyz).

For this reason, **I now have a branch that contains the build** of the GUI (and is updated everytime there's a push to master): https://github.com/pfebrer/sislGUI/tree/build.

In this PR I added a git submodule to link to that branch, as I think you wanted it this way and it's probably more convenient.