### PR TITLE
bug: 2D geometry plots didn't take perspective into account.

### DIFF
--- a/docs/visualization/viz_module/showcase/GeometryPlot.ipynb
+++ b/docs/visualization/viz_module/showcase/GeometryPlot.ipynb
@@ -178,7 +178,7 @@
     "Specifying the axes\n",
     "----------\n",
     "\n",
-    "There are many ways in which you may want to display the coordinates of your geometry. The most common one is to display the cartesian coordinates. You indicate that you want cartesian coordinates by passing `{\"x\", \"y\", \"z\"}`. You can pass them as a list: "
+    "There are many ways in which you may want to display the coordinates of your geometry. The most common one is to display the cartesian coordinates. You indicate that you want cartesian coordinates by passing `(+-){\"x\", \"y\", \"z\"}`. You can pass them as a list: "
    ]
   },
   {
@@ -226,7 +226,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You are not limited to cartesian coordinates though. Passing `{\"a\", \"b\", \"c\"}` will display the fractional coordinates:"
+    "You are not limited to cartesian coordinates though. Passing `(+-){\"a\", \"b\", \"c\"}` will display the fractional coordinates:"
    ]
   },
   {
@@ -292,8 +292,8 @@
    "source": [
     "To summarize the different possibilities:\n",
     "\n",
-    "- `{\"x\", \"y\", \"z\"}`: The **cartesian coordinates** are displayed.\n",
-    "- `{\"a\", \"b\", \"c\"}`: The **fractional coordinates** are displayed. Same for {0,1,2}.\n",
+    "- `(+-){\"x\", \"y\", \"z\"}`: The **cartesian coordinates** are displayed.\n",
+    "- `(+-){\"a\", \"b\", \"c\"}`: The **fractional coordinates** are displayed. Same for {0,1,2}.\n",
     "- `np.array of shape (3, )`: The coordinates are **projected into that direction**. If two directions are passed, the coordinates are not projected to each axis separately. The displayed coordinates are then the coefficients of the linear combination to get that point (or the projection of that point into the plane formed by the two axes).\n",
     "\n",
     "<div class=\"alert alert-warning\">\n",
@@ -301,6 +301,68 @@
     "Some non-obvious behavior\n",
     "    \n",
     "**Fractional coordinates are only displayed if all axes are lattice vectors**. Otherwise, the plot works as if you had passed the direction of the lattice vector. Also, for now, the **3D representation only displays cartesian coordinates**.\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "## 2D perspective\n",
+    "\n",
+    "It is not trivial to notice that the **axes you choose determine what is your point of view**. For example, if you choose to view `\"xy\"`, the `z` axis will be pointing \"outside of the screen\", while if you had chosen `\"yx\"` the `z` axis will point \"inside the screen\". This affects the depth of the atoms, i.e. **which atoms are on top and which are on the bottom**.\n",
+    "\n",
+    "To visualize it, we build a bilayer of graphene and boron nitride:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bilayer = sisl.geom.bilayer(top_atoms=\"C\", bottom_atoms=[\"B\", \"N\"], stacking=\"AA\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we want to see the `\"xy\"` axes, we would be viewing the structure from the top:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bilayer.plot(axes=\"xy\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "but if we set the axes to `yx`, `-xy` or `x-y`, we will see it from the bottom:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bilayer.plot(axes=\"-xy\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That is, we are flipping the geometry. In the above example we are doing it around the Y axis. Notice that **trying to view `xy` from the `-z` perspective would show you a mirrored view** of your structure!\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "    \n",
+    "Non-cartesian axes\n",
+    "    \n",
+    "The above behavior is also true for all valid axes that you can pass. However, we have made lattice vectors follow the same rules as cartesian vectors. That is, `abc` cross products follow the rules of `xyz` cross products. As a result, if you ask for `axes=\"ab\"` you will see the structure from the `c` perspective.\n",
     "\n",
     "</div>"
    ]


### PR DESCRIPTION
This PR addresses the issue raised [here](https://discord.com/channels/742636379871379577/845235607461691402/889459719138320384) on discord.

Perspective wasn't taken into account for drawing atoms in 2D and as a result the atoms on top were just the last atoms in the geometry, not the ones that were actually on top.

Now the perspective is automatically determined by your axes choice. I.e.:

```python
import sisl
import sisl.viz

bilayer = sisl.geom.bilayer(top_atoms="C", bottom_atoms=["B", "N"], stacking="AA")

bilayer.plot(axes="xy")
```
Shows you the view from the top:
![image](https://user-images.githubusercontent.com/42074085/135500382-165913ec-b14b-4f07-a214-7d158897676e.png)

and

```python
bilayer.plot(axes="-xy")
```

Shows you the view from the bottom:
![image](https://user-images.githubusercontent.com/42074085/135500503-f192dd6d-d806-42a6-9aad-58742b0a29d2.png)

This has been added to the documentation. New tests have also been added.