### PR TITLE
Generalized inner product for ElectronState

### DIFF
--- a/sisl/physics/electron.py
+++ b/sisl/physics/electron.py
@@ -1615,7 +1615,7 @@ class _electron_State:
         S = self.Sk()
         return conj(self.state) * S.dot(self.state.T).T
 
-    def inner(self, right=None, matrix=None, diagonal=True):
+    def inner(self, right=None, matrix=None, diag=True):
         r""" Return the inner product by :math:`\mathbf M_{ij} = \langle\psi_i| \mathbf M |\psi'_j\rangle`
 
         Parameters
@@ -1625,7 +1625,7 @@ class _electron_State:
            product with itself. This object will always be the left :math:`\langle\psi_i|`.
         matrix : array_like, optional
            a matrix that expresses the operator `M`. Defaults to the overlap matrix `S`.
-        diagonal : bool, optional
+        diag : bool, optional
            only return the diagonal matrix :math:`\mathbf M_{ii}`.
 
         Raises
@@ -1645,7 +1645,7 @@ class _electron_State:
 
         # TODO, perhaps check that it is correct... and fix multiple transposes
         if right is None:
-            if diagonal:
+            if diag:
                 return einsum('ij,ji->i', conj(self.state), M.dot(self.state.T))
             return dot(conj(self.state), M.dot(self.state.T))
 
@@ -1655,7 +1655,7 @@ class _electron_State:
 
             # Same as State.inner
             # In the current implementation we require no overlap matrix!
-            if diagonal:
+            if diag:
                 if self.shape[0] != right.shape[0]:
                     return np.diag(dot(conj(self.state), M.dot(right.state.T)))
                 return einsum('ij,ji->i', conj(self.state), M.dot(right.state.T))

--- a/sisl/physics/electron.py
+++ b/sisl/physics/electron.py
@@ -1615,7 +1615,7 @@ class _electron_State:
         S = self.Sk()
         return conj(self.state) * S.dot(self.state.T).T
 
-    def inner(self, right=None, matrix=None, diagonal=True, align=False):
+    def inner(self, right=None, matrix=None, diagonal=True):
         r""" Return the inner product by :math:`\mathbf M_{ij} = \langle\psi_i| \mathbf M |\psi'_j\rangle`
 
         Parameters
@@ -1627,8 +1627,6 @@ class _electron_State:
            a matrix that expresses the operator `M`. Defaults to the overlap matrix `S`.
         diagonal : bool, optional
            only return the diagonal matrix :math:`\mathbf M_{ii}`.
-        align : bool, optional
-           first align `right` with the angles for this state (see `align`)
 
         Raises
         ------
@@ -1657,12 +1655,6 @@ class _electron_State:
 
             # Same as State.inner
             # In the current implementation we require no overlap matrix!
-            if align:
-                if self.shape[0] != right.shape[0]:
-                    raise ValueError(f"{self.__class__.__name__}.inner with align=True requires exactly the same shape!")
-                # Align the states
-                right = self.align_phase(right)
-
             if diagonal:
                 if self.shape[0] != right.shape[0]:
                     return np.diag(dot(conj(self.state), M.dot(right.state.T)))

--- a/sisl/physics/electron.py
+++ b/sisl/physics/electron.py
@@ -1134,7 +1134,7 @@ def berry_phase(contour, sub=None, eigvals=False, closed=True, method='berry'):
             # Loop remaining eigenstates
             for second in eigenstates:
                 second.change_gauge('r')
-                prd = _process(prd, prev.inner(second, diagonal=False))
+                prd = _process(prd, prev.inner(second, diag=False))
                 prev = second
 
             # Complete the loop
@@ -1152,7 +1152,7 @@ def berry_phase(contour, sub=None, eigvals=False, closed=True, method='berry'):
                         prev.state *= exp(1j * phase)
 
                 # Include last-to-first segment
-                prd = _process(prd, prev.inner(first, diagonal=False))
+                prd = _process(prd, prev.inner(first, diag=False))
             return prd
 
     else:
@@ -1164,7 +1164,7 @@ def berry_phase(contour, sub=None, eigvals=False, closed=True, method='berry'):
             for second in eigenstates:
                 second = second.sub(sub)
                 second.change_gauge('r')
-                prd = _process(prd, prev.inner(second, diagonal=False))
+                prd = _process(prd, prev.inner(second, diag=False))
                 prev = second
             if closed:
                 if method == "zak":
@@ -1177,7 +1177,7 @@ def berry_phase(contour, sub=None, eigvals=False, closed=True, method='berry'):
                         prev.state *= np.repeat(exp(1j * phase), 2, axis=1)
                     else:
                         prev.state *= exp(1j * phase)
