### PR TITLE
mnt: changed all origo references to origin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 0.X.Y
 =====
 
+- renamed origo to origin, see #365
+
 - enabled copying Dispatchers for subclasses.
 	This allows chained dictionary look-ups for subclasses.
 	By default the dispatch dictionary is a chainmap and

--- a/setup.py
+++ b/setup.py
@@ -397,7 +397,7 @@ def cythonizer(extensions, *args, **kwargs):
 
 
 MAJOR = 0
-MINOR = 11
+MINOR = 12
 MICRO = 0
 ISRELEASED = False
 VERSION = f"{MAJOR}.{MINOR}.{MICRO}"

--- a/sisl/geom/bilayer.py
+++ b/sisl/geom/bilayer.py
@@ -95,7 +95,7 @@ def bilayer(bond=1.42, bottom_atoms=None, top_atoms=None, stacking='AB',
         natoms = 2 * (n ** 2 + n * m + m ** 2)
 
     if rep > 1:
-        # Set origo through an A atom near the middle of the geometry
+        # Set origin through an A atom near the middle of the geometry
         align_vec = - rep * (ref_cell[0] + ref_cell[1]) / 2
 
         bottom = (bottom

--- a/sisl/io/cube.py
+++ b/sisl/io/cube.py
@@ -20,7 +20,7 @@ class cubeSile(Sile):
     """ CUBE file object """
 
     @sile_fh_open()
-    def write_supercell(self, sc, fmt='15.10e', size=None, origo=None,
+    def write_supercell(self, sc, fmt='15.10e', size=None, origin=None,
                         *args, **kwargs):
         """ Writes `SuperCell` object attached to this grid
 
@@ -32,8 +32,8 @@ class cubeSile(Sile):
             floating point format for stored values
         size : (3, ), optional
             shape of the stored grid (``[1, 1, 1]``)
-        origo : (3, ), optional
-            origo of the cell (``[0, 0, 0]``)
+        origin : (3, ), optional
+            origin of the cell (``[0, 0, 0]``)
         """
         sile_raise_write(self)
 
@@ -43,13 +43,13 @@ class cubeSile(Sile):
 
         if size is None:
             size = np.ones([3], np.int32)
-        if origo is None:
-            origo = sc.origo[:]
+        if origin is None:
+            origin = sc.origin[:]
 
         _fmt = '{:d} {:15.10e} {:15.10e} {:15.10e}\n'
 
-        # Add #-of atoms and origo
-        self._write(_fmt.format(1, *(origo * Ang2Bohr)))
+        # Add #-of atoms and origin
+        self._write(_fmt.format(1, *(origin * Ang2Bohr)))
 
         # Write the cell and voxels
         for ix in range(3):
@@ -59,7 +59,7 @@ class cubeSile(Sile):
         self._write('1 0. 0. 0. 0.\n')
 
     @sile_fh_open()
-    def write_geometry(self, geometry, fmt='15.10e', size=None, origo=None,
+    def write_geometry(self, geometry, fmt='15.10e', size=None, origin=None,
             *args, **kwargs):
         """ Writes `Geometry` object attached to this grid
 
@@ -71,8 +71,8 @@ class cubeSile(Sile):
             floating point format for stored values
         size : (3, ), optional
             shape of the stored grid (``[1, 1, 1]``)
-        origo : (3, ), optional
-            origo of the cell (``[0, 0, 0]``)
+        origin : (3, ), optional
+            origin of the cell (``[0, 0, 0]``)
         """
         sile_raise_write(self)
 
@@ -82,16 +82,16 @@ class cubeSile(Sile):
 
         if size is None:
             size = np.ones([3], np.int32)
-        if origo is None:
-            origo = geometry.origo[:]
+        if origin is None:
+            origin = geometry.origin[:]
 
         _fmt = '{:d} {:15.10e} {:15.10e} {:15.10e}\n'
 
         valid_Z = (geometry.atoms.Z > 0).nonzero()[0]
         geometry = geometry.sub(valid_Z)
 
-        # Add #-of atoms and origo
-        self._write(_fmt.format(len(geometry), *(origo * Ang2Bohr)))
+        # Add #-of atoms and origin
+        self._write(_fmt.format(len(geometry), *(origin * Ang2Bohr)))
 
         # Write the cell and voxels
         for ix in range(3):
@@ -168,9 +168,9 @@ class cubeSile(Sile):
         """
         self.readline()  # header 1
         self.readline()  # header 2
-        origo = self.readline().split() # origo
-        lna = int(origo[0])
-        origo = np.fromiter(map(float, origo[1:]), np.float64)
+        origin = self.readline().split() # origin
+        lna = int(origin[0])
+        origin = np.fromiter(map(float, origin[1:]), np.float64)
 
         cell = np.empty([3, 3], np.float64)
         for i in [0, 1, 2]:
@@ -181,10 +181,10 @@ class cubeSile(Sile):
                 cell[i, j] = float(tmp[j]) * s
 
         cell = cell / Ang2Bohr
-        origo = origo / Ang2Bohr
+        origin = origin / Ang2Bohr
         if na:
-            return lna, SuperCell(cell, origo=origo)
-        return SuperCell(cell, origo=origo)
+            return lna, SuperCell(cell, origin=origin)
+        return SuperCell(cell, origin=origin)
 
     @sile_fh_open()
     def read_geometry(self):
@@ -230,7 +230,7 @@ class cubeSile(Sile):
         # Now seek behind to read grid sizes
         self.fh.seek(0)
 
-        # Skip headers and origo
+        # Skip headers and origin
         self.readline()
         self.readline()
         na = int(self.readline().split()[0])

--- a/sisl/io/pdb.py
+++ b/sisl/io/pdb.py
@@ -117,7 +117,7 @@ class pdbSile(Sile):
         #46 - 55         Real(10.5)    t[n]          Tn
         fmt = 'ORIGX{:1d}   ' + '{:10.6f}' * 3 + '{:10.5f}\n'
         for i in range(3):
-            args = [i + 1, 0, 0, 0, sc.origo[i]]
+            args = [i + 1, 0, 0, 0, sc.origin[i]]
             self._write(fmt.format(*args))
 
     @sile_fh_open()
@@ -147,13 +147,13 @@ class pdbSile(Sile):
                 raise SileError(str(self) + ' found SCALE1 but not SCALE3!')
             cell[2, :] = float(line[11:20]), float(line[21:30]), float(line[31:40])
 
-        origo = np.zeros(3)
+        origin = np.zeros(3)
         for i in range(3):
             f, line = self._step_record('ORIGX{}'.format(i + 1))
             if f:
-                origo[i] = float(line[45:55])
+                origin[i] = float(line[45:55])
 
-        return SuperCell(cell, origo=origo)
+        return SuperCell(cell, origin=origin)
 
     @sile_fh_open()
     def write_geometry(self, geometry):

--- a/sisl/io/siesta/fdf.py
+++ b/sisl/io/siesta/fdf.py
@@ -1391,15 +1391,15 @@ class fdfSileSiesta(SileSiesta):
 
         # If the user requests a shifted geometry
         # we correct for this
-        origo = _a.zerosd([3])
+        origin = _a.zerosd([3])
         lor = self.get('AtomicCoordinatesOrigin')
         if lor:
             if kwargs.get('origin', True):
                 if isinstance(lor, str):
-                    origo = lor.lower()
+                    origin = lor.lower()
                 else:
-                    origo = _a.asarrayd(list(map(float, lor[0].split()[:3]))) * s
-        # Origo cannot be interpreted with fractional coordinates
+                    origin = _a.asarrayd(list(map(float, lor[0].split()[:3]))) * s
+        # Origin cannot be interpreted with fractional coordinates
         # hence, it is not transformed.
 
         # Read atom block
@@ -1443,34 +1443,34 @@ class fdfSileSiesta(SileSiesta):
             atoms = [atoms[i] for i in species]
         atoms = Atoms(atoms, na=len(xyz))
 
-        if isinstance(origo, str):
-            opt = origo
+        if isinstance(origin, str):
+            opt = origin
             if opt.startswith('cop'):
-                origo = sc.cell.sum(0) * 0.5 - np.average(xyz, 0)
+                origin = sc.cell.sum(0) * 0.5 - np.average(xyz, 0)
             elif opt.startswith('com'):
                 # TODO for ghost atoms its mass should not be used
                 w = atom.mass
                 w /= w.sum()
-                origo = sc.cell.sum(0) * 0.5 - np.average(xyz, 0, weights=w)
+                origin = sc.cell.sum(0) * 0.5 - np.average(xyz, 0, weights=w)
             elif opt.startswith('min'):
-                origo = - np.amin(xyz, 0)
+                origin = - np.amin(xyz, 0)
             if len(opt) > 4:
                 opt = opt[4:]
                 if opt == 'x':
-                    origo[1:] = 0.
+                    origin[1:] = 0.
                 elif opt == 'y':
-                    origo[[0, 2]] = 0.
+                    origin[[0, 2]] = 0.
                 elif opt == 'z':
-                    origo[:2] = 0.
+                    origin[:2] = 0.
                 elif opt == 'xy' or opt == 'yx':
-                    origo[2] = 0.
+                    origin[2] = 0.
                 elif opt == 'xz' or opt == 'zx':
-                    origo[1] = 0.
+                    origin[1] = 0.
                 elif opt == 'yz' or opt == 'zy':
-                    origo[0] = 0.
+                    origin[0] = 0.
 
         # create geometry
-        xyz += origo
+        xyz += origin
         geom = Geometry(xyz, atoms, sc=sc)
 
         # and finally check for supercell constructs

--- a/sisl/io/xsf.py
+++ b/sisl/io/xsf.py
@@ -306,7 +306,7 @@ class xsfSile(Sile):
         def write_cell(grid):
             # Now write the grid
             self._write('  {} {} {}\n'.format(*grid.shape))
-            self._write('  ' + _v3.format(*grid.origo))
+            self._write('  ' + _v3.format(*grid.origin))
             self._write('  ' + _v3.format(*grid.cell[0, :]))
             self._write('  ' + _v3.format(*grid.cell[1, :]))
             self._write('  ' + _v3.format(*grid.cell[2, :]))

--- a/sisl/orbital.py
+++ b/sisl/orbital.py
@@ -292,7 +292,7 @@ class Orbital:
         from .grid import Grid
         from .atom import Atom
         from .physics.electron import wavefunction
-        sc = SuperCell(R*2, origo=[-R] * 3)
+        sc = SuperCell(R*2, origin=[-R] * 3)
         if isinstance(atom, Atom):
             atom = atom.copy(orbitals=self)
         else:

--- a/sisl/physics/brillouinzone.py
+++ b/sisl/physics/brillouinzone.py
@@ -328,8 +328,8 @@ class BrillouinZone:
         return BrillouinZone(sc, k)
 
     @classmethod
-    def param_circle(self, sc, N_or_dk, kR, normal, origo, loop=False):
-        r""" Create a parameterized k-point list where the k-points are generated on a circle around an origo
+    def param_circle(self, sc, N_or_dk, kR, normal, origin, loop=False):
+        r""" Create a parameterized k-point list where the k-points are generated on a circle around an origin
 
         The generated circle is a perfect circle in the reciprocal space (Cartesian coordinates).
         To generate a perfect circle in units of the reciprocal lattice vectors one can
@@ -349,8 +349,8 @@ class BrillouinZone:
            radius of the k-point. In 1/Ang
         normal : array_like of float
            normal vector to determine the circle plane
-        origo : array_like of float
-           origo of the circle used to generate the circular parameterization
+        origin : array_like of float
+           origin of the circle used to generate the circular parameterization
         loop : bool, optional
            whether the first and last point are equal
 
@@ -385,9 +385,9 @@ class BrillouinZone:
         bz = BrillouinZone(sc)
 
         normal = _a.arrayd(normal)
-        origo = _a.arrayd(origo)
+        origin = _a.arrayd(origin)
         k_n = bz.tocartesian(normal)
-        k_o = bz.tocartesian(origo)
+        k_o = bz.tocartesian(origin)
 
         # Generate a preset list of k-points on the unit-circle
         if loop:
@@ -1419,8 +1419,8 @@ class MonkhorstPack(BrillouinZone):
             else:
                 cell = parent.sc.rcell * self._size.reshape(1, -1) / units('Ang', grid_unit)
 
-            # Find the grid origo
-            origo = -(cell * 0.5).sum(0)
+            # Find the grid origin
+            origin = -(cell * 0.5).sum(0)
 
             # Calculate first k-point (to get size and dtype)
             v = wrap(func(*args, k=k[0], **kwargs), parent=parent, k=k[0], weight=w[0])
@@ -1446,7 +1446,7 @@ class MonkhorstPack(BrillouinZone):
 
             # Correct cell for the grid
             if trs_axis >= 0:
-                origo[trs_axis] = 0.
+                origin[trs_axis] = 0.
                 # Correct offset since we only have the positive halve
                 if self._diag[trs_axis] % 2 == 0 and not self._centered:
                     offset[trs_axis] = steps[trs_axis] / 2
@@ -1459,7 +1459,7 @@ class MonkhorstPack(BrillouinZone):
                                                    centered=self._centered, trs=True)[1])
 
             # Create the grid in the reciprocal cell
-            sc = SuperCell(cell, origo=origo)
+            sc = SuperCell(cell, origin=origin)
             grid = Grid(diag, sc=sc, dtype=v.dtype)
             if data_axis is None:
                 grid[k2idx(k[0])] = v

--- a/sisl/physics/densitymatrix.py
+++ b/sisl/physics/densitymatrix.py
@@ -544,12 +544,12 @@ class _densitymatrix(SparseOrbitalBZSpin):
         # For extremely skewed lattices this will be way too much, hence we make
         # them square.
         o = sc.toCuboid(True)
-        sc = SuperCell(o._v + np.diag(2 * add_R), origo=o.origo - add_R)
+        sc = SuperCell(o._v + np.diag(2 * add_R), origin=o.origin - add_R)
 
         # Retrieve all atoms within the grid supercell
         # (and the neighbours that connect into the cell)
         IA, XYZ, ISC = geometry.within_inf(sc, periodic=pbc)
-        XYZ -= grid.sc.origo.reshape(1, 3)
+        XYZ -= grid.sc.origin.reshape(1, 3)
 
         # Retrieve progressbar
         eta = progressbar(len(IA), f"{self.__class__.__name__}.density", "atom", eta)
@@ -619,8 +619,8 @@ class _densitymatrix(SparseOrbitalBZSpin):
 
         # Get offset in supercell in orbitals
         off = geometry.no * primary_i_s
-        origo = grid.origo
-        # TODO sum the non-origo atoms to the csrDM matrix
+        origin = grid.origin
+        # TODO sum the non-origin atoms to the csrDM matrix
         #      this would further decrease the loops required.
 
         # Loop over all atoms in the grid-cell
@@ -629,7 +629,7 @@ class _densitymatrix(SparseOrbitalBZSpin):
             ia_atom = atoms[ia]
             IO = a2o(ia)
             IO_range = range(ia_atom.no)
-            cell_offset = (cell * isc.reshape(3, 1)).sum(0) - origo
+            cell_offset = (cell * isc.reshape(3, 1)).sum(0) - origin
 
             # Extract maximum R
             R = ia_atom.maxR()

--- a/sisl/physics/electron.py
+++ b/sisl/physics/electron.py
@@ -1071,8 +1071,8 @@ def berry_phase(contour, sub=None, eigvals=False, closed=True, method='berry'):
     >>> N = 30
     >>> kR = 0.01
     >>> normal = [0, 0, 1]
-    >>> origo = [1/3, 2/3, 0]
-    >>> bz = BrillouinZone.param_circle(H, N, kR, normal, origo)
+    >>> origin = [1/3, 2/3, 0]
+    >>> bz = BrillouinZone.param_circle(H, N, kR, normal, origin)
     >>> phase = berry_phase(bz)
 
     Calculate Berry-phase for first band
@@ -1080,8 +1080,8 @@ def berry_phase(contour, sub=None, eigvals=False, closed=True, method='berry'):
     >>> N = 30
     >>> kR = 0.01
     >>> normal = [0, 0, 1]
-    >>> origo = [1/3, 2/3, 0]
-    >>> bz = BrillouinZone.param_circle(H, N, kR, normal, origo)
+    >>> origin = [1/3, 2/3, 0]
+    >>> bz = BrillouinZone.param_circle(H, N, kR, normal, origin)
     >>> phase = berry_phase(bz, sub=0)
 
     References
@@ -1268,7 +1268,7 @@ def wavefunction(v, grid, geometry=None, k=None, spinor=0, spin=None, eta=None):
         geometry = grid.geometry
     if geometry is None:
         raise SislError("wavefunction: did not find a usable Geometry through keywords or the Grid!")
-    # Ensure coordinates are in the primary unit-cell, regardless of origo etc.
+    # Ensure coordinates are in the primary unit-cell, regardless of origin etc.
     geometry = geometry.copy()
     geometry.xyz = (geometry.fxyz % 1) @ geometry.sc.cell
 
@@ -1365,7 +1365,7 @@ def wavefunction(v, grid, geometry=None, k=None, spinor=0, spin=None, eta=None):
     del ctheta_sphi, stheta_sphi, cphi, idx, rxyz, nrxyz
 
     # Fast loop (only per specie)
-    origo = grid.sc.origo.reshape(1, 3)
+    origin = grid.sc.origin.reshape(1, 3)
     idx_mm = _a.emptyd([geometry.na, 2, 3])
     all_negative_R = True
     for atom, ia in geometry.atoms.iter(True):
@@ -1376,9 +1376,9 @@ def wavefunction(v, grid, geometry=None, k=None, spinor=0, spin=None, eta=None):
 
         # Now do it for all the atoms to get indices of the middle of
         # the atoms
-        # The coordinates are relative to origo, so we need to shift (when writing a grid
-        # it is with respect to origo)
-        idx = dot(geometry.xyz[ia, :] - origo, ic_shape.T)
+        # The coordinates are relative to origin, so we need to shift (when writing a grid
+        # it is with respect to origin)
+        idx = dot(geometry.xyz[ia, :] - origin, ic_shape.T)
 
         # Get min-max for all atoms
         idx_mm[ia, 0, :] = idxm * R + idx
@@ -1391,7 +1391,7 @@ def wavefunction(v, grid, geometry=None, k=None, spinor=0, spin=None, eta=None):
     # When we run the below loop all indices can be retrieved by looking
     # up in the above table.
     # Before continuing, we can easily clean up the temporary arrays
-    del origo, idx
+    del origin, idx
 
     arangei = _a.arangei
 
@@ -1416,16 +1416,16 @@ def wavefunction(v, grid, geometry=None, k=None, spinor=0, spin=None, eta=None):
     # them square.
 
     o = sc.toCuboid(True)
-    sc = SuperCell(o._v + np.diag(2 * add_R), origo=o.origo - add_R)
+    sc = SuperCell(o._v + np.diag(2 * add_R), origin=o.origin - add_R)
 
     # Retrieve all atoms within the grid supercell
     # (and the neighbours that connect into the cell)
-    # Note that we cannot pass the "moved" origo because then ISC would be wrong
+    # Note that we cannot pass the "moved" origin because then ISC would be wrong
     IA, XYZ, ISC = geometry.within_inf(sc, periodic=pbc)
-    # We need to revert the grid supercell origo as that is not subtracted in the `within_inf` returned
-    # coordinates (and the below loop expects positions with respect to the origo of the plotting
+    # We need to revert the grid supercell origin as that is not subtracted in the `within_inf` returned
+    # coordinates (and the below loop expects positions with respect to the origin of the plotting
     # grid).
-    XYZ -= grid.sc.origo.reshape(1, 3)
+    XYZ -= grid.sc.origin.reshape(1, 3)
 
     phk = k * 2 * np.pi
     phase = 1

--- a/sisl/physics/tests/test_hamiltonian.py
+++ b/sisl/physics/tests/test_hamiltonian.py
@@ -1774,7 +1774,7 @@ def test_wavefunction2():
     ES = H.eigenstate(dtype=np.float64)
     # This is effectively plotting outside where no atoms exists
     # (there could however still be psi weight).
-    grid = Grid(0.1, sc=SuperCell([2, 2, 2], origo=[2] * 3))
+    grid = Grid(0.1, sc=SuperCell([2, 2, 2], origin=[2] * 3))
     grid.fill(0.)
     ES.sub(0).wavefunction(grid)
 
@@ -1789,7 +1789,7 @@ def test_wavefunction3():
     H.construct([R, param])
     ES = H.eigenstate()
     # Plot in the full thing
-    grid = Grid(0.1, dtype=np.complex128, sc=SuperCell([2, 2, 2], origo=[-1] * 3))
+    grid = Grid(0.1, dtype=np.complex128, sc=SuperCell([2, 2, 2], origin=[-1] * 3))
     grid.fill(0.)
     ES.sub(0).wavefunction(grid)
 
@@ -1804,6 +1804,6 @@ def test_wavefunction_eta():
     H.construct([R, param])
     ES = H.eigenstate()
     # Plot in the full thing
-    grid = Grid(0.1, dtype=np.complex128, sc=SuperCell([2, 2, 2], origo=[-1] * 3))
+    grid = Grid(0.1, dtype=np.complex128, sc=SuperCell([2, 2, 2], origin=[-1] * 3))
     grid.fill(0.)
     ES.sub(0).wavefunction(grid, eta=True)

--- a/sisl/shape/base.py
+++ b/sisl/shape/base.py
@@ -74,6 +74,11 @@ class Shape:
         """ The geometric center of the shape """
         return self._center
 
+    @center.setter
+    def center(self, center):
+        """ Set the geometric center of the shape """
+        self._center[:] = center
+
     def scale(self, scale):
         """ Return a new Shape with a scaled size """
         raise NotImplementedError(f"{self.__class__.__name__}.scale has not been implemented")

--- a/sisl/shape/ellipsoid.py
+++ b/sisl/shape/ellipsoid.py
@@ -29,7 +29,7 @@ class Ellipsoid(PureShape):
        I.e. the first vector is considered a principal axis, then the second vector will
        be orthogonalized onto the first, and this is the second principal axis. And so on.
     center : (3,), optional
-       the center of the ellipsoid. Defaults to the origo.
+       the center of the ellipsoid. Defaults to the origin.
 
     Examples
     --------
@@ -125,10 +125,6 @@ class Ellipsoid(PureShape):
         """ Return a cuboid with side lengths equal to the diameter of each ellipsoid vectors """
         from .prism4 import Cuboid
         return Cuboid(self._v * 2, self.center)
-
-    def set_center(self, center):
-        """ Change the center of the object """
-        super().__init__(center)
 
     def within_index(self, other, tol=1.e-8):
         r""" Return indices of the points that are within the shape

--- a/sisl/shape/prism4.py
+++ b/sisl/shape/prism4.py
@@ -28,10 +28,10 @@ class Cuboid(PureShape):
        vectors describing the cuboid, if only 3 the cuboid will be
        along the Euclidean vectors.
     center : (3,), optional
-       the center of the cuboid. Defaults to the origo.
-       Not allowed as argument if `origo` is passed.
-    origo : (3,), optional
-       the offset for the cuboid. The center will be equal to ``v.sum(0) + origo``.
+       the center of the cuboid. Defaults to the origin.
+       Not allowed as argument if `origin` is passed.
+    origin : (3,), optional
+       the offset for the cuboid. The center will be equal to ``v.sum(0) + origin``.
        Not allowed as argument if `center` is passed.
 
     Examples
@@ -48,7 +48,7 @@ class Cuboid(PureShape):
     #  Cuboid().to.ellipsoid() will convert to an sisl.shape.Ellipsoid object
     to = PureShape.to.copy()
 
-    def __init__(self, v, center=None, origo=None):
+    def __init__(self, v, center=None, origin=None):
 
         v = _a.asarrayd(v)
         if v.size == 1:
@@ -60,10 +60,10 @@ class Cuboid(PureShape):
         else:
             raise ValueError(f"{self.__class__.__name__} requires initialization with 3 vectors defining the cuboid")
 
-        if center is not None and origo is not None:
-            raise ValueError(f"{self.__class__.__name__} only allows either origo or center argument")
-        elif origo is not None:
-            center = self._v.sum(0) / 2 + origo
+        if center is not None and origin is not None:
+            raise ValueError(f"{self.__class__.__name__} only allows either origin or center argument")
+        elif origin is not None:
+            center = self._v.sum(0) / 2 + origin
 
         # initialize the center
         super().__init__(center)
@@ -75,15 +75,11 @@ class Cuboid(PureShape):
         return self.__class__(self._v, self.center)
 
     def __str__(self):
-        return self.__class__.__name__ + '{{O({1} {2} {3}), vol: {0}}}'.format(self.volume(), *self.origo)
+        return self.__class__.__name__ + '{{O({1} {2} {3}), vol: {0}}}'.format(self.volume(), *self.origin)
 
     def volume(self):
         """ Return volume of Cuboid """
         return abs(dot3(self._v[0, :], cross3(self._v[1, :], self._v[2, :])))
-
-    def set_center(self, center):
-        """ Re-setting the center can sometimes be necessary """
-        super().__init__(center)
 
     def scale(self, scale):
         """ Scale the cuboid box size (center is retained)
@@ -148,8 +144,8 @@ class Cuboid(PureShape):
         """
         other = _a.asarrayd(other).reshape(-1, 3)
 
-        # Offset origo
-        tmp = dot(other - self.origo[None, :], self._iv)
+        # Offset origin
+        tmp = dot(other - self.origin[None, :], self._iv)
 
         # First reject those that are definitely not inside
         # The proximity is 1e-12 of the inverse cell.
@@ -158,13 +154,14 @@ class Cuboid(PureShape):
         return indices_gt_le(tmp, -tol, 1. + tol)
 
     @property
-    def origo(self):
+    def origin(self):
         """ Return the origin of the Cuboid (lower-left corner) """
         return self.center - (self._v * 0.5).sum(0)
 
-    def set_origo(self, origo):
-        """ Re-setting the origo can sometimes be necessary """
-        super().__init__(origo + (self._v * 0.5).sum(0))
+    @origin.setter
+    def origin(self, origin):
+        """ Re-setting the origin can sometimes be necessary """
+        super().__init__(origin + (self._v * 0.5).sum(0))
 
     @property
     def edge_length(self):
@@ -213,14 +210,14 @@ class Cube(Cuboid):
     side : float
        side-length of the cube, or vector
     center : (3,), optional
-       the center of the cuboid. Defaults to the origo.
-       Not allowed as argument if `origo` is passed.
-    origo : (3,), optional
+       the center of the cuboid. Defaults to the origin.
+       Not allowed as argument if `origin` is passed.
+    origin : (3,), optional
        the lower left corner of the cuboid.
        Not allowed as argument if `center` is passed.
     """
     __slots__ = ()
 
-    def __init__(self, side, center=None, origo=None):
+    def __init__(self, side, center=None, origin=None):
         side = _a.asarrayd(side).ravel()[0]
-        super().__init__(side, center, origo)
+        super().__init__(side, center, origin)

--- a/sisl/shape/tests/test_prism4.py
+++ b/sisl/shape/tests/test_prism4.py
@@ -15,7 +15,7 @@ def test_create_cuboid():
     cube = Cuboid([1.0]*3)
     cube = Cuboid([1.0]*3, [1.]*3)
     cube = Cuboid([1.0, 2.0, 3.0], [1.]*3)
-    cube = Cuboid([1.0, 2.0, 3.0], origo=[1.]*3)
+    cube = Cuboid([1.0, 2.0, 3.0], origin=[1.]*3)
     v0 = [1., 0.2, 1.0]
     v1 = [1., -0.2, 1.0]
     v2 = [1., -0.2, -1.0]
@@ -31,7 +31,7 @@ def test_create_fail():
     with pytest.raises(ValueError):
         el = Cuboid([v0, v1, v2, v3])
     with pytest.raises(ValueError):
-        el = Cuboid(2, center=v1, origo=v2)
+        el = Cuboid(2, center=v1, origin=v2)
 
 
 def test_tosphere():
@@ -87,11 +87,11 @@ def test_vol1():
     assert cube.volume() == 1.
 
 
-def test_origo():
+def test_origin():
     cube = Cuboid([1.0]*3)
-    assert np.allclose(cube.origo, -0.5)
-    cube.set_origo(1)
-    assert np.allclose(cube.origo, 1)
+    assert np.allclose(cube.origin, -0.5)
+    cube.origin = 1
+    assert np.allclose(cube.origin, 1)
 
 
 def test_within1():

--- a/sisl/tests/test_geometry.py
+++ b/sisl/tests/test_geometry.py
@@ -776,8 +776,8 @@ class TestGeometry:
         g = setup.mol.translate([0.05] * 3)
         sc = SuperCell(1.5)
         for o in range(10):
-            origo = [o - 0.5, -0.5, -0.5]
-            sc.origo = origo
+            origin = [o - 0.5, -0.5, -0.5]
+            sc.origin = origin
             idx = g.within_inf(sc)[0]
             assert len(idx) == 1
             assert idx[0] == o

--- a/sisl/tests/test_sparse_orbital.py
+++ b/sisl/tests/test_sparse_orbital.py
@@ -338,7 +338,7 @@ def test_sparse_orbital_replace_hole():
     # now replace every position that can be replaced
     for y in [0, 2, 3]:
         for x in [1, 2, 3]:
-            cube = Cuboid(hole.sc.cell, origo=g.sc.offset([x, y, 0]) - 0.1)
+            cube = Cuboid(hole.sc.cell, origin=g.sc.offset([x, y, 0]) - 0.1)
             atoms = big.within(cube)
             assert len(atoms) == 4 * 6 * 6
             new = big.replace(atoms, hole)
@@ -380,7 +380,7 @@ def test_sparse_orbital_replace_hole_norbs():
     # now replace every position that can be replaced
     for y in [0, 3]:
         for x in [1, 3]:
-            cube = Cuboid(hole.sc.cell, origo=g.sc.offset([x, y, 0]) - 0.1)
+            cube = Cuboid(hole.sc.cell, origin=g.sc.offset([x, y, 0]) - 0.1)
             atoms = big.within(cube)
             assert len(atoms) == 4 * 6 * 6
             new = big.replace(atoms, hole)

--- a/sisl/viz/backends/templates/_plots/geometry.py
+++ b/sisl/viz/backends/templates/_plots/geometry.py
@@ -157,7 +157,7 @@ class GeometryBackend(Backend):
 
     def _draw_cell_2D_axes(self, geometry, cell, xaxis="x", yaxis="y"):
         cell_xy = GeometryPlot._projected_2Dcoords(geometry, xyz=cell, xaxis=xaxis, yaxis=yaxis)
-        origo_xy = GeometryPlot._projected_2Dcoords(geometry, xyz=geometry.origo, xaxis=xaxis, yaxis=yaxis)
+        origo_xy = GeometryPlot._projected_2Dcoords(geometry, xyz=geometry.origin, xaxis=xaxis, yaxis=yaxis)
 
         for i, vec in enumerate(cell_xy):
             x = np.array([0, vec[0]]) + origo_xy[0]
@@ -170,7 +170,7 @@ class GeometryBackend(Backend):
 
     def _draw_cell_2D_box(self, cell, geometry, xaxis="x", yaxis="y", color=None, **kwargs):
 
-        cell_corners = GeometryPlot._get_cell_corners(cell) + geometry.origo
+        cell_corners = GeometryPlot._get_cell_corners(cell) + geometry.origin
         x, y = GeometryPlot._projected_2Dcoords(geometry, xyz=cell_corners, xaxis=xaxis, yaxis=yaxis).T
 
         self.draw_line(x, y, line={"color": color}, name="Unit cell", **kwargs)
@@ -300,15 +300,15 @@ class GeometryBackend(Backend):
 
         for i, vec in enumerate(cell):
             self.draw_line3D(
-                x=np.array([0, vec[0]]) + geometry.origo[0],
-                y=np.array([0, vec[1]]) + geometry.origo[1],
-                z=np.array([0, vec[2]]) + geometry.origo[2],
+                x=np.array([0, vec[0]]) + geometry.origin[0],
+                y=np.array([0, vec[1]]) + geometry.origin[1],
+                z=np.array([0, vec[2]]) + geometry.origin[2],
                 name=f'Axis {i}',
                 **kwargs
             )
 
     def _draw_cell_3D_box(self, cell, geometry, color=None, width=2, **kwargs):
-        x, y, z = (GeometryPlot._get_cell_corners(cell) + geometry.origo).T
+        x, y, z = (GeometryPlot._get_cell_corners(cell) + geometry.origin).T
 
         self.draw_line3D(x, y, z, line={'color': color, 'width': width}, name="Unit cell", **kwargs)
 

--- a/sisl/viz/plots/grid.py
+++ b/sisl/viz/plots/grid.py
@@ -501,7 +501,7 @@ class GridPlot(Plot):
         grid = self.grid.copy()
 
         self._ndim = len(axes)
-        self.offsets["origin"] = grid.origo
+        self.offsets["origin"] = grid.origin
 
         # Choose the representation of the grid that we want to display
         grid.grid = self._get_representation(grid, represent)


### PR DESCRIPTION
The usage of origo is a Danish word. So all is now transferred
to origin. Some of the routines still enable origo, but are
marked as deprecated.

This will probably break some codes.

Updated change-log

@pfebrer please have a look at this as it touches your code... Any comments are welcome!

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Partially closes #37
 - [x] User visible changes (including notable bug fixes) are documented in `CHANGELOG`
