### PR TITLE
maint: Using dispatchers for plot handlers

### DIFF
--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -4621,6 +4621,7 @@ class GeometryToAseDispatcher(GeometryToDispatcher):
 
 Geometry.to.register("ase", GeometryToAseDispatcher)
 
+
 class GeometryTopymatgenDispatcher(GeometryToDispatcher):
     def dispatch(self, *args, **kwargs):
         from pymatgen.core import Lattice, Structure, Molecule
@@ -4637,7 +4638,7 @@ class GeometryTopymatgenDispatcher(GeometryToDispatcher):
         PT = PeriodicTable()
         xyz = geom.xyz
         species = [PT.Z_label(Z) for Z in geom.atoms.Z]
-        
+
         if all(self.nsc == 1):
             # we define a molecule
             return Molecule(species, xyz, **kwargs)

--- a/sisl/viz/_plotables.py
+++ b/sisl/viz/_plotables.py
@@ -1,264 +1,90 @@
 """
 This file provides tools to handle plotability of objects
 """
-
-from copy import copy
-from functools import wraps
+from sisl._dispatcher import ClassDispatcher, AbstractDispatch, ObjectDispatcher
 
 __all__ = ["register_plotable"]
 
 
-class PlotEngine:
-    """
-    Stores and takes care of calling all methods of a plotting engine.
-    """
+class ClassPlotHandler(ClassDispatcher):
+    """Handles all plotting possibilities for a class"""
 
-    def __init__(self, name, handler, default=None, methods={}):
-
-        self._raw_methods = {}
-        self._handler = handler
-
-        for name, method in methods.items():
-            self._add(name, method)
-
-        self._name = name
-        self._default = default
-
-    def copy(self, **kwargs):
-        return self.__class__(self._name, kwargs.get("handler", self._handler),
-            default=self._default, methods=self._raw_methods)
-
-    def __dir__(self):
-        return list(self._raw_methods)
-
-    def _add(self, name, function, default=False):
-        """
-        Makes a new function available to this plotting engine.
-
-        Parameters
-        -----------
-        name: str
-            the name of the plotting method. 
-
-            This will be the name of the attribute where the function is stored.
-        function: function
-            the plotting method.
-        default: bool, optional
-            whether this method is the default for the engine.
-
-            The default method can be called by simply calling the engine.        
-        """
-        if default:
-            self._default = name
-
-        self._raw_methods[name] = function
-
-    def _get_wrapped_function(self, name):
-        function = self._raw_methods[name]
-
-        # This is the function that really does the plotting and goes
-        # into the engine
-        @wraps(function)
-        def real_function(*args, **kwargs):
-            return function(self._handler._obj, *args, **kwargs)
-
-        return real_function
-
-    def set_handler(self, handler):
-        self._handler = handler
-
-        return self
-
-    def __getattr__(self, key):
-        return self._get_wrapped_function(key)
-
-    def get(self, method=None, otherwise='raise'):
-        """
-        Returns a method of the engine.
-
-        Parameters
-        -----------
-        method: str, optional
-            the name of the method that we want.
-
-            If not provided, the default will be returned
-        otherwise: any, optional
-            what to return in case that the method is not found.
-
-            If you want the method to raise an exception, set this to 'raise'.
-        """
-
-        if method is None:
-            if self._default is None:
-                raise ValueError('There is no default plotting method registered in this plotting engine')
-            method = self._default
-
-        if otherwise == 'raise':
-            return getattr(self, method)
-        else:
-            return getattr(self, method, otherwise)
-
-    def __call__(self, method=None, **kwargs):
-        """
-        Handles a call to the engine, which will trigger calling plot methods.
-
-        Note that you can also call the methods directly, since they are stored
-        in attributes.
-
-        Parameters
-        -----------
-        method: str, optional
-            the method that we want to execute.
-
-            If not provided, the default will be executed.
-        **kwargs:
-            all the keyword arguments that will go into executing the method
-        """
-
-        return self.get(method)(**kwargs)
+    def __init__(self, *args, **kwargs):
+        if not "instance_dispatcher" in kwargs:
+            kwargs["instance_dispatcher"] = ObjectPlotHandler
+        super().__init__(*args, **kwargs)
 
 
-class PlotHandler:
-    """
-    Handles all plotting possibilities for a class.
+class ObjectPlotHandler(ObjectDispatcher):
+    """Handles all plotting possibilities for an object."""
 
-    It supports handling multiple plotting engines while keeping autocompletion
-    and help messages meaningful to make the plotting experience smooth.
+    def __call__(self, *args, **kwargs):
+        """If the plot handler is called, we will run the default plotting function"""
+        return getattr(self, self._default)(*args, **kwargs)
+
+
+class PlotDispatch(AbstractDispatch):
+    """Wraps a plotting function to be used in the dispatchers framework"""
+
+    def dispatch(self, *args, **kwargs):
+        """Runs the plotting function by passing the object instance to it."""
+        return self._plot(self._obj, *args, **kwargs)
+
+
+def create_plot_dispatch(function, name):
+    """From a function, creates a dispatch class that will be used by the dispatchers.
 
     Parameters
