### PR TITLE
Reading net charges from outSileSiesta

### DIFF
--- a/sisl/__init__.py
+++ b/sisl/__init__.py
@@ -56,6 +56,9 @@ from .info import (
     cite
 )
 
+# import the common options used
+from ._common import *
+
 # Import the Selector
 from .selector import *
 

--- a/sisl/_common.py
+++ b/sisl/_common.py
@@ -1,0 +1,15 @@
+""" Global common files """
+from enum import Enum, Flag, auto, unique
+
+__all__ = ["Opt"]
+
+
+@unique
+class Opt(Flag):
+    """ Global option arguments used throughout sisl
+
+    These flags may be combined via bit-wise operations
+    """
+    NONE = auto()
+    ANY = auto()
+    ALL = auto()

--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -948,7 +948,7 @@ class outSileSiesta(SileSiesta):
                 charges are present or not, without needing to read them.
 
                 If `True`, returns True when charges are available or the results of the
-                self.step_either() call otherwise.
+                self.step_to() call otherwise.
 
             Returns
             ---------
@@ -956,7 +956,9 @@ class outSileSiesta(SileSiesta):
                 Returns the list of net charges that has found. If it hasn't found any, returns None. 
             """
             # Try to find the next charges block
-            found, i_found, line = self.step_either([f"{which} Atomic Populations", f"{which} Net Atomic Populations", *stop_strings])
+            found, line, i_found = self.step_to([f"{which} Atomic Populations",
+                                                 f"{which} Net Atomic Populations",
+                                                 *stop_strings], ret_index=True)
 
             # We didn't find a charges block
             if not found or i_found > 1:

--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -881,7 +881,7 @@ class outSileSiesta(SileSiesta):
 
     @sile_fh_open()
     def read_charge(self, name, iscf=Opt.ANY, imd=Opt.ANY, key_scf="scf", as_dataframe=False):
-        r"""Read charges printed in the output
+        r"""Read charges calculated in SCF loop or MD loop (or both)
 
         Siesta enables many different modes of writing out charges.
 
@@ -905,13 +905,13 @@ class outSileSiesta(SileSiesta):
 
         Notes
         -----
-        Users may experience ``None`` returns where data is expected. Generally
-        this occurs if one force requests a specific SCF index or MD index
-        and the output file does not fulfil *A*, *B* or *C* cases in the
-        above table.
-        Generally.
-        Pass `Opt.ANY` as arguments to `imd` for cases *B* and *D*.
-        Pass `Opt.ANY` as arguments to `iscf` for cases *A* and *D*.
+        Errors will be raised if one requests information not present. I.e.
+        passing an integer or `Opt.ALL` for `iscf` will raise an error if
+        the SCF charges are not present. For `Opt.ANY` it will return
+        the most information, effectively SCF will be returned if present.
+
+        Currently Mulliken is not implemented, any help in reading this would be
+        very welcome.
 
         Parameters
         ----------
@@ -921,10 +921,14 @@ class outSileSiesta(SileSiesta):
             index (0-based) of the scf iteration you want the charges for.
             If the enum specifier `Opt.ANY` or `Opt.ALL` are used, then
             the returned quantities depend on what is present.
+            If ``None/Opt.NONE`` it will not return any SCF charges.
+            If both `imd` and `iscf` are ``None`` then only the final charges will be returned.
         imd: int or Opt, optional
             index (0-based) of the md step you want the charges for.
             If the enum specifier `Opt.ANY` or `Opt.ALL` are used, then
             the returned quantities depend on what is present.
+            If ``None/Opt.NONE`` it will not return any MD charges.
+            If both `imd` and `iscf` are ``None`` then only the final charges will be returned.
         key_scf : str, optional
             the key lookup for the scf iterations (a ":" will automatically be appended)
         as_dataframe: boolean, optional
@@ -936,10 +940,9 @@ class outSileSiesta(SileSiesta):
             if a specific MD+SCF index is requested (or special cases where output is
             not complete)
         list of numpy.ndarray
-            if one of `iscf` or `imd` is None and the output contains the other.
+            if one both `iscf` or `imd` is different from ``None/Opt.NONE``.
         pandas.DataFrame
-            if `as_dataframe` is requested. Here the returned data frames may be
-            empty; see Notes above. The dataframe will have multi-indices if multiple
+            if `as_dataframe` is requested. The dataframe will have multi-indices if multiple
             SCF or MD steps are requested.
         """
         if not hasattr(self, 'fh'):

--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -975,7 +975,8 @@ class outSileSiesta(SileSiesta):
 
             # first line is the header
             header = (self.readline()
-                      .replace("Qatom", "q") # Qatom in 4.1, dQatom in master
+                      .replace("dQatom", "dq") # dQatom in master
+                      .replace(" Qatom", " dq") # Qatom in 4.1
                       .replace("Atom pop", "e") # not found in 4.1
                       .split())[2:-1]
 
