### PR TITLE
Parallel calculation of PDOS and (fat)bands

### DIFF
--- a/sisl/viz/backends/templates/_plots/bands.py
+++ b/sisl/viz/backends/templates/_plots/bands.py
@@ -51,8 +51,10 @@ class BandsBackend(Backend):
         else:
             draw_band_func = self._draw_band
 
+        if "spin" not in filtered_bands.coords:
+            filtered_bands = filtered_bands.expand_dims("spin")
         # Now loop through all bands to draw them
-        for spin_bands, ispin in zip(filtered_bands.transpose('spin', 'band', 'k'), filtered_bands.spin.values):
+        for ispin, spin_bands in enumerate(filtered_bands.transpose('spin', 'band', 'k')):
             line_style = line
             if ispin == 1:
                 line_style.update(spindown_line)

--- a/sisl/viz/backends/templates/_plots/fatbands.py
+++ b/sisl/viz/backends/templates/_plots/fatbands.py
@@ -56,10 +56,12 @@ class FatbandsBackend(BandsBackend):
         bands: xarray.DataArray with indices (spin, band, k)
             Contains all the eigenvalues of the band structure.
         """
+        if "spin" not in bands.coords:
+            bands = bands.expand_dims("spin")
 
-        for ispin, spin_weights in enumerate(weights):
+        for ispin, spin_weights in enumerate(weights.transpose("spin", "band", "k")):
             for i, band_weights in enumerate(spin_weights):
-                band_values = bands.sel(band=band_weights.band, spin=band_weights.spin)
+                band_values = bands.sel(band=band_weights.band, spin=ispin)
 
                 self._draw_band_weights(
                     x=x, y=band_values, weights=band_weights.values,

--- a/sisl/viz/input_fields/dropdown.py
+++ b/sisl/viz/input_fields/dropdown.py
@@ -156,10 +156,10 @@ class SpinSelect(DropdownInput):
     }
 
     _options = {
-        Spin.UNPOLARIZED: [{"label": "Total", "value": 0}],
+        Spin.UNPOLARIZED: [],
         Spin.POLARIZED: [{"label": "↑", "value": 0}, {"label": "↓", "value": 1}],
-        Spin.NONCOLINEAR: [{"label": val, "value": val} for val in ("sum", "x", "y", "z")],
-        Spin.SPINORBIT: [{"label": val, "value": val} for val in ("sum", "x", "y", "z")]
+        Spin.NONCOLINEAR: [{"label": val, "value": val} for val in ("total", "x", "y", "z")],
+        Spin.SPINORBIT: [{"label": val, "value": val} for val in ("total", "x", "y", "z")]
     }
 
     def __init__(self, *args, only_if_polarized=False, **kwargs):

--- a/sisl/viz/input_fields/queries.py
+++ b/sisl/viz/input_fields/queries.py
@@ -299,7 +299,7 @@ class OrbitalQueries(QueriesInput):
 
         # If "spin" was one of the keys, we are going to incorporate the spin options, taking into
         # account the position (column index) where they are expected to be returned.
-        if spin_in_keys:
+        if spin_in_keys and len(spin_options) > 0:
             options = np.concatenate([np.insert(options, spin_key_i, spin, axis=1) for spin in spin_options])
 
         # Squeeze the options array, just in case there is only one key

--- a/sisl/viz/plots/bands.py
+++ b/sisl/viz/plots/bands.py
@@ -6,18 +6,25 @@ from functools import partial
 import itertools
 
 import numpy as np
+import xarray as xr
 
 import sisl
+from sisl.messages import warn
 from ..plot import Plot, entry_point
-from ..plotutils import call_method_if_present, find_files
+from ..plotutils import find_files
 from ..input_fields import (
-    TextInput, SwitchInput, ColorPicker, DropdownInput,
-    IntegerInput, FloatInput, RangeInput, RangeSlider,
-    QueriesInput, ProgramaticInput, FunctionInput, SileInput,
-    PlotableInput, SpinSelect, AiidaNodeInput, BandStructureInput
+    TextInput, SwitchInput, ColorPicker,
+    FloatInput, RangeSlider,
+    QueriesInput, FunctionInput, SileInput,
+    SpinSelect, AiidaNodeInput, BandStructureInput
 )
 from ..input_fields.range import ErangeInput
 
+try:
+    import pathos
+    _do_parallel_calc = True
+except:
+    _do_parallel_calc = False
 
 class BandsPlot(Plot):
     """
