### PR TITLE
Make github actions build the docs

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -1,0 +1,52 @@
+name: Build docs and upload them to gh-pages
+
+on:
+  push:
+    branches:
+      - gh-pages-docs
+  workflow_dispatch:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          lfs: true
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+
+      - name: Install sisl
+        run: |
+          python -m pip install --upgrade pip
+          pip install Cython
+          pip install .[viz]
+        
+      - name: Install dependencies to build the docs
+        run: |
+          pip install IPython sphinx sphinx-gallery sphinx-rtd-theme nbsphinx ipykernel
+          pip install tqdm ipywidgets
+          pip install git+https://github.com/pfebrer/sisl-gui.git
+          pip install kaleido
+ 
+      - uses: r-lib/actions/setup-pandoc@v1 
+
+      - name: Build the docs
+        run: |
+          cd docs
+          SISL_FILES_TESTS=${GITHUB_WORKSPACE}/files/tests make html
+          cd ..
+        
+      # Deploy to github pages
+      - name: Deploy to github pages
+        uses: JamesIves/github-pages-deploy-action@132898
+        with:
+          BRANCH: gh-pages-pol
+          FOLDER: docs/build/html
+          GITHUB_TOKEN: ${{ github.token }}
+

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -1,9 +1,11 @@
-name: Build docs and upload them to gh-pages
+name: Build documentation + upload to gh-pages
 
 on:
   push:
     branches:
       - gh-pages-docs
+  schedule:
+    - cron: '37 10 * * SAT'
   workflow_dispatch:
   
 jobs:
@@ -14,39 +16,43 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
         with:
+          # The files submodule is required for viz documentation
           submodules: true
+          # the files submodule uses lfs
           lfs: true
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.6'
+      # This should generally not be required, but in the end it is just easier
+      - name: Ensure fortran
+        run: |
+          sudo apt-get update
+          sudo apt-get install gfortran
 
-      - name: Install sisl
+      - name: Setup python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Install sisl + doc deps
         run: |
           python -m pip install --upgrade pip
-          pip install Cython
-          pip install .[viz]
+          python -m pip install Cython
+          python -m pip install .[viz]
+          python -m pip install -r docs/requirements.txt
         
-      - name: Install dependencies to build the docs
-        run: |
-          pip install IPython sphinx sphinx-gallery sphinx-rtd-theme nbsphinx ipykernel
-          pip install tqdm ipywidgets
-          pip install git+https://github.com/pfebrer/sisl-gui.git
-          pip install kaleido
- 
-      - uses: r-lib/actions/setup-pandoc@v1 
+      #- uses: r-lib/actions/setup-pandoc@v1 
 
       - name: Build the docs
         run: |
           cd docs
           SISL_FILES_TESTS=${GITHUB_WORKSPACE}/files/tests make html
+          rm -rf build/html/_sources
           cd ..
         
       # Deploy to github pages
       - name: Deploy to github pages
-        uses: JamesIves/github-pages-deploy-action@132898
+        uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
-          BRANCH: gh-pages-pol
+          BRANCH: gh-pages-action
           FOLDER: docs/build/html
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -39,7 +39,7 @@ jobs:
           python -m pip install .[viz]
           python -m pip install -r docs/requirements.txt
         
-      #- uses: r-lib/actions/setup-pandoc@v1 
+      - uses: r-lib/actions/setup-pandoc@v1 
 
       - name: Build the docs
         run: |

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -22,7 +22,7 @@ jobs:
           lfs: true
 
       # This should generally not be required, but in the end it is just easier
-      - name: Ensure fortran
+      - name: Ensure system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install gfortran
@@ -30,9 +30,9 @@ jobs:
       - name: Setup python environment
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
-      - name: Install sisl + doc deps
+      - name: Install sisl + documentation dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install Cython
@@ -41,7 +41,7 @@ jobs:
         
       - uses: r-lib/actions/setup-pandoc@v1 
 
-      - name: Build the docs
+      - name: Build the documentation using the sisl-files as well
         run: |
           cd docs
           SISL_FILES_TESTS=${GITHUB_WORKSPACE}/files/tests make html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,9 +8,14 @@ pyparsing>=1.5.7
 matplotlib
 ipykernel
 nbsphinx
-matplotlib
 dill>=0.3.2
 pathos
 xarray>=0.10.0
 scikit-image
 plotly
+sphinx-gallery
+sphinx-rtd-theme
+tqdm
+ipywidgets
+kaleido
+


### PR DESCRIPTION
I'm trying to make github actions build the docs automatically and upload them to the `gh-pages` branch.

Mostly, it's working, but I have two doubts:
- How can I make the files in sisl-files available for the notebooks to use? I've tried to do `git submodule init` and `git submodule update`, but this is not giving me the actual files.
- For some reason, the rtd theme isn't working (see https://pfebrer.github.io/sisl/, which is hosted at https://github.com/pfebrer/sisl/tree/gh-pages-pol). Any hint as to why?

Thanks!

(I will squash all commits if this is to be merged, I've done a lot of testing)