@@ -1002,8 +1003,7 @@ class outSileSiesta(SileSiesta):
 
             # the precision is limited, so no need for double precision
             return pd.DataFrame(atom_charges, columns=header, dtype=np.float32,
-                                index=pd.RangeIndex(stop=len(atom_charges),
-                                                    name="atom", dtype=np.int32))
+                                index=pd.RangeIndex(stop=len(atom_charges), name="atom"))
 
         # define helper function for reading voronoi+hirshfeld charges
         def _mulliken_charges():
@@ -1156,11 +1156,11 @@ class outSileSiesta(SileSiesta):
             # regardless of user requests. This is an overhead... But probably not that big of a problem.
             if FOUND_SCF:
                 md_scf_charge = pd.concat([pd.concat(iscf,
-                                                     keys=pd.RangeIndex(1, len(iscf)+1, dtype=np.int32, name="iscf"))
+                                                     keys=pd.RangeIndex(1, len(iscf)+1, name="iscf"))
                                            for iscf in md_scf_charge],
-                                          keys=pd.RangeIndex(1, len(md_scf_charge)+1, dtype=np.int32, name="imd"))
+                                          keys=pd.RangeIndex(1, len(md_scf_charge)+1, name="imd"))
             if FOUND_MD:
-                md_charge = pd.concat(md_charge, keys=pd.RangeIndex(1, len(md_charge)+1, dtype=np.int32, name="imd"))
+                md_charge = pd.concat(md_charge, keys=pd.RangeIndex(1, len(md_charge)+1, name="imd"))
         else:
             if FOUND_SCF:
                 nan_array = _a.emptyf(md_scf_charge[0][0].shape)

--- a/sisl/io/siesta/tests/test_out_charges.py
+++ b/sisl/io/siesta/tests/test_out_charges.py
@@ -1,0 +1,135 @@
+from itertools import product
+import sys
+import pytest
+import os.path as osp
+import sisl
+from sisl.io.siesta.out import *
+import numpy as np
+
+
+pytestmark = [pytest.mark.io, pytest.mark.siesta, pytest.mark.only]
+_dir = osp.join('sisl', 'io', 'siesta', 'outs')
+
+# tests here tests charge reads for output
+#  voronoi + hirshfeld: test_vh_*
+#  voronoi: test_v_*
+#  hirshfeld: test_h_*
+#  mulliken: test_m_*
+
+Opt = sisl.Opt
+SileError = sisl.SileError
+
+
+def with_pandas():
+    try:
+        import pandas
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.parametrize('name', ["voronoi", "Hirshfeld"])
+def test_vh_empty_file(name, sisl_files):
+    f = sisl_files(_dir, "voronoi_hirshfeld_4.1_none.out")
+    out = outSileSiesta(f)
+
+    with pytest.raises(SileError, match="any charges"):
+        out.read_charge(name)
+
+    with pytest.raises(SileError, match="any charges"):
+        out.read_charge(name, iscf=-1, imd=Opt.NONE)
+
+    with pytest.raises(SileError, match="any charges"):
+        out.read_charge(name, iscf=-1, imd=-1)
+
+    with pytest.raises(SileError, match="any charges"):
+        out.read_charge(name, iscf=None, imd=-1)
+
+
+@pytest.mark.parametrize('name', ["voronoi", "Hirshfeld"])
+def test_vh_final(name, sisl_files):
+    f = sisl_files(_dir, "voronoi_hirshfeld.out")
+    out = outSileSiesta(f)
+
+    q = out.read_charge(name, iscf=None, imd=None)
+    assert q.size > 0
+    assert not all(v is None for v in q)
+
+    q0 = out.read_charge(name, iscf=Opt.NONE, imd=Opt.NONE)
+    assert np.allclose(q, q0)
+
+    with pytest.raises(SileError, match="MD/SCF charges"):
+        out.read_charge(name, iscf=-1, imd=Opt.NONE)
+
+    with pytest.raises(SileError, match="MD/SCF charges"):
+        out.read_charge(name, iscf=-1, imd=-1)
+
+    with pytest.raises(SileError, match="MD/SCF charges"):
+        out.read_charge(name, iscf=None, imd=-1)
+
+    if with_pandas():
+        df = out.read_charge(name, as_dataframe=True)
+        assert np.allclose(df.values, q)
+
+
+@pytest.mark.parametrize('fname', ["md", "4.1_pol_md", "nc_md"])
+@pytest.mark.parametrize('name', ["voronoi", "Hirshfeld"])
+def test_vh_md(name, fname, sisl_files):
+    #  voronoi_hirshfeld_md.out
+    f = sisl_files(_dir, f"voronoi_hirshfeld_{fname}.out")
+    out = outSileSiesta(f)
+
+    q = out.read_charge(name)
+
+    q0 = out.read_charge(name, imd=Opt.ALL)
+    assert np.allclose(q, q0)
+
+    q0 = out.read_charge(name, imd=-1)
+    assert np.allclose(q[-1], q0)
+
+    with pytest.raises(SileError, match="final charges"):
+        out.read_charge(name, iscf=None, imd=None)
+
+    for iscf in [-1, Opt.ALL]:
+        # space to not match MD/SCF charges
+        with pytest.raises(SileError, match=" SCF charges"):
+            out.read_charge(name, iscf=-1)
+
+    if with_pandas():
+        df = out.read_charge(name, imd=Opt.ALL, as_dataframe=True)
+        assert np.allclose(q.ravel(), df.values.ravel())
+
+        df = out.read_charge(name, imd=-1, as_dataframe=True)
+        assert np.allclose(q[-1].ravel(), df.values.ravel())
+
+
+@pytest.mark.parametrize('fname', ["md_scf", "nc_md_scf", "pol_md_scf", "soc_md_scf"])
+@pytest.mark.parametrize('name', ["voronoi", "Hirshfeld"])
+def test_vh_md_scf(name, fname, sisl_files):
+    f = sisl_files(_dir, f"voronoi_hirshfeld_{fname}.out")
+    out = outSileSiesta(f)
+
+    q = out.read_charge(name)
+
+    with pytest.raises(SileError, match="final charges"):
+        out.read_charge(name, iscf=None, imd=Opt.NONE)
+
+    q0 = out.read_charge(name, iscf=-1, imd=-1)
+    assert np.allclose(q0, q[-1][-1])
+
+    q0 = out.read_charge(name, iscf=Opt.ANY, imd=-1)
+    assert np.allclose(q0, q[-1])
+
+    q0 = out.read_charge(name, iscf=-1, imd=Opt.ALL)
+    assert np.allclose(q0, np.stack((qq[-1] for qq in q)))
+
+    # iscf is
+    q0 = out.read_charge(name, iscf=1, imd=Opt.ALL)
+    assert np.allclose(q0, np.stack((qq[1] for qq in q)))
+
+    q0 = out.read_charge(name, iscf=None, imd=-1)
+    assert np.allclose(q0, q[-1][-1])
+
+    if with_pandas():
+        df = out.read_charge(name, iscf=-1, imd=-1, as_dataframe=True)
+        assert np.allclose(df.values, q[-1][-1])