@@ -123,14 +130,6 @@ class BandsPlot(Plot):
         AiidaNodeInput(key="aiida_bands", name="Aiida BandsData node",
             default=None,
             help="""An aiida BandsData node."""
-        ),
-
-        FunctionInput(key="eigenstate_map", name="Eigenstate map function",
-            default=None,
-            positional=["eigenstate", "plot"],
-            returns=[],
-            help="""This function receives the eigenstate object for each k value when the bands are being extracted from a hamiltonian.
-            You can do whatever you want with it, the point of this function is to avoid running the diagonalization process twice."""
         ),
 
         FunctionInput(key="add_band_data", name="Add band data function",
@@ -281,6 +280,14 @@ class BandsPlot(Plot):
             return [childPlot.get_setting("bands_file").name for childPlot in self.child_plots]
 
         return cls.animated("bands_file", bands_files, frame_names = _get_frame_names, wdir = wdir, **kwargs)
+    
+    @property
+    def bands(self):
+        return self.bands_data["E"]
+
+    @property
+    def spin_moments(self):
+        return self.bands_data["spin_moments"].sel(spin=0)
 
     def _after_init(self):
         self.spin = sisl.Spin("")
@@ -308,7 +315,7 @@ class BandsPlot(Plot):
             tick_info["ticklabels"].append(label)
 
         # Construct the dataarray
-        self.bands = xr.DataArray(
+        self.bands_data = xr.DataArray(
             bands,
             coords={
                 "spin": np.arange(0, bands.shape[0]),
@@ -320,12 +327,10 @@ class BandsPlot(Plot):
         )
 
     @entry_point('band structure')
-    def _read_from_H(self, band_structure, eigenstate_map):
+    def _read_from_H(self, band_structure, extra_vars=()):
         """
         Uses a sisl's `BandStructure` object to calculate the bands.
         """
-        import xarray as xr
-
         if band_structure is None:
             raise ValueError("No band structure (k points path) was provided")
 
@@ -340,24 +345,21 @@ class BandsPlot(Plot):
 
         self.ticks = band_structure.lineartick()
 
-        # We define a wrapper to get the values out of the eigenstates
-        # to give the possibility to the user to do something inbetween
-        # NOTE THAT THIS IS USED BY FAT BANDS TO GET THE WEIGHTS SIMULTANEOUSLY
-        eig_map = eigenstate_map
-
-        # Also, in this wrapper we will get the spin moments in case it is a non_colinear
-        # or spin-orbit calculation
-        if self.spin.is_noncolinear or self.spin.is_spinorbit:
-            self.spin_moments = []
-        elif hasattr(self, "spin_moments"):
-            del self.spin_moments
+        # In case it is a non_colinear or spin-orbit calculation we will get the spin moments
+        if not self.spin.is_diagonal:
+            def _spin_moment_getter(eigenstate, plot, spin):
+                return eigenstate.spin_moment().real
+            
+            extra_vars = ({
+                "coords": ("band", "axis"), "coords_values": dict(axis=["x", "y", "z"]),
+                "name": "spin_moments", "getter": _spin_moment_getter},
+            *extra_vars)
 
         def bands_wrapper(eigenstate, spin_index):
-            if callable(eig_map):
-                eig_map(eigenstate, self, spin_index)
-            if hasattr(self, "spin_moments"):
-                self.spin_moments.append(eigenstate.spin_moment())
-            return eigenstate.eig
+            returns = []
+            for extra_var in extra_vars:
+                returns.append(extra_var["getter"](eigenstate, self, spin_index))
+            return (eigenstate.eig, *returns)
 
         # Define the available spins
         spin_indices = [0]
@@ -366,38 +368,36 @@ class BandsPlot(Plot):
 
         # Get the eigenstates for all the available spin components
         bands_arrays = []
+        name = ["E"]
+        coords = [('band'), ]
+        coords_values = {"spin": spin_indices, "k": band_structure.lineark()}
+        for extra_var in extra_vars:
+            name.append(extra_var["name"])
+            coords.append(extra_var["coords"])
+            coords_values.update(extra_var.get("coords_values", {}))
+
         for spin_index in spin_indices:
 
             # Non collinear routines don't accept the keyword argument "spin"
             spin_kwarg = {"spin": spin_index}
-            if self.spin.is_noncolinear:
+            if not self.spin.is_diagonal:
                 spin_kwarg = {}
-
-            spin_bands = band_structure.apply.dataarray.eigenstate(
-                wrap=partial(bands_wrapper, spin_index=spin_index),
-                **spin_kwarg,
-                coords=('band',),
-            )
+            
+            with band_structure.apply(pool=_do_parallel_calc, unzip=True) as parallel:
+                spin_bands = parallel.dataarray.eigenstate(
+                    wrap=partial(bands_wrapper, spin_index=spin_index),
+                    **spin_kwarg,
+                    coords=coords, name=name,
+                )
 
             bands_arrays.append(spin_bands)
 
-        # Merge everything into a single dataarray with a spin dimension
-        self.bands = xr.concat(bands_arrays, "spin").assign_coords({"spin": spin_indices}).transpose("k", "spin", "band")
+        # Merge everything into a single dataset with a spin dimension
+        self.bands_data = xr.concat(bands_arrays, "spin").assign_coords(coords_values)
 
         self.bands['k'] = band_structure.lineark()
         # Inform of where to place the ticks
-        self.bands.attrs = {"ticks": self.ticks[0], "ticklabels": self.ticks[1], **bands_arrays[0].attrs}
-
-        if hasattr(self, "spin_moments"):
-            self.spin_moments = xr.DataArray(
-                self.spin_moments,
-                coords={
-                    "k": self.bands.k,
-                    "band": self.bands.band,
-                    "axis": ["x", "y", "z"]
-                },
-                dims=("k", "band", "axis")
-            )
+        self.bands_data.attrs = {"ticks": self.ticks[0], "ticklabels": self.ticks[1], **bands_arrays[0].attrs}
 
     @entry_point('bands file')
     def _read_siesta_output(self, bands_file, band_structure):
@@ -407,13 +407,17 @@ class BandsPlot(Plot):
         if band_structure:
             raise ValueError("A path was provided, therefore we can not use the .bands file even if there is one")
 
-        self.bands = self.get_sile(bands_file or "bands_file").read_data(as_dataarray=True)
+        self.bands_data = self.get_sile(bands_file or "bands_file").read_data(as_dataarray=True)
 
         # Define the spin class of the results we have retrieved
-        if len(self.bands.spin.values) == 2:
+        if len(self.bands_data.spin.values) == 2:
             self.spin = sisl.Spin("p")
 
     def _after_read(self):
+        if isinstance(self.bands_data, xr.DataArray):
+            attrs = self.bands_data.attrs
+            self.bands_data = xr.Dataset({"E": self.bands_data})
+            self.bands_data.attrs = attrs
 
         # Inform the spin input of what spin class are we handling
         self.get_param("spin").update_options(self.spin)
@@ -461,7 +465,7 @@ class BandsPlot(Plot):
             self.update_settings(run_updates=False, bands_range=[int(filtered_bands['band'].min()), int(filtered_bands['band'].max())], no_log=True)
 
         # Give the filtered bands the same attributes as the full bands
-        filtered_bands.attrs = self.bands.attrs
+        filtered_bands.attrs = self.bands_data.attrs
 
         # Let's treat the spin if the user requested it
         self.spin_texture = False
@@ -592,9 +596,9 @@ class BandsPlot(Plot):
         try:
             san_k = float(k)
         except ValueError:
-            if k in self.bands.attrs["ticklabels"]:
-                i_tick = self.bands.attrs["ticklabels"].index(k)
-                san_k = self.bands.attrs["ticks"][i_tick]
+            if k in self.bands_data.attrs["ticklabels"]:
+                i_tick = self.bands_data.attrs["ticklabels"].index(k)
+                san_k = self.bands_data.attrs["ticks"][i_tick]
             else:
                 pass
                 # raise ValueError(f"We can not interpret {k} as a k-location in the current bands plot")

--- a/sisl/viz/plots/fatbands.py
+++ b/sisl/viz/plots/fatbands.py
@@ -254,7 +254,9 @@ class FatbandsPlot(BandsPlot):
         weights = weights.expand_dims("spin")
 
         # Merge everything into a dataset
+        attrs = self.bands_data.attrs
         self.bands_data = Dataset({"E": self.bands_data, "weight": weights})
+        self.bands_data.attrs = attrs
 
         # Set up the options for the 'groups' setting based on the plot's associated geometry
         self._set_group_options()

--- a/sisl/viz/plots/fatbands.py
+++ b/sisl/viz/plots/fatbands.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import numpy as np
-from xarray import DataArray
+from xarray import DataArray, Dataset
 
 import sisl
 from ..plot import entry_point
@@ -239,7 +239,7 @@ class FatbandsPlot(BandsPlot):
         weights = np.array(weights).real
 
         # Finally, build the weights dataarray so that it can be used by _set_data
-        self.weights = DataArray(
+        weights = DataArray(
             weights,
             coords={
                 "k": self.bands.k,
@@ -251,7 +251,10 @@ class FatbandsPlot(BandsPlot):
 
         # Add the spin dimension so that the weights array is normalized,
         # even though spin is not yet supported by this entrypoint
-        self.weights = self.weights.expand_dims("spin")
+        weights = weights.expand_dims("spin")
+
+        # Merge everything into a dataset
+        self.bands_data = Dataset({"E": self.bands_data, "weight": weights})
 
         # Set up the options for the 'groups' setting based on the plot's associated geometry
         self._set_group_options()
@@ -381,6 +384,8 @@ class FatbandsPlot(BandsPlot):
 
         if weights is None:
             weights = self.weights
+        if "spin" not in weights.coords:
+            weights = weights.expand_dims("spin")
 
         groups_param = self.get_param("groups")
 

--- a/sisl/viz/plots/pdos.py
+++ b/sisl/viz/plots/pdos.py
@@ -491,10 +491,11 @@ class PdosPlot(Plot):
             return
 
         req_PDOS = E_PDOS.sel(orb=orb)
-        if request['spin'] is not None and 'spin' in req_PDOS.coords:
+        if request['spin'] is not None and 'spin' in req_PDOS.dims:
             req_PDOS = req_PDOS.sel(spin=request['spin'])
 
-        reduce_coords = set(["orb", "spin"]).intersection(req_PDOS.coords)
+        reduce_coords = set(["orb", "spin"]).intersection(req_PDOS.dims)
+
         if request["normalize"]:
             req_PDOS = req_PDOS.mean(reduce_coords)
         else:

--- a/sisl/viz/plots/tests/test_bands.py
+++ b/sisl/viz/plots/tests/test_bands.py
@@ -104,8 +104,8 @@ class TestBandsPlot(_TestPlot):
         # Check that it is a dataarray containing the right information
         bands = plot.bands
         assert isinstance(bands, DataArray)
-        assert bands.dims == ('k', 'spin', 'band')
-        assert bands.shape == test_attrs['bands_shape']
+        assert set(bands.dims) == set(['k', 'spin', 'band'])
+        assert bands.transpose("k", "spin", "band").shape == test_attrs['bands_shape']
 
     def test_bands_in_figure(self, plot, test_attrs):
 
@@ -178,7 +178,7 @@ class TestBandsPlot(_TestPlot):
         # Check that it is a dataarray containing the right information
         spin_moments = plot.spin_moments
         assert isinstance(spin_moments, DataArray)
-        assert spin_moments.dims == ('k', 'band', 'axis')
+        assert set(spin_moments.dims) == set(('k', 'band', 'axis'))
         assert spin_moments.shape == (test_attrs['bands_shape'][0], test_attrs['bands_shape'][-1], 3)
 
     def test_spin_texture(self, plot, test_attrs):

--- a/sisl/viz/plots/tests/test_bands.py
+++ b/sisl/viz/plots/tests/test_bands.py
@@ -28,7 +28,8 @@ class TestBandsPlot(_TestPlot):
         "gap", # Float. The value of the gap in eV
         "ticklabels", # Array-like with the tick labels
         "tickvals", # Array-like with the expected positions of the ticks
-        "spin_texture" # Whether spin texture should be possible to draw or not.
+        "spin_texture", # Whether spin texture should be possible to draw or not.
+        "spin", # The spin class of the calculation
     ]
 
     @pytest.fixture(params=BandsPlot.get_class_param("backend").options)
@@ -47,11 +48,12 @@ class TestBandsPlot(_TestPlot):
             # From a siesta .bands file
             init_func = sisl.get_sile(siesta_test_files("SrTiO3.bands")).plot
             attrs = {
-                "bands_shape": (150, 1, 72),
+                "bands_shape": (150, 72),
                 "ticklabels": ('Gamma', 'X', 'M', 'Gamma', 'R', 'X'),
                 "tickvals": [0.0, 0.429132, 0.858265, 1.465149, 2.208428, 2.815313],
                 "gap": 1.677,
-                "spin_texture": False
+                "spin_texture": False,
+                "spin": sisl.Spin("")
             }
         elif name.startswith("sisl_H"):
             gr = sisl.geom.graphene()
@@ -60,14 +62,14 @@ class TestBandsPlot(_TestPlot):
 
             spin_type = name.split("_")[-1]
             n_spin, H = {
-                "unpolarized": (1, H),
+                "unpolarized": (0, H),
                 "polarized": (2, H.transform(spin=sisl.Spin.POLARIZED)),
-                "noncolinear": (1, H.transform(spin=sisl.Spin.NONCOLINEAR)),
-                "spinorbit": (1, H.transform(spin=sisl.Spin.SPINORBIT))
+                "noncolinear": (0, H.transform(spin=sisl.Spin.NONCOLINEAR)),
+                "spinorbit": (0, H.transform(spin=sisl.Spin.SPINORBIT))
             }.get(spin_type)
 
             n_states = 2
-            if H.spin.is_spinorbit or H.spin.is_noncolinear:
+            if not H.spin.is_diagonal:
                 n_states *= 2
 
             # Let's create the same graphene bands plot using the hamiltonian
@@ -84,11 +86,12 @@ class TestBandsPlot(_TestPlot):
                 init_func = bz.plot
 
             attrs = {
-                "bands_shape": (6, n_spin, n_states),
+                "bands_shape": (6, n_spin, n_states) if n_spin != 0 else (6, n_states),
                 "ticklabels": ["Gamma", "M", "K"],
                 "tickvals": [0., 1.70309799, 2.55464699],
                 "gap": 0,
-                "spin_texture": H.spin.is_spinorbit or H.spin.is_noncolinear
+                "spin_texture": not H.spin.is_diagonal,
+                "spin": H.spin
             }
 
         return init_func, attrs
@@ -104,8 +107,14 @@ class TestBandsPlot(_TestPlot):
         # Check that it is a dataarray containing the right information
         bands = plot.bands
         assert isinstance(bands, DataArray)
-        assert set(bands.dims) == set(['k', 'spin', 'band'])
-        assert bands.transpose("k", "spin", "band").shape == test_attrs['bands_shape']
+
+        if test_attrs["spin"].is_polarized:
+            expected_coords = ('k', 'spin', 'band')
+        else:
+            expected_coords = ('k', 'band')
+
+        assert set(bands.dims) == set(expected_coords)
+        assert bands.transpose(*expected_coords).shape == test_attrs['bands_shape']
 
     def test_bands_in_figure(self, plot, test_attrs):
 

--- a/sisl/viz/plots/tests/test_fatbands.py
+++ b/sisl/viz/plots/tests/test_fatbands.py
@@ -85,6 +85,13 @@ class TestFatbandsPlot(_TestBandsPlot):
             expected_dims = ("k", "band", "orb")
         assert weights.dims == expected_dims
         assert weights.shape == test_attrs["weights_shape"]
+    
+    def test_group_weights(self, plot):
+
+        total_weights = plot._get_group_weights({})
+
+        assert isinstance(total_weights, DataArray)
+        assert set(total_weights.dims) == set(("spin", "band", "k"))
 
     def test_weights_values(self, plot, test_attrs):
         assert np.allclose(plot.weights.sum("orb"), 1), "Weight values do not sum 1 for all states."

--- a/sisl/viz/plots/tests/test_pdos.py
+++ b/sisl/viz/plots/tests/test_pdos.py
@@ -91,6 +91,12 @@ class TestPdosPlot(_TestPlot):
 
         # Check if we have the correct number of orbitals
         assert len(PDOS.orb) == test_attrs["no"] == geom.no
+    
+    def test_request_PDOS(self, plot):
+        total_DOS = plot._get_request_PDOS({})
+
+        assert total_DOS.ndim == 1
+        assert total_DOS.shape == (plot.PDOS.E.shape)
 
     def test_splitDOS(self, plot, test_attrs, inplace_split):
         if inplace_split:


### PR DESCRIPTION
Now if `pathos` is available, PDOS and (fat)bands calculated from a hamiltonian are computed in parallel over k-points using the functionality of the `BrillouinZone` applies.

If someone doesn't want parallelization they can control it through the `SISL_NPROCS` env variable by setting it to `1`, so I didn't add any settings for it.
