### PR TITLE
bug: origo not taken into account for plots

### DIFF
--- a/sisl/viz/plotly/plots/geometry.py
+++ b/sisl/viz/plotly/plots/geometry.py
@@ -442,7 +442,7 @@ class GeometryPlot(Plot):
         if unique:
             points = np.unique(points, axis=0)
 
-        return np.array([xyz(coeffs) for coeffs in points])
+        return self.geometry.origo + np.array([xyz(coeffs) for coeffs in points])
 
     def _get_atoms_bonds(self, bonds, atom, geom=None, sanitize_atom=True):
         """
@@ -862,12 +862,13 @@ class GeometryPlot(Plot):
             cell = self.geometry.cell
 
         cell_xy = self._projected_2Dcoords(xyz=cell, xaxis=xaxis, yaxis=yaxis).T
+        origo_xy = self._projected_2Dcoords(xyz=self.geometry.origo, xaxis=xaxis, yaxis=yaxis).T
 
         return [{
             'type': 'scatter',
             'mode': 'markers+lines',
-            'x': [0, vec[0]],
-            'y': [0, vec[1]],
+            'x': np.array([0, vec[0]]) + origo_xy[0],
+            'y': np.array([0, vec[1]]) + origo_xy[1], 
             'name': f'Axis {i}'
         } for i, vec in enumerate(cell_xy)]
 
@@ -1055,9 +1056,9 @@ class GeometryPlot(Plot):
 
         return [{
             'type': 'scatter3d',
-            'x': [0, vec[0]],
-            'y': [0, vec[1]],
-            'z': [0, vec[2]],
+            'x': np.array([0, vec[0]]) + self.geometry.origo[0],
+            'y': np.array([0, vec[1]]) + self.geometry.origo[1],
+            'z': np.array([0, vec[2]]) + self.geometry.origo[2],
             'name': f'Axis {i}'
         } for i, vec in enumerate(cell)]
 

--- a/sisl/viz/plotly/plots/grid.py
+++ b/sisl/viz/plotly/plots/grid.py
@@ -555,7 +555,7 @@ class GridPlot(Plot):
     def _get_offset(self, ax, offset, x_range, y_range, z_range):
 
         ax_range = [x_range, y_range, z_range][ax]
-        grid_offset = _a.asarrayd(offset) + self.offsets["vacuum"] + self.offsets["cell_transform"]
+        grid_offset = self.grid.origo[ax] + _a.asarrayd(offset) + self.offsets["vacuum"] + self.offsets["cell_transform"]
 
         if ax_range is not None:
             offset = ax_range[0]


### PR DESCRIPTION
This bug was also discovered by @tfrederiksen here: https://discord.com/channels/742636379871379577/845235607461691402/845284162994176081

Basically the `origo` of the supercell was not taken into account for plotting.

With this solution, the axes of the cell are plotted from `origo` instead of (0,0,0) and the coordinates of the atoms are plotted as they are. Grid plots have also been modified so that their axes ranges take origo into account.

It has been suggested that `origo` should be the (0,0,0) point. In that case, atoms coordinates should be displaced (coords -= `origo`), and the modification to axes display and grid plots is not needed. Let me know what you prefer.

Here is the display of a grid that Thomas sent me, with this coordinates and origo:
```python
print(grid.geometry.xyz)
print(grid.origo)
```
```
[[ 0.          0.          0.        ]
 [ 0.          0.          2.56000131]
 [ 0.          0.          5.12000261]
 [ 0.          0.          7.68000339]
 [ 0.          0.         10.2400047 ]
 [ 0.          0.         12.800006  ]
 [ 0.          0.         14.70770427]
 [ 0.          0.         15.94428144]
 [ 0.          0.         19.36000892]
 [ 0.          0.         21.92001023]
 [ 0.          0.         24.48001154]
 [ 0.          0.         27.04001284]
 [ 0.          0.         29.60001415]
 [ 0.          0.         32.16001493]]
[-5.00000215 -5.00000215 -5.00000215]
```
Before fixing the bug:
![origo_not_implemented](https://user-images.githubusercontent.com/42074085/119965492-9e882480-bfaa-11eb-9107-4b6b32a3668b.png)

And after fixing the bug (in the above mentioned way):
![origo_implemented](https://user-images.githubusercontent.com/42074085/119965518-a647c900-bfaa-11eb-8d53-5193a0dc0694.png)