-    ----------
-    default_engine: str, optional
-        the plotting engine that should be used as the default.
+    -----------
+    function: function
+        function that will be executed when the dispatch is called. It will receive
+        the object from the dispatch.
+    name: str
+        the class name
+    """
+    return type(
+        f"Plot{name.capitalize()}Dispatch",
+        (PlotDispatch, ),
+        {"_plot": staticmethod(function), "__doc__": function.__doc__}
+    )
 
-        With this, the plotting methods of the engine get exposed also as
-        attributes of the plot handler. Calling the plot handler without
-        specifying an engine will call the default engine.
 
-    Usage
-    --------
-    class A:
+def _get_plotting_func(PlotClass, setting_key):
+    """
+    Generates a plotting function for an object.
 
-        plot = PlotHandler()
+    Parameters
+    -----------
+    PlotClass: child of Plot
+        the plot class that you want to use to plot the object.
+    setting_key: str
+        the setting where the plotable should go
 
-    or
+    Returns
+    -----------
+    function
+        a function that accepts the object as first argument and then generates the plot.
 
-    class A:
-        pass
-
-    A.plot = PlotHandler()
-
-    NOTE: It only works if it is set as an attribute of the class!
-
-    You can not do:
-
-    A().plot = PlotHandler()
-
+        It sends the object to the appropiate setting key. The rest works exactly the same as
+        calling the plot class. I.e. you can provide all the extra settings/keywords that you want.  
     """
 
-    def __init__(self, obj=None, engines=None, default_engine='plotly'):
-        self._obj = obj
+    def _plot(obj, *args, **kwargs):
+        return PlotClass(*args, **{setting_key: obj, **kwargs})
 
-        self._engines = engines or {}
-        self._default_engine = default_engine
+    _plot.__doc__ = f"""Builds a {PlotClass.__name__} by setting the value of "{setting_key}" to the current object.
 
-    def __dir__(self):
-        return ["register", *list(self._engines), *dir(self._engines[self._default_engine])]
-
-    def register(self, function, name=None, engine=None, default=False):
-        """
-        Registers plotting functions to the plot handler.
-
-        Parameters
-        -----------
-        function: function
-            the plotting function that we want to register.
-        name: str, optional
-            the name that should be used to identify this plotting method through
-            the plot handler and the plot engines.
-
-            If not provided, the name of the function will be used.
-        engine: str, optional
-            the engine where we should register this plotting function. 
-
-            If it doesn't exist yet, a new plotting engine is created.
-
-            If not provided, the default engine is used.
-        default: boolean, optional
-            whether this should be set as the default plotting method
-            for the engine.
-
-            The default method can be accessed by just calling the engine
-            with no "method" argument.
-            The default method of the default engine can be accessed by calling the
-            plot handler with no "engine" and "method" arguments.
-        """
-        if name is None:
-            name = function.__name__
-
-        if engine is None:
-            engine = self._default_engine
-
-        # Initialize a new plot engine, if it isn't already present
-        if engine not in self._engines:
-            self._engines[engine] = PlotEngine(engine, handler=self)
-
-        engine = self._engines[engine]
-
-        engine._add(name, function, default=default)
-
-    def __getattr__(self, key):
-
-        if key in self._engines:
-            return self._engines[key]
-
-        return getattr(self._engines[self._default_engine], key)
-
-    def __get__(self, instance, owner):
-        """
-        Makes the plot handler aware of what is the instance that it is handling
-        plots for.
-        """
-        if instance is not None:
-
-            new_handler = self.__class__(obj=instance, default_engine=self._default_engine)
-
-            for name, engine in self._engines.items():
-                new_handler._engines[name] = engine.copy(handler=new_handler)
-
-            return new_handler
-
-        return self
-
-    def __call__(self, engine=None, method=None, **kwargs):
-        """
-        Handles a call to the engine, which will trigger calling plot methods.
-
-        Note that you can also call the methods directly, since they are stored
-        in attributes in the plot handler (for the default engine) or in the engines,
-        which are attributes of the plot handler.
-
-        Parameters
-        -----------
-        engine: str
-            the engine where we should look for methods.
-
-            If not provided the default engine will be used
-        method: str, optional
-            the method that we want to execute.
-
-            If not provided, the default will be executed.
-        **kwargs:
-            all the keyword arguments that will go into executing the method
-        """
-
-        if engine is None:
-            engine = self._default_engine
-
-        return self._engines[engine](method=method, **kwargs)
+    Apart from this specific parameter ,it accepts the same arguments as {PlotClass.__name__}.
+    
+    Documentation for {PlotClass.__name__}
+    -------------
+    
+    {PlotClass.__doc__}
+    """
+    return _plot
 
 
-def register_plotable(plotable, plotting_func, name=None,
-                      engine='plotly', default=False, plot_handler_attr='plot'):
+def register_plotable(plotable, PlotClass=None, setting_key=None, plotting_func=None, name=None, default=False, plot_handler_attr='plot', engine=None, **kwargs):
     """
     Makes the sisl.viz module aware of which sisl objects can be plotted and how to do it.
 
@@ -270,6 +96,11 @@ def register_plotable(plotable, plotting_func, name=None,
     plotable: any
         any class or object that you want to make plotable. Note that, if it's an object, the plotting
         capabilities will be attributed to all instances of the object's class.
+    PlotClass: child of sisl.Plot, optional
+        The class of the Plot that we want this object to use.
+    setting_key: str, optional
+        The key of the setting where the object must go. This works together with
+        the PlotClass parameter.
     plotting_func: function
         the function that takes care of the plotting.
         It should accept (self, *args, **kwargs) and return a plot object.
@@ -281,25 +112,34 @@ def register_plotable(plotable, plotting_func, name=None,
         If not provided, the name of the function will be used
     default: boolean, optional 
         whether this way of plotting the class should be the default one.
-    engine: str, optional
-        the engine that the function uses.
     plot_handler_attr: str, optional
         the attribute where the plot handler is or should be located in the class that you want to register.
     """
+
+    # If no plotting function is provided, we will try to create one by using the PlotClass
+    # and the setting_key that have been provided
+    if plotting_func is None:
+        plotting_func = _get_plotting_func(PlotClass, setting_key)
+
+    if name is None:
+        # We will take the name of the plot class as the name
+        name = PlotClass.suffix()
+
     # Check if we already have a plot_handler
-    plot_handler = getattr(plotable, plot_handler_attr, None)
+    plot_handler = plotable.__dict__.get(plot_handler_attr, None)
 
     # If it's the first time that the class is being registered,
     # let's give the class a plot handler
-    if not isinstance(plot_handler, PlotHandler):
+    if not isinstance(plot_handler, ClassPlotHandler):
 
         # If the user is passing an instance, we get the class
         if not isinstance(plotable, type):
             plotable = type(plotable)
 
-        setattr(plotable, plot_handler_attr, PlotHandler())
+        setattr(plotable, plot_handler_attr, ClassPlotHandler(plot_handler_attr))
 
         plot_handler = getattr(plotable, plot_handler_attr)
 
+    plot_dispatch = create_plot_dispatch(plotting_func, name)
     # Register the function in the plot_handler
-    plot_handler.register(plotting_func, name=name, engine=engine, default=default)
+    plot_handler.register(name, plot_dispatch, default=default, **kwargs)

--- a/sisl/viz/plotly/_plotables.py
+++ b/sisl/viz/plotly/_plotables.py
@@ -1,133 +1,24 @@
 """
-This file defines all the siles that are plotable.
+This file defines all the classes that are plotable.
 
-It does so by patching the classes accordingly
-
-In the future, sisl objects will probably be 'plotable' too
+It does so by patching them accordingly
 """
-from functools import partial
-from types import MethodType
-
-import numpy as np
-
+import sisl
 import sisl.io.siesta as siesta
 import sisl.io.tbtrans as tbtrans
 from sisl.io.sile import get_siles, BaseSile
 
-import sisl
 from .plots import *
 from .plot import Plot
 from .plotutils import get_plot_classes
 
 from .._plotables import register_plotable
 
-__all__= ["register_plotly_plotable"]
-# -----------------------------------------------------
-#   Let's define the functions that will help us here
-# -----------------------------------------------------
-
-
-def _get_plotting_func(PlotClass, setting_key):
-    """
-    Generates a plotting function for an object.
-
-    Parameters
-    -----------
-    PlotClass: child of Plot
-        the plot class that you want to use to plot the object.
-    setting_key: str
-        the setting where the plotable should go
-
-    Returns
-    -----------
-    function
-        a function that accepts the object as first argument and then generates the plot.
-
-        It sends the object to the appropiate setting key. The rest works exactly the same as
-        calling the plot class. I.e. you can provide all the extra settings/keywords that you want.  
-    """
-
-    def _plot(self, *args, **kwargs):
-
-        return PlotClass(*args, **{setting_key: self, **kwargs})
-
-    _plot.__doc__ = f"""Builds a {PlotClass.__name__} by setting the value of "{setting_key}" to the current object.
-
-    Apart from this specific parameter ,it accepts the same arguments as {PlotClass.__name__}.
-    
-    Documentation for {PlotClass.__name__}
-    -------------
-    
-    {PlotClass.__doc__}
-    """
-    return _plot
-
-
-def register_plotly_plotable(plotable, PlotClass=None, setting_key=None, plotting_func=None,
-    name=None, default=False, plot_handler_attr='plot'):
-    """
-    Makes the sisl.viz module aware of which sisl objects have a plotly representation available.
-
-    Basically, this handles generating the plotting functions from a PlotClass to make the process
-    easier and create a consistent behavior that other parts of the framework can rely on (i.e. the GUI).
-
-    Once a plotting function is generated, the rest is handled by `sisl.viz.register_plotable`.
-
-    Parameters
-    ------------
-    plotable: any
-        any class or object that you want to make plotable. Note that, if it's an object, the plotting
-        capabilities will be attributed ONLY to that object, not the whole class. You can change this
-        behavior by setting the `all_instances` parameter to True.
-    PlotClass: child of sisl.Plot, optional
-        The class of the Plot that we want this object to use.
-    setting_key: str, optional
-        The key of the setting where the object must go. This works together with
-        the PlotClass parameter.
-    name: str, optional
-        name that will be used to identify the particular plot function that is being registered.
-
-        E.g.: If name is "nicely", the plotting function will be registered under "obj.plot_nicely()"
-
-        IF THE PLOT CLASS YOU ARE USING IS NOT ALREADY REGISTERED FOR THE PLOTABLE, PLEASE LET THE NAME
-        BE HANDLED AUTOMATICALLY UNLESS YOU HAVE A GOOD REASON NOT TO DO SO. This will help keeping consistency
-        across the different objects as the name is determined by the plot class that is being used.
-    plotting_func: function, optional
-        if the PlotClass - setting_key pair does not satisfy your needs, you can pass a more complex function here
-        instead.
-        It should accept (self, *args, **kwargs) and return a plot object.
-    default: boolean, optional 
-        whether this way of plotting the class should be the default one.
-    plot_handler_attr: str, optional
-        the attribute where the plot handler is or should be located in the class that you want to register.
-    """
-
-    # If no plotting function is provided, we will try to create one by using the PlotClass
-    # and the setting_key that have been provided
-    if plotting_func is None:
-        plotting_func = _get_plotting_func(PlotClass, setting_key)
-
-    if name is None:
-        # We will take the name of the plot class as the name
-        name = PlotClass.suffix()
-
-    register_plotable(
-        plotable, plotting_func, name=name, engine='plotly', default=default, plot_handler_attr=plot_handler_attr
-    )
-
-    # And to help keep track of the plotability we tell to the plot class that
-    # it can plot this object, and which setting to use.
-    # if PlotClass is not None:
-    #     if not hasattr(PlotClass, '_registered_plotables'):
-    #         PlotClass._registered_plotables = {}
-
-    #     PlotClass._registered_plotables[plotable] = setting_key
-
 # -----------------------------------------------------
 #               Register plotable siles
 # -----------------------------------------------------
 
-register = register_plotly_plotable
+register = register_plotable
 
 for GridSile in get_siles(attrs=["read_grid"]):
     register(GridSile, GridPlot, 'grid_file', default=True)
@@ -143,7 +34,7 @@ for HSile in get_siles(attrs=["read_hamiltonian"]):
     register(HSile, FatbandsPlot, "H")
 
 for cls in get_plot_classes():
-    register(siesta.fdfSileSiesta, cls, "root_fdf")
+    register(siesta.fdfSileSiesta, cls, "root_fdf", overwrite=True)
 
 register(siesta.outSileSiesta, ForcesPlot, 'out_file', default=True)
 


### PR DESCRIPTION
This addresses https://github.com/zerothi/sisl/issues/301 to use dispatchers for plot handlers in the viz module.

Also, since different plot backends will be introduced in https://github.com/zerothi/sisl/pull/312 and the backend will simply be another setting, there's no need for `PlotEngine` anymore.

Overall, handling of plotables is much cleaner now.