### PR TITLE
More intuitive behavior of Geometry.swapaxes

### DIFF
--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -2181,14 +2181,18 @@ class Geometry(SuperCellChild):
            the xyz (Cartesian) axis are swapped.
            Both may be in `swap`.
         """
-        xyz = np.copy(self.xyz)
-        if 'xyz' in swap:
-            xyz[:, axis_a] = self.xyz[:, axis_b]
-            xyz[:, axis_b] = self.xyz[:, axis_a]
         if 'cell' in swap:
             sc = self.sc.swapaxes(axis_a, axis_b)
         else:
             sc = self.sc.copy()
+
+        xyz = np.copy(self.xyz)
+        if 'xyz' in swap:
+            xyz[:, axis_a] = self.xyz[:, axis_b]
+            xyz[:, axis_b] = self.xyz[:, axis_a]
+            sc.origo[[axis_a, axis_b]] = sc.origo[[axis_b, axis_a]]
+            sc.cell[:, [axis_a, axis_b]] = sc.cell[:, [axis_b, axis_a]]
+
         return self.__class__(xyz, atoms=self.atoms.copy(), sc=sc)
 
     def center(self, atoms=None, what='xyz'):


### PR DESCRIPTION
Calling `.swapaxes(..., swap='xyz')` on geometry creates unintuitive results, because only the Cartesian coordinates of atomic positions are being swapped. 

Example
``` python 
import sisl
geom = sisl.geom.zgnr(10).swap_axes(0, 1, swap='xyz')
geom.write(....)
```

With this change the Cartesian coordinates of the lattice vectors and the cell origin are being swapped as well. 