### PR DESCRIPTION
Instead of generating Voronoi charges as in my question 2 days ago I decided to let SIESTA do it. I then implemented a method to parse the charges from siesta's output. Is it useful enough to go in?

If you agree this could be useful, we can discuss the API. Right now it doesn't let the user decide which charges they want, it will return different things depending on how often charges have been written. You can find [in this zip](https://github.com/zerothi/sisl/files/6001925/different_outputs.zip) different output files of a 3 step MD of graphene, and following you can see how the method behaves for the different situations.



### Charges at the end of the calculation


```python
sisl.get_sile("charges_final.out").read_net_charges("voronoi")
```




    array([-0.00598,  0.00596])




```python
sisl.get_sile("charges_final.out").read_net_charges("hirshfeld")
```




    array([-0.e+00, -2.e-05])



### Charges at every MD step


```python
sisl.get_sile("charges_MD_step.out").read_net_charges("voronoi")
```




    [array([[-0.02935,  0.02934]]),
     array([[-0.01198,  0.01196]]),
     array([[-0.00598,  0.00596]])]




```python
sisl.get_sile("charges_MD_step.out").read_net_charges("hirshfeld")
```




    [array([[-7.e-05,  5.e-05]]),
     array([[-1.e-05, -1.e-05]]),
     array([[-0.e+00, -2.e-05]])]



### Charges at every SCF step


```python
sisl.get_sile("charges_scf_step.out").read_net_charges("voronoi")
```




    [array([[-0.03033,  0.03032],
            [-0.02957,  0.02955],
            [-0.02954,  0.02952],
            [-0.02939,  0.02938],
            [-0.02937,  0.02936],
            [-0.02935,  0.02934],
            [-0.02935,  0.02934],
            [-0.02935,  0.02934]]), array([[-0.01225,  0.01223],
            [-0.01199,  0.01197],
            [-0.01198,  0.01196],
            [-0.01197,  0.01195],
            [-0.01198,  0.01196],
            [-0.01198,  0.01196]]), array([[-0.00581,  0.00579],
            [-0.00601,  0.00598],
            [-0.00599,  0.00597],
            [-0.00598,  0.00595],
            [-0.00598,  0.00596],
            [-0.00598,  0.00596]])]




```python
sisl.get_sile("charges_scf_step.out").read_net_charges("hirshfeld")
```




    [array([[-9.e-05,  8.e-05],
            [-5.e-05,  3.e-05],
            [-6.e-05,  5.e-05],
            [-8.e-05,  6.e-05],
            [-7.e-05,  6.e-05],
            [-7.e-05,  5.e-05],
            [-7.e-05,  5.e-05],
            [-7.e-05,  5.e-05]]), array([[-6.e-05,  4.e-05],
            [-2.e-05,  0.e+00],
            [-2.e-05, -0.e+00],
            [-1.e-05, -1.e-05],
            [-1.e-05, -1.e-05],
            [-1.e-05, -1.e-05]]), array([[-7.e-05,  4.e-05],
            [-2.e-05, -1.e-05],
            [-1.e-05, -2.e-05],
            [ 0.e+00, -3.e-05],
            [-0.e+00, -2.e-05],
            [-0.e+00, -2.e-05]])]

Cheers!