-                prd = _process(prd, prev.inner(first, diagonal=False))
+                prd = _process(prd, prev.inner(first, diag=False))
             return prd
 
     # Do the actual calculation of the final matrix

--- a/sisl/physics/electron.py
+++ b/sisl/physics/electron.py
@@ -1676,45 +1676,6 @@ class _electron_State:
         """
         return spin_moment(self.state, self.Sk(), project=project)
 
-    def expectation(self, A, diag=True):
-        r""" Calculate the expectation value of matrix `A`
-
-        The expectation matrix is calculated as:
-
-        .. math::
-            A_{ij} = \langle \psi_i | \mathbf A | \psi_j \rangle
-
-        If `diag` is true, only the diagonal elements are returned.
-
-        Parameters
-        ----------
-        A : array_like
-           a vector or matrix that expresses the operator `A`
-        diag : bool, optional
-           whether only the diagonal elements are calculated or if the full expectation
-           matrix is calculated
-
-        Returns
-        -------
-        numpy.ndarray
-            a vector if `diag` is true, otherwise a matrix with expectation values
-        """
-        ndim = A.ndim
-        s = self.state
-
-        if diag:
-            if ndim == 2:
-                a = einsum("ij,ji->i", s.conj(), A.dot(s.T))
-            elif ndim == 1:
-                a = einsum("ij,j,ij->i", s.conj(), A, s)
-        elif ndim == 2:
-            a = s.conj().dot(A.dot(s.T))
-        elif ndim == 1:
-            a = einsum("ij,j,jk", s.conj(), A, s.T)
-        else:
-            raise ValueError("expectation: requires matrix A to be 1D or 2D")
-        return a
-
     def wavefunction(self, grid, spinor=0, eta=False):
         r""" Expand the coefficients as the wavefunction on `grid` *as-is*
 

--- a/sisl/physics/electron.py
+++ b/sisl/physics/electron.py
@@ -1604,15 +1604,15 @@ class _electron_State:
         S = self.Sk()
         return conj(self.state) * S.dot(self.state.T).T
 
-    def inner(self, right=None, matrix=None, diag=True):
+    def inner(self, ket=None, matrix=None, diag=True):
         r""" Calculate the inner product by :math:`\mathbf A_{ij} = \langle\psi_i| \mathbf M |\psi'_j\rangle`
 
         The bra will be `self.state`.
 
         Parameters
         ----------
-        right : State or array_like, optional
-           the right object to calculate the inner product with, if not passed it will do the inner
+        ket : State or array_like, optional
+           the ket object to calculate the inner product with, if not passed it will do the inner
            product with itself.
         matrix : array_like, optional
            a vector or matrix that expresses the operator `M`. Defaults to the overlap matrix `S`.
@@ -1621,7 +1621,7 @@ class _electron_State:
 
         Raises
         ------
-        ValueError : in case where `right` is not None and `self` and `right` has differing overlap matrix.
+        ValueError : in case where `ket` is not None and `self` and `ket` has differing overlap matrix.
 
         Returns
         -------
@@ -1632,7 +1632,7 @@ class _electron_State:
             # Retrieve the overlap matrix (FULL S is required for NC)
             matrix = self.Sk()
 
-        return super().inner(right, matrix, diag)
+        return super().inner(ket, matrix, diag)
 
     def spin_moment(self, project=False):
         r""" Calculate spin moment from the states

--- a/sisl/physics/phonon.py
+++ b/sisl/physics/phonon.py
@@ -277,7 +277,6 @@ class _phonon_Mode:
         return self.state
 
 
-
 @set_module("sisl.physics.phonon")
 class CoefficientPhonon(Coefficient):
     """ Coefficients describing some physical quantity related to phonons """

--- a/sisl/physics/state.py
+++ b/sisl/physics/state.py
@@ -476,14 +476,14 @@ class State(ParentContainer):
                 else:
                     bra = bra[:len(ket)]
             if ndim == 2:
-                Mij = einsum('ij,ji->i', _conj(bra), M.dot(ket.T))
+                Aij = einsum('ij,ji->i', _conj(bra), M.dot(ket.T))
             elif ndim == 1:
-                Mij = einsum('ij,j,ij->i', _conj(bra), M, ket)
+                Aij = einsum('ij,j,ij->i', _conj(bra), M, ket)
         elif ndim == 2:
-            Mij = _conj(bra) @ M.dot(ket.T)
+            Aij = _conj(bra) @ M.dot(ket.T)
         elif ndim == 1:
-            Mij = einsum('ij,j,kj->ik', _conj(bra), M, ket)
-        return Mij
+            Aij = einsum('ij,j,kj->ik', _conj(bra), M, ket)
+        return Aij
 
     def phase(self, method='max', return_indices=False):
         r""" Calculate the Euler angle (phase) for the elements of the state, in the range :math:`]-\pi;\pi]`

--- a/sisl/physics/tests/test_hamiltonian.py
+++ b/sisl/physics/tests/test_hamiltonian.py
@@ -589,10 +589,10 @@ class TestHamiltonian:
             assert np.allclose(e, es.eig)
             assert np.allclose(v, es.state.T)
             assert np.allclose(es.norm2(), 1)
-            assert np.allclose(es.inner(diagonal=False) - np.eye(len(es)), 0)
+            assert np.allclose(es.inner(diag=False) - np.eye(len(es)), 0)
 
             assert es.inner(es.sub(0)).shape == (1, )
-            assert es.inner(es.sub(0), diagonal=False).shape == (len(es), 1)
+            assert es.inner(es.sub(0), diag=False).shape == (len(es), 1)
 
             eig1 = HS.eigh(k)
             eig2 = np.sort(HS.eig(k).real)
@@ -605,7 +605,7 @@ class TestHamiltonian:
             assert np.allclose(eig1, eig5, atol=1e-5)
 
             assert es.inner(matrix=HS.Hk([0.1] * 3), right=HS.eigenstate([0.3] * 3),
-                            diagonal=False).shape == (len(es), len(es))
+                            diag=False).shape == (len(es), len(es))
 
     def test_gauge_eig(self, setup):
         # Test of eigenvalues

--- a/sisl/physics/tests/test_hamiltonian.py
+++ b/sisl/physics/tests/test_hamiltonian.py
@@ -589,9 +589,9 @@ class TestHamiltonian:
             assert np.allclose(e, es.eig)
             assert np.allclose(v, es.state.T)
             assert np.allclose(es.norm2(), 1)
-            assert np.allclose(es.inner(diag=False) - np.eye(len(es)), 0)
+            assert np.allclose(es.inner(diag=False), np.eye(len(es)))
 
-            assert es.inner(es.sub(0)).shape == (1, )
+            assert es.inner(es.sub(0)).shape == (len(es), )
             assert es.inner(es.sub(0), diag=False).shape == (len(es), 1)
 
             eig1 = HS.eigh(k)
@@ -792,14 +792,14 @@ class TestHamiltonian:
         for k in ([0] *3, [0.2] * 3):
             es = H.eigenstate(k)
 
-            d = es.expectation(D)
+            d = es.inner(matrix=D)
             assert np.allclose(d, D)
-            d = es.expectation(D, diag=False)
+            d = es.inner(matrix=D, diag=False)
             assert np.allclose(d, I)
 
-            d = es.expectation(I)
+            d = es.inner(matrix=I)
             assert np.allclose(d, D)
-            d = es.expectation(I, diag=False)
+            d = es.inner(matrix=I, diag=False)
             assert np.allclose(d, I)
 
     def test_velocity_orthogonal(self, setup):
@@ -1158,7 +1158,7 @@ class TestHamiltonian:
 
             # Perform spin-moment calculation
             sm = es.spin_moment()
-            sm2 = es.expectation(SZ).real
+            sm2 = es.inner(matrix=SZ).real
             sm3 = np.diag(np.dot(np.conj(es.state), SZ).dot(es.state.T)).real
             assert np.allclose(sm[:, 2], sm2)
             assert np.allclose(sm[:, 2], sm3)
@@ -1299,7 +1299,7 @@ class TestHamiltonian:
             assert np.allclose(es.eig, eig1)
 
             sm = es.spin_moment()
-            sm2 = es.expectation(SZ).real
+            sm2 = es.inner(matrix=SZ).real
             sm3 = np.diag(np.dot(np.conj(es.state), SZ).dot(es.state.T)).real
             assert np.allclose(sm[:, 2], sm2)
             assert np.allclose(sm[:, 2], sm3)

--- a/sisl/physics/tests/test_hamiltonian.py
+++ b/sisl/physics/tests/test_hamiltonian.py
@@ -598,13 +598,13 @@ class TestHamiltonian:
             eig2 = np.sort(HS.eig(k).real)
             eig3 = np.sort(HS.eig(k, eigvals_only=False)[0].real)
             eig4 = es.inner(matrix=HS.Hk(k))
-            eig5 = es.inner(right=es, matrix=HS.Hk(k))
+            eig5 = es.inner(ket=es, matrix=HS.Hk(k))
             assert np.allclose(eig1, eig2, atol=1e-5)
             assert np.allclose(eig1, eig3, atol=1e-5)
             assert np.allclose(eig1, eig4, atol=1e-5)
             assert np.allclose(eig1, eig5, atol=1e-5)
 
-            assert es.inner(matrix=HS.Hk([0.1] * 3), right=HS.eigenstate([0.3] * 3),
+            assert es.inner(matrix=HS.Hk([0.1] * 3), ket=HS.eigenstate([0.3] * 3),
                             diag=False).shape == (len(es), len(es))
 
     def test_inner(self, setup):

--- a/sisl/physics/tests/test_hamiltonian.py
+++ b/sisl/physics/tests/test_hamiltonian.py
@@ -597,8 +597,15 @@ class TestHamiltonian:
             eig1 = HS.eigh(k)
             eig2 = np.sort(HS.eig(k).real)
             eig3 = np.sort(HS.eig(k, eigvals_only=False)[0].real)
+            eig4 = es.inner(matrix=HS.Hk(k))
+            eig5 = es.inner(right=es, matrix=HS.Hk(k))
             assert np.allclose(eig1, eig2, atol=1e-5)
             assert np.allclose(eig1, eig3, atol=1e-5)
+            assert np.allclose(eig1, eig4, atol=1e-5)
+            assert np.allclose(eig1, eig5, atol=1e-5)
+
+            assert es.inner(matrix=HS.Hk([0.1] * 3), right=HS.eigenstate([0.3] * 3),
+                            diagonal=False).shape == (len(es), len(es))
 
     def test_gauge_eig(self, setup):
         # Test of eigenvalues

--- a/sisl/physics/tests/test_hamiltonian.py
+++ b/sisl/physics/tests/test_hamiltonian.py
@@ -591,7 +591,7 @@ class TestHamiltonian:
             assert np.allclose(es.norm2(), 1)
             assert np.allclose(es.inner(diag=False), np.eye(len(es)))
 
-            assert es.inner(es.sub(0)).shape == (len(es), )
+            assert es.inner(es.sub(0)).shape == (1, )
             assert es.inner(es.sub(0), diag=False).shape == (len(es), 1)
 
             eig1 = HS.eigh(k)
@@ -606,6 +606,32 @@ class TestHamiltonian:
 
             assert es.inner(matrix=HS.Hk([0.1] * 3), right=HS.eigenstate([0.3] * 3),
                             diag=False).shape == (len(es), len(es))
+
+    def test_inner(self, setup):
+        HS = setup.HS.copy()
+        HS.construct([(0.1, 1.5), ((2., 1.), (3., 0.))])
+        HS = HS.tile(2, 0).tile(2, 1)
+
+        es1 = HS.eigenstate([0.1] * 3)
+        es2 = HS.eigenstate([0.2] * 3)
+        m1 = es1.inner(es2, diag=False)
+        assert m1.shape == (len(es1), len(es2))
+        m2 = es2.inner(es1, diag=False)
+        assert np.allclose(m1, m2.conj().T)
+        m3 = es2.inner(es1.state, diag=False)
+        assert np.allclose(m1, m3.conj().T)
+
+        r = range(3)
+        m1 = es1.sub(r).inner(es2, diag=False)
+        m2 = es2.inner(es1.sub(r), diag=False)
+        assert np.allclose(m1, m2.conj().T)
+        assert es1.sub(r).inner(es2, diag=False).shape == (len(r), len(es2))
+        assert es1.inner(es2.sub(r), diag=False).shape == (len(es1), len(r))
+        m1 = es1.sub(r).inner(es2, diag=True)
+        assert m1.shape == (len(r), )
+        m2 = es2.inner(es1.sub(r), diag=True)
+        assert m2.shape == (len(r), )
+        assert np.allclose(m1, m2.conj())
 
     def test_gauge_eig(self, setup):
         # Test of eigenvalues

--- a/sisl/physics/tests/test_state.py
+++ b/sisl/physics/tests/test_state.py
@@ -141,19 +141,16 @@ def test_state_inner1():
     state = State(state)
     inner = state.inner()
     assert np.allclose(inner, state.inner(state))
-    inner = state.inner(diagonal=False)
-    assert np.allclose(inner, state.inner(state, diagonal=False))
+    inner = state.inner(diag=False)
+    assert np.allclose(inner, state.inner(state, diag=False))
 
 
 def test_state_inner_differing_size():
     state1 = State(ar(8, 10))
     state2 = State(ar(4, 10))
 
-    inner = state1.inner(state2, diagonal=False)
+    inner = state1.inner(state2, diag=False)
     assert inner.shape == (8, 4)
-
-    inner = state1.inner(state2)
-    assert inner.shape == (4, )
 
 
 def test_state_phase_max():


### PR DESCRIPTION
As discussed in #352 this branch

- [x] generalizes the `inner` product to allow for an optional operator (matrix) to be passed,
- [x] removes the `align` keyword in `inner`
- [x] removes the `expectation` function