### PR TITLE
mnt: enabled tiling an eigenstate

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 0.X.Y
 =====
 
+- enabled tiling a State object, #354 and #355
+
 - enabled reading from STRUCT_* files (Siesta input/output) #308
 
 - enabled reading the SuperCell block from fdf

--- a/sisl/physics/state.py
+++ b/sisl/physics/state.py
@@ -305,7 +305,7 @@ class State(ParentContainer):
         sub.info = self.info
         return sub
 
-    def tile(self, reps, axis, normalize=False):
+    def tile(self, reps, axis, normalize=False, offset=0):
         r"""Tile the state vectors for a new supercell
 
         Tiling a state vector makes use of the Bloch factors for a state by utilizing
@@ -314,7 +314,10 @@ class State(ParentContainer):
 
            \psi_{\mathbf k}(\mathbf r + \mathbf T) \propto e^{i\mathbf k\cdot \mathbf T}
 
-        where :math:`\mathbf T = i\mathbf a_0 + j\mathbf a_1 + k\mathbf a_2`.
+        where :math:`\mathbf T = i\mathbf a_0 + j\mathbf a_1 + l\mathbf a_2`. Note that `axis`
+        selects which of the :math:`\mathbf a_i` vectors that are translated and `reps` corresponds
+        to the :math:`i`, :math:`j` and :math:`l` variables. The `offset` moves the individual states
+        by said amount, i.e. :math:`i\to i-\mathrm{offset}`.
 
         Parameters
         ----------
@@ -325,6 +328,8 @@ class State(ParentContainer):
         normalize: bool, optional
            whether the states are normalized upon return, may be useful for
            eigenstates
+        offset: float, optional
+           the offset for the phase factors
 
         See Also
         --------
@@ -346,7 +351,7 @@ class State(ParentContainer):
         # with T being
         #   i * a_0 + j * a_1 + k * a_2
         # We can leave out the lattice vectors entirely
-        phase = exp(k[axis] * _a.aranged(reps) * 2j * _pi)
+        phase = exp(k[axis] * (_a.aranged(reps) - offset) * 2j * _pi)
 
         state *= phase.reshape(1, -1, 1)
         state.shape = (len(self), -1)

--- a/sisl/physics/state.py
+++ b/sisl/physics/state.py
@@ -346,7 +346,7 @@ class State(ParentContainer):
         where :math:`\mathbf T = i\mathbf a_0 + j\mathbf a_1 + l\mathbf a_2`. Note that `axis`
         selects which of the :math:`\mathbf a_i` vectors that are translated and `reps` corresponds
         to the :math:`i`, :math:`j` and :math:`l` variables. The `offset` moves the individual states
-        by said amount, i.e. :math:`i\to i-\mathrm{offset}`.
+        by said amount, i.e. :math:`i\to i+\mathrm{offset}`.
 
         Parameters
         ----------
@@ -380,7 +380,7 @@ class State(ParentContainer):
         # with T being
         #   i * a_0 + j * a_1 + k * a_2
         # We can leave out the lattice vectors entirely
-        phase = exp(2j*_pi * k[axis] * (_a.aranged(reps) - offset))
+        phase = exp(2j*_pi * k[axis] * (_a.aranged(reps) + offset))
 
         state *= phase.reshape(1, -1, 1)
         state.shape = (len(self), -1)

--- a/sisl/physics/state.py
+++ b/sisl/physics/state.py
@@ -305,6 +305,38 @@ class State(ParentContainer):
         sub.info = self.info
         return sub
 
+    @property
+    def state_sc(self):
+        r""" Calculate the state coefficients in the auxiliary supercell
+
+        The format of this state vector is usable for `inner` as the ``ket`` argument.
+        The order of the state vectors is equivalent to the auxiliary supercell order.
+
+        See Also
+        --------
+        inner : these state vectors may be used in the inner product
+        tile : equivalent form along a single given axis
+        translate : a single translation of the state vectors
+
+        Examples
+        --------
+        The returned state vectors can be formulated like this:
+
+        >>> state = State(...)
+        >>> state_sc = np.stack([state.translate(isc)
+        ...                      for _, isc in state.parent.sc])
+        >>> assert state_sc.shape == (len(state) * state.parent.n_s, state.shape[1])
+        """
+        k = _a.asarrayd(self.info.get("k", [0]*3))
+        sc = self.parent.sc
+        if np.allclose(k, 0):
+            def translate(isc):
+                return self.state
+        else:
+            def translate(isc):
+                return self.state * exp(2j*_pi * k @ isc)
+        return np.concatenate([translate(isc) for _, isc in sc], axis=0)
+
     def translate(self, isc):
         r""" Translate the vectors to a new unit-cell position
 

--- a/sisl/physics/tests/test_hamiltonian.py
+++ b/sisl/physics/tests/test_hamiltonian.py
@@ -672,6 +672,27 @@ class TestHamiltonian:
             abs_out = np.absolute(out)
             assert np.isclose(abs_out, 1).sum() == len(es1)
 
+    def test_eigenstate_tile_offset(self, setup):
+        # Test of eigenvalues
+        R, param = [0.1, 1.5], [0., 2.7]
+        H1 = setup.H.copy()
+        H1.construct((R, param))
+        H2 = H1.tile(2, 1)
+
+        k = [0] * 3
+        # we must select a k that does not fold on
+        # itself which then creates degenerate states
+        for k1 in [0.5, 1/3]:
+            k[1] = k1
+            es1 = H1.eigenstate(k)
+            es1_2 = es1.tile(2, 1, normalize=True, offset=1)
+            es2 = H2.eigenstate(es1_2.info['k']).translate([0, 1, 0])
+
+            # we need to check that these are somewhat the same
+            out = es1_2.inner(es2, diag=False)
+            abs_out = np.absolute(out)
+            assert np.isclose(abs_out, 1).sum() == len(es1)
+
     def test_eigenstate_translate(self, setup):
         # Test of eigenvalues
         R, param = [0.1, 1.5], [0., 2.7]

--- a/sisl/physics/tests/test_hamiltonian.py
+++ b/sisl/physics/tests/test_hamiltonian.py
@@ -696,21 +696,38 @@ class TestHamiltonian:
     def test_eigenstate_translate(self, setup):
         # Test of eigenvalues
         R, param = [0.1, 1.5], [0., 2.7]
-        H1 = setup.H.copy()
-        H1.construct((R, param))
+        H = setup.H.copy()
+        H.construct((R, param))
 
         k = [0] * 3
         # we must select a k that does not fold on
         # itself which then creates degenerate states
         for k1 in [0.5, 1/3]:
             k[1] = k1
-            es1 = H1.eigenstate(k)
+            es1 = H.eigenstate(k)
             es1_2 = es1.tile(2, 1)
             es2 = es1.translate([0, 1, 0])
             assert np.allclose(es1_2.state[:, :len(es1)],
                                es1.state)
             assert np.allclose(es1_2.state[:, len(es1):],
                                es2.state)
+
+    def test_eigenstate_state_sc(self, setup):
+        # Test of eigenvalues
+        R, param = [0.1, 1.5], [0., 2.7]
+        H = setup.H.copy()
+        H.construct((R, param))
+
+        k = [0] * 3
+        # we must select a k that does not fold on
+        # itself which then creates degenerate states
+        for k1 in [0.5, 1/3]:
+            k[1] = k1
+            es = H.eigenstate(k)
+            state_sc = es.state_sc.reshape(-1, *es.shape)
+            for i, (_, isc) in enumerate(H.geometry.sc):
+                est = es.translate(isc)
+                assert np.allclose(state_sc[i], est.state)
 
     def test_gauge_velocity(self, setup):
         R, param = [0.1, 1.5], [1., 0.1]

--- a/sisl/physics/tests/test_hamiltonian.py
+++ b/sisl/physics/tests/test_hamiltonian.py
@@ -672,6 +672,25 @@ class TestHamiltonian:
             abs_out = np.absolute(out)
             assert np.isclose(abs_out, 1).sum() == len(es1)
 
+    def test_eigenstate_translate(self, setup):
+        # Test of eigenvalues
+        R, param = [0.1, 1.5], [0., 2.7]
+        H1 = setup.H.copy()
+        H1.construct((R, param))
+
+        k = [0] * 3
+        # we must select a k that does not fold on
+        # itself which then creates degenerate states
+        for k1 in [0.5, 1/3]:
+            k[1] = k1
+            es1 = H1.eigenstate(k)
+            es1_2 = es1.tile(2, 1)
+            es2 = es1.translate([0, 1, 0])
+            assert np.allclose(es1_2.state[:, :len(es1)],
+                               es1.state)
+            assert np.allclose(es1_2.state[:, len(es1):],
+                               es2.state)
+
     def test_gauge_velocity(self, setup):
         R, param = [0.1, 1.5], [1., 0.1]
         g = setup.g.tile(2, 0).tile(2, 1).tile(2, 2)

--- a/sisl/physics/tests/test_hamiltonian.py
+++ b/sisl/physics/tests/test_hamiltonian.py
@@ -651,6 +651,27 @@ class TestHamiltonian:
         assert np.allclose(es1.eig, es2.eig)
         assert not np.allclose(es1.state, es2.state)
 
+    def test_eigenstate_tile(self, setup):
+        # Test of eigenvalues
+        R, param = [0.1, 1.5], [0., 2.7]
+        H1 = setup.H.copy()
+        H1.construct((R, param))
+        H2 = H1.tile(2, 1)
+
+        k = [0] * 3
+        # we must select a k that does not fold on
+        # itself which then creates degenerate states
+        for k1 in [0.5, 1/3]:
+            k[1] = k1
+            es1 = H1.eigenstate(k)
+            es1_2 = es1.tile(2, 1, normalize=True)
+            es2 = H2.eigenstate(es1_2.info['k'])
+
+            # we need to check that these are somewhat the same
+            out = es1_2.inner(es2, diag=False)
+            abs_out = np.absolute(out)
+            assert np.isclose(abs_out, 1).sum() == len(es1)
+
     def test_gauge_velocity(self, setup):
         R, param = [0.1, 1.5], [1., 0.1]
         g = setup.g.tile(2, 0).tile(2, 1).tile(2, 2)


### PR DESCRIPTION
Using the Bloch expansion we can get the same state for
a new lattice by expanding it.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #354 
 - [x] Tests added
 - [x] Documentation for functionality
 - [x] User visible changes (including notable bug fixes) are documented in `CHANGELOG`

@tfrederiksen could you have a look at this
