### PR TITLE
Fixing bug in spin treatment for PdosPlot

### DIFF
--- a/sisl/viz/plotly/input_fields/dropdown.py
+++ b/sisl/viz/plotly/input_fields/dropdown.py
@@ -155,10 +155,10 @@ class SpinSelect(DropdownInput):
     }
 
     _options = {
-        Spin.UNPOLARIZED: [],
+        Spin.UNPOLARIZED: [{"label": "Total", "value": 0}],
         Spin.POLARIZED: [{"label": "↑", "value": 0}, {"label": "↓", "value": 1}],
-        Spin.NONCOLINEAR: [{"label": val, "value": val} for val in ("x", "y", "z")],
-        Spin.SPINORBIT: []
+        Spin.NONCOLINEAR: [{"label": val, "value": val} for val in ("sum", "x", "y", "z")],
+        Spin.SPINORBIT: [{"label": val, "value": val} for val in ("sum", "x", "y", "z")]
     }
 
     def __init__(self, *args, only_if_polarized=False, **kwargs):

--- a/sisl/viz/plotly/plots/tests/test_pdos.py
+++ b/sisl/viz/plotly/plots/tests/test_pdos.py
@@ -20,7 +20,7 @@ pytestmark = [pytest.mark.viz, pytest.mark.plotly]
 _dir = osp.join('sisl', 'io', 'siesta')
 
 
-@pytest.fixture(params=[True, False], ids=["method_splitting", "inplace_split"])
+@pytest.fixture(params=[True, False], ids=["inplace_split", "method_splitting"])
 def inplace_split(request):
     return request.param
 
@@ -59,7 +59,7 @@ class PdosPlotTester(PlotTester):
             "species": (len(self.species), self.species[0]),
             "atoms": (self.na, 1),
             "orbitals": (len(unique_orbs), unique_orbs[0]),
-            "spin": (self.n_spin, None)
+            "spin": (self.n_spin, None),
         }
 
         # Test all splittings
@@ -136,6 +136,22 @@ pdos_plots["siesta_PDOS_file"] = {
     "na": 5,
     "no": 72,
     "n_spin": 1,
+    "species": ('Sr', 'Ti', 'O')
+}
+
+pdos_plots["siesta_PDOS_file_polarized"] = {
+    "plot_file": osp.join(_dir, "SrTiO3_polarized.PDOS"),
+    "na": 5,
+    "no": 72,
+    "n_spin": 2,
+    "species": ('Sr', 'Ti', 'O')
+}
+
+pdos_plots["siesta_PDOS_file_noncollinear"] = {
+    "plot_file": osp.join(_dir, "SrTiO3_noncollinear.PDOS"),
+    "na": 5,
+    "no": 72,
+    "n_spin": 4,
     "species": ('Sr', 'Ti', 'O')
 }
 


### PR DESCRIPTION
There were two bugs:
- `pdos_plot.split_DOS(on="spin")` didn't work properly. The same bug caused `pdos_plot.split_DOS(...)` to cancel the ability to use the spin parameter in requests anymore.
- PDOS calculated from the hamiltonian was always interpreted to be spin polarized.

The first bug was not detected by the tests because there is no test that involves spin. Probably I should generate the `SrTiO3.PDOS` file from a spin polarized calculation. I will do it tomorrow, and then I will also need to change something in the `test_pdos.py` file.

The second bug sneaked through tests due to a magical compensation by the first bug.

Also, as @arsalan-akhtar reported this bug, he also noted (I already had it in mind for a long time) that it is usual to have "spin down DOS" with a negative value. I introduced a `scale` parameter to the request dict so that the user now can multiply the DOS by whatever number they want:

```python
pdos_plot.update_settings(requests=[
    {"spin": [0]},
    {"spin": [1], "scale": -1}
])
```

in the future there should probably be an "invert_spin_down" setting that automatically sets up the scale values, but for now this should be fine.

**PS**: I'm in the process of thinking about the things of your PR, but this bug was quite important and it took me a while to realize what was going on so I wanted to fix it while it was fresh in my mind.
