### PR TITLE
enh: optimizing the reading of eigenstates from WFSX file

### DIFF
--- a/sisl/io/siesta/_src/wfsx_read.f90
+++ b/sisl/io/siesta/_src/wfsx_read.f90
@@ -1,28 +1,31 @@
 ! This Source Code Form is subject to the terms of the Mozilla Public
 ! License, v. 2.0. If a copy of the MPL was not distributed with this
 ! file, You can obtain one at https://mozilla.org/MPL/2.0/.
-subroutine read_wfsx_sizes(fname, nspin, no_u, nk, Gamma)
-  use io_m, only: open_file, close_file
+
+! All routines read_wfsx_next_* and skip_wfsx_* expect that the file unit is handled externally.
+! The file unit should already be open and in the correct position.
+! On the other hand, routines with another name manage the opening and closing
+! themselves.
+
+! --------------------------------------------------------------
+!             Routines to read header information
+! --------------------------------------------------------------
+! These routines read the information written at the beggining
+! of the WFSX file.
+
+subroutine read_wfsx_next_sizes(iu, skip_basis, nspin, no_u, nk, Gamma)
   use io_m, only: iostat_update
 
   implicit none
 
   ! Input parameters
-  character(len=*), intent(in) :: fname
+  integer, intent(in) :: iu
+  logical, intent(in) :: skip_basis
   integer, intent(out) :: nspin, no_u, nk
   logical, intent(out) :: Gamma
 
-! Define f2py intents
-!f2py intent(in) :: fname
-!f2py intent(out) :: nspin
-!f2py intent(out) :: no_u
-!f2py intent(out) :: nk
-!f2py intent(out) :: Gamma
-
-! Internal variables and arrays
-  integer :: iu, ierr
-
-  call open_file(fname, 'read', 'old', 'unformatted', iu)
+  ! Internal variables and arrays
+  integer :: ierr
 
   read(iu, iostat=ierr) nk, Gamma
   call iostat_update(ierr)
@@ -33,9 +36,88 @@ subroutine read_wfsx_sizes(fname, nspin, no_u, nk, Gamma)
   read(iu, iostat=ierr) no_u
   call iostat_update(ierr)
 
+  if (skip_basis) then
+    read(iu, iostat=ierr) ! This contains basis information
+    call iostat_update(ierr)
+  endif 
+
+end subroutine read_wfsx_next_sizes
+
+subroutine read_wfsx_sizes(fname, nspin, no_u, nk, Gamma)
+  use io_m, only: open_file, close_file
+
+  implicit none
+
+  ! Input parameters
+  character(len=*), intent(in) :: fname
+  integer, intent(out) :: nspin, no_u, nk
+  logical, intent(out) :: Gamma
+
+  ! Internal variables and arrays
+  integer :: iu, ierr
+
+  call open_file(fname, 'read', 'old', 'unformatted', iu)
+
+  call read_wfsx_next_sizes(iu, .false., nspin, no_u, nk, Gamma)
+
   call close_file(iu)
 
 end subroutine read_wfsx_sizes
+
+subroutine read_wfsx_next_basis(iu, no_u, atom_indices, atom_labels, &
+   orb_index_atom, orb_n, orb_simmetry)  
+    use io_m, only: iostat_update
+  
+    implicit none
+  
+    ! Input parameters
+    integer, intent(in) :: iu, no_u
+    integer, intent(out) :: atom_indices(no_u), orb_index_atom(no_u)
+    character, intent(out) :: atom_labels(no_u, 20), orb_simmetry(no_u, 20)
+    integer, intent(out) :: orb_n(no_u)
+  
+  ! Internal variables and arrays
+    integer :: j, ierr
+  
+    read(iu, iostat=ierr) (atom_indices(j), atom_labels(j, :), orb_index_atom(j), &
+                 orb_n(j), orb_simmetry(j, :), j=1,no_u)
+
+    call iostat_update(ierr)
+  
+end subroutine read_wfsx_next_basis
+
+! --------------------------------------------------------------
+!             Routines to read k point information
+! --------------------------------------------------------------
+! These routines read the information for a given k point in the
+! WFSX file.
+
+subroutine read_wfsx_next_info(iu, ispin, ik, k, kw, nwf)
+    use io_m, only: iostat_update
+  
+    implicit none
+  
+    integer, parameter :: dp = selected_real_kind(p=15)
+  
+    ! Input parameters
+    integer, intent(in) :: iu
+    integer, intent(out) :: ispin, ik
+    real(dp), intent(out) :: k(3), kw
+    integer, intent(out) :: nwf
+  
+    integer :: i
+  ! Internal variables and arrays
+    integer :: ierr
+  
+    ! read information here
+    read(iu, iostat=ierr) ik, k, kw
+    call iostat_update(ierr)
+    read(iu, iostat=ierr) ispin
+    call iostat_update(ierr)
+    read(iu, iostat=ierr) nwf
+    call iostat_update(ierr)
+  
+end subroutine read_wfsx_next_info
 
 subroutine read_wfsx_index_info(fname, ispin, ik, k, kw, nwf)
   use io_m, only: open_file, close_file
@@ -51,112 +133,22 @@ subroutine read_wfsx_index_info(fname, ispin, ik, k, kw, nwf)
   real(dp), intent(out) :: k(3), kw
   integer, intent(out) :: nwf
 
-! Define f2py intents
-!f2py intent(in) :: fname
-!f2py intent(in) :: ispin
-!f2py intent(in) :: ik
-!f2py intent(out) :: k
-!f2py intent(out) :: kw
-!f2py intent(out) :: nwf
-
   integer :: i
-! Internal variables and arrays
+  integer :: file_ispin, file_ik
+  ! Internal variables and arrays
   integer :: iu, ierr
 
   call open_file(fname, 'read', 'old', 'unformatted', iu)
 
   call skip_wfsx_index(iu, ispin, ik)
 
-  ! read information here
-  read(iu, iostat=ierr) i, k, kw
-  call iostat_update(ierr)
-  read(iu, iostat=ierr) ! ispin
-  call iostat_update(ierr)
-  read(iu, iostat=ierr) nwf
-  call iostat_update(ierr)
+  call read_wfsx_next_info(iu, file_ispin, file_ik, k, kw, nwf)
 
   call close_file(iu)
 
 end subroutine read_wfsx_index_info
 
-subroutine skip_wfsx_index(iu, ispin, ik)
-  use io_m, only: open_file, close_file
-  use io_m, only: iostat_update
-
-  implicit none
-
-  integer, parameter :: sp = selected_real_kind(p=6)
-  integer, parameter :: dp = selected_real_kind(p=15)
-
-  ! Input parameters
-  integer, intent(in) :: iu
-  integer, intent(in) :: ispin, ik
-
-! Define f2py intents
-!f2py intent(in) :: iu
-!f2py intent(in) :: ispin, ik
-
-  integer :: no_u
-  integer :: nk, spin, i, j
-! Internal variables and arrays
-  integer :: ierr
-
-  read(iu, iostat=ierr) nk !, is_gamma
-  call iostat_update(ierr)
-  if ( ik > nk ) then
-    call iostat_update(-1)
-  end if
-
-  read(iu, iostat=ierr) spin
-  call iostat_update(ierr)
-  if ( ispin > spin ) then
-    call iostat_update(-2)
-  end if
-
-  read(iu, iostat=ierr) no_u
-  call iostat_update(ierr)
-
-  read(iu, iostat=ierr) ! basis-information
-  call iostat_update(ierr)
-
-  ! Read pass the spin
-  do j = 1 , ispin - 1
-    do i = 1 , nk
-      call skip_k()
-    end do
-  end do
-
-  ! skip the indices not requested
-  do i = 1 , ik - 1
-    call skip_k()
-  end do
-
-contains
-
-  subroutine skip_k()
-    integer :: nwf, iwf
-
-    read(iu, iostat=ierr) ! ik, k, kw
-    call iostat_update(ierr)
-    read(iu, iostat=ierr) ! ispin
-    call iostat_update(ierr)
-    read(iu, iostat=ierr) nwf
-    call iostat_update(ierr)
-
-    do iwf = 1, nwf
-      read(iu, iostat=ierr) ! indwf
-      call iostat_update(ierr)
-      read(iu, iostat=ierr) ! eig [eV]
-      call iostat_update(ierr)
-      read(iu, iostat=ierr) ! state
-      call iostat_update(ierr)
-    end do
-
-  end subroutine skip_k
-
-end subroutine skip_wfsx_index
-
-subroutine read_wfsx_index_check(iu, ispin, ik, nwf, fail)
+subroutine read_wfsx_next_index_check(iu, ispin, ik, nwf, fail)
   use io_m, only: iostat_update, iostat_query
 
   implicit none
@@ -186,7 +178,184 @@ subroutine read_wfsx_index_check(iu, ispin, ik, nwf, fail)
     fail = -3
   end if
 
-end subroutine read_wfsx_index_check
+end subroutine read_wfsx_next_index_check
+
+! --------------------------------------------------------------
+!               Routines that skip over things
+! --------------------------------------------------------------
+! Useful if we want to ignore contents of the file. This routines
+! ALWAYS depend on the file unit being handled externally.
+
+subroutine skip_wfsx_next_eigenstate(iu)
+  use io_m, only: iostat_update
+
+  integer, intent(in) :: iu
+
+  integer :: nwf
+
+  read(iu, iostat=ierr) ! ik, k, kw
+  call iostat_update(ierr)
+  read(iu, iostat=ierr) ! ispin
+  call iostat_update(ierr)
+  read(iu, iostat=ierr) nwf
+  call iostat_update(ierr)
+
+  call skip_wfsx_next_vals(iu, nwf)
+
+end subroutine skip_wfsx_next_eigenstate
+
+subroutine skip_wfsx_next_vals(iu, nwf)
+  use io_m, only: iostat_update
+
+  integer, intent(in) :: iu, nwf
+
+  integer :: iwf
+
+  do iwf = 1, nwf
+    read(iu, iostat=ierr) ! indwf
+    call iostat_update(ierr)
+    read(iu, iostat=ierr) ! eig [eV]
+    call iostat_update(ierr)
+    read(iu, iostat=ierr) ! state
+    call iostat_update(ierr)
+  end do
+
+end subroutine skip_wfsx_next_vals
+
+subroutine skip_wfsx_index(iu, ispin, ik)
+  use io_m, only: iostat_update
+
+  implicit none
+
+  ! Input parameters
+  integer, intent(in) :: iu
+  integer, intent(in) :: ispin, ik
+
+  ! Internal variables
+  integer :: no_u
+  integer :: nk, nspin, i, j
+  logical :: Gamma
+
+  call read_wfsx_next_sizes(iu, .true., nspin, no_u, nk, Gamma)
+
+  ! Check that the requested indices make sense
+  if ( ik > nk ) call iostat_update(-1)
+  if ( ispin > nspin ) call iostat_update(-2)
+
+  ! Skip until the k index that we need
+  do i = 1 , ik - 1
+    do j = 1 , nspin
+      call skip_wfsx_next_eigenstate(iu)
+    end do
+  end do
+
+  ! Skip until the desired spin index
+  do i = 1 , ispin - 1
+    call skip_wfsx_next_eigenstate(iu)
+  end do
+
+end subroutine skip_wfsx_index
+
+! --------------------------------------------------------------
+!             Routines that read the next values
+! --------------------------------------------------------------
+! There are three different cases:
+! - 1: When only the gamma point is in the WFSX file. The state
+!   is in a real array.
+! - 2: All other cases where spin is not non-colinear. The state 
+!   is in a complex array.
+! - 4: For non-colinear spins. The state's first dimension is two
+!   times larger than the number of actual orbitals in the system.
+
+subroutine read_wfsx_next_1(iu, no_u, nwf, idx, eig, state)
+  use io_m, only: iostat_update
+
+  implicit none
+
+  integer, parameter :: sp = selected_real_kind(p=6)
+  integer, parameter :: dp = selected_real_kind(p=15)
+
+  ! Input parameters
+  integer, intent(in) :: iu
+  integer, intent(in) :: no_u, nwf
+  integer, intent(out) :: idx(nwf)
+  real(dp), intent(out) :: eig(nwf)
+  real(sp), intent(out) :: state(no_u, nwf)
+
+  integer :: iwf
+  ! Internal variables and arrays
+  integer :: ierr
+
+  do iwf = 1, nwf
+    read(iu, iostat=ierr) idx(iwf)
+    call iostat_update(ierr)
+    read(iu, iostat=ierr) eig(iwf)
+    call iostat_update(ierr)
+    read(iu, iostat=ierr) state(:,iwf)
+    call iostat_update(ierr)
+  end do
+
+end subroutine read_wfsx_next_1
+
+subroutine read_wfsx_next_2(iu, no_u, nwf, idx, eig, state)
+  use io_m, only: iostat_update
+
+  implicit none
+
+  integer, parameter :: sp = selected_real_kind(p=6)
+  integer, parameter :: dp = selected_real_kind(p=15)
+
+  ! Input parameters
+  integer, intent(in) :: iu
+  integer, intent(in) :: no_u, nwf
+  integer, intent(out) :: idx(nwf)
+  real(dp), intent(out) :: eig(nwf)
+  complex(sp), intent(out) :: state(no_u, nwf)
+
+  integer :: iwf
+  ! Internal variables and arrays
+  integer :: ierr
+
+  do iwf = 1, nwf
+    read(iu, iostat=ierr) idx(iwf)
+    call iostat_update(ierr)
+    read(iu, iostat=ierr) eig(iwf)
+    call iostat_update(ierr)
+    read(iu, iostat=ierr) state(:,iwf)
+    call iostat_update(ierr)
+  end do
+
+end subroutine read_wfsx_next_2
+
+subroutine read_wfsx_next_4(iu, no_u, nwf, idx, eig, state)
+  use io_m, only: iostat_update
+
+  implicit none
+
+  integer, parameter :: sp = selected_real_kind(p=6)
+  integer, parameter :: dp = selected_real_kind(p=15)
+
+  ! Input parameters
+  integer, intent(in) :: iu
+  integer, intent(in) :: no_u, nwf
+  integer, intent(out) :: idx(nwf)
+  real(dp), intent(out) :: eig(nwf)
+  complex(sp), intent(out) :: state(2*no_u, nwf)
+
+  integer :: iwf
+  ! Internal variables and arrays
+  integer :: ierr
+
+  do iwf = 1, nwf
+    read(iu, iostat=ierr) idx(iwf)
+    call iostat_update(ierr)
+    read(iu, iostat=ierr) eig(iwf)
+    call iostat_update(ierr)
+    read(iu, iostat=ierr) state(:,iwf)
+    call iostat_update(ierr)
+  end do
+
+end subroutine read_wfsx_next_4
 
 subroutine read_wfsx_index_1(fname, ispin, ik, no_u, nwf, idx, eig, state)
   use io_m, only: open_file, close_file
@@ -204,34 +373,22 @@ subroutine read_wfsx_index_1(fname, ispin, ik, no_u, nwf, idx, eig, state)
   real(dp), intent(out) :: eig(nwf)
   real(sp), intent(out) :: state(no_u, nwf)
 
-! Define f2py intents
-!f2py intent(in) :: fname
-!f2py intent(in) :: ispin, ik, no_u, nwf
-!f2py intent(out) :: idx, eig, state
-
   integer :: iwf
-! Internal variables and arrays
+  ! Internal variables and arrays
   integer :: iu, ierr
 
   call open_file(fname, 'read', 'old', 'unformatted', iu)
 
   call skip_wfsx_index(iu, ispin, ik)
 
-  call read_wfsx_index_check(iu, ispin, ik, nwf, ierr)
+  call read_wfsx_next_index_check(iu, ispin, ik, nwf, ierr)
   if ( ierr /= 0 ) then
     call iostat_update(ierr)
     call close_file(iu)
     return
   end if
 
-  do iwf = 1, nwf
-    read(iu, iostat=ierr) idx(iwf)
-    call iostat_update(ierr)
-    read(iu, iostat=ierr) eig(iwf)
-    call iostat_update(ierr)
-    read(iu, iostat=ierr) state(:,iwf)
-    call iostat_update(ierr)
-  end do
+  call read_wfsx_next_1(iu, no_u, nwf, idx, eig, state)
 
   call close_file(iu)
 
@@ -253,34 +410,22 @@ subroutine read_wfsx_index_2(fname, ispin, ik, no_u, nwf, idx, eig, state)
   real(dp), intent(out) :: eig(nwf)
   complex(sp), intent(out) :: state(no_u, nwf)
 
-! Define f2py intents
-!f2py intent(in) :: fname
-!f2py intent(in) :: ispin, ik, no_u, nwf
-!f2py intent(out) :: idx, eig, state
-
   integer :: iwf
-! Internal variables and arrays
+  ! Internal variables and arrays
   integer :: iu, ierr
 
   call open_file(fname, 'read', 'old', 'unformatted', iu)
 
   call skip_wfsx_index(iu, ispin, ik)
 
-  call read_wfsx_index_check(iu, ispin, ik, nwf, ierr)
+  call read_wfsx_next_index_check(iu, ispin, ik, nwf, ierr)
   if ( ierr /= 0 ) then
     call iostat_update(ierr)
     call close_file(iu)
     return
   end if
 
-  do iwf = 1, nwf
-    read(iu, iostat=ierr) idx(iwf)
-    call iostat_update(ierr)
-    read(iu, iostat=ierr) eig(iwf)
-    call iostat_update(ierr)
-    read(iu, iostat=ierr) state(:,iwf)
-    call iostat_update(ierr)
-  end do
+  call read_wfsx_next_2(iu, no_u, nwf, idx, eig, state)
 
   call close_file(iu)
 
@@ -302,35 +447,60 @@ subroutine read_wfsx_index_4(fname, ispin, ik, no_u, nwf, idx, eig, state)
   real(dp), intent(out) :: eig(nwf)
   complex(sp), intent(out) :: state(2*no_u, nwf)
 
-! Define f2py intents
-!f2py intent(in) :: fname
-!f2py intent(in) :: ispin, ik, no_u, nwf
-!f2py intent(out) :: idx, eig, state
-
   integer :: iwf
-! Internal variables and arrays
+  ! Internal variables and arrays
   integer :: iu, ierr
 
   call open_file(fname, 'read', 'old', 'unformatted', iu)
 
   call skip_wfsx_index(iu, ispin, ik)
 
-  call read_wfsx_index_check(iu, ispin, ik, nwf, ierr)
+  call read_wfsx_next_index_check(iu, ispin, ik, nwf, ierr)
   if ( ierr /= 0 ) then
     call iostat_update(ierr)
     call close_file(iu)
     return
   end if
 
-  do iwf = 1, nwf
-    read(iu, iostat=ierr) idx(iwf)
-    call iostat_update(ierr)
-    read(iu, iostat=ierr) eig(iwf)
-    call iostat_update(ierr)
-    read(iu, iostat=ierr) state(:,iwf)
-    call iostat_update(ierr)
-  end do
+  call read_wfsx_next_4(iu, no_u, nwf, idx, eig, state)
 
   call close_file(iu)
 
 end subroutine read_wfsx_index_4
+
+! --------------------------------------------------------------
+!   Routines that read the information of all k points
+! --------------------------------------------------------------
+! They skip the actual values of the eigenstates and might be
+! useful to check the contents of the file.
+
+subroutine read_wfsx_next_all_info(iu, nspin, nk, ks, kw, nwf)
+  ! This function should be called after reading sizes.
+  ! It reads the k value, weight and number of wavefunctions
+  ! of all the k points in the file.
+  use io_m, only: iostat_update
+
+  implicit none
+
+  integer, parameter :: dp = selected_real_kind(p=15)
+
+  ! Input parameters
+  integer, intent(in) :: iu
+  integer, intent(in) :: nspin, nk
+  real(dp), intent(out) :: ks(nk, 3), kw(nk)
+  integer, intent(out) :: nwf(nspin, nk)
+
+  ! Internal variables and arrays
+  integer :: ik, ispin, file_ik, file_ispin
+
+  do ik = 1 , nk
+    do ispin = 1, nspin
+      ! Notice that if there is more than one spin, we write more than once
+      ! to the same position. It doesn't matter, since the k value and the k weight
+      ! is the same for all spin indices.
+      call read_wfsx_next_info(iu, file_ispin, file_ik, ks(ik, :), kw(ik), nwf(ispin, ik))
+      call skip_wfsx_next_vals(iu, nwf(ispin, ik))
+    end do
+  end do
+
+end subroutine read_wfsx_next_all_info

--- a/sisl/io/siesta/_src/wfsx_read.f90
+++ b/sisl/io/siesta/_src/wfsx_read.f90
@@ -54,7 +54,7 @@ subroutine read_wfsx_sizes(fname, nspin, no_u, nk, Gamma)
   logical, intent(out) :: Gamma
 
   ! Internal variables and arrays
-  integer :: iu, ierr
+  integer :: iu
 
   call open_file(fname, 'read', 'old', 'unformatted', iu)
 
@@ -67,23 +67,23 @@ end subroutine read_wfsx_sizes
 subroutine read_wfsx_next_basis(iu, no_u, atom_indices, atom_labels, &
    orb_index_atom, orb_n, orb_simmetry)  
     use io_m, only: iostat_update
-  
+
     implicit none
-  
+
     ! Input parameters
     integer, intent(in) :: iu, no_u
     integer, intent(out) :: atom_indices(no_u), orb_index_atom(no_u)
     character, intent(out) :: atom_labels(no_u, 20), orb_simmetry(no_u, 20)
     integer, intent(out) :: orb_n(no_u)
-  
+
   ! Internal variables and arrays
     integer :: j, ierr
-  
+
     read(iu, iostat=ierr) (atom_indices(j), atom_labels(j, :), orb_index_atom(j), &
                  orb_n(j), orb_simmetry(j, :), j=1,no_u)
 
     call iostat_update(ierr)
-  
+
 end subroutine read_wfsx_next_basis
 
 ! --------------------------------------------------------------
@@ -94,21 +94,20 @@ end subroutine read_wfsx_next_basis
 
 subroutine read_wfsx_next_info(iu, ispin, ik, k, kw, nwf)
     use io_m, only: iostat_update
-  
+
     implicit none
-  
+
     integer, parameter :: dp = selected_real_kind(p=15)
-  
+
     ! Input parameters
     integer, intent(in) :: iu
     integer, intent(out) :: ispin, ik
     real(dp), intent(out) :: k(3), kw
     integer, intent(out) :: nwf
-  
-    integer :: i
+
   ! Internal variables and arrays
     integer :: ierr
-  
+
     ! read information here
     read(iu, iostat=ierr) ik, k, kw
     call iostat_update(ierr)
@@ -116,7 +115,7 @@ subroutine read_wfsx_next_info(iu, ispin, ik, k, kw, nwf)
     call iostat_update(ierr)
     read(iu, iostat=ierr) nwf
     call iostat_update(ierr)
-  
+
 end subroutine read_wfsx_next_info
 
 subroutine read_wfsx_index_info(fname, ispin, ik, k, kw, nwf)
@@ -133,10 +132,9 @@ subroutine read_wfsx_index_info(fname, ispin, ik, k, kw, nwf)
   real(dp), intent(out) :: k(3), kw
   integer, intent(out) :: nwf
 
-  integer :: i
   integer :: file_ispin, file_ik
   ! Internal variables and arrays
-  integer :: iu, ierr
+  integer :: iu
 
   call open_file(fname, 'read', 'old', 'unformatted', iu)
 
@@ -373,7 +371,6 @@ subroutine read_wfsx_index_1(fname, ispin, ik, no_u, nwf, idx, eig, state)
   real(dp), intent(out) :: eig(nwf)
   real(sp), intent(out) :: state(no_u, nwf)
 
-  integer :: iwf
   ! Internal variables and arrays
   integer :: iu, ierr
 
@@ -410,7 +407,6 @@ subroutine read_wfsx_index_2(fname, ispin, ik, no_u, nwf, idx, eig, state)
   real(dp), intent(out) :: eig(nwf)
   complex(sp), intent(out) :: state(no_u, nwf)
 
-  integer :: iwf
   ! Internal variables and arrays
   integer :: iu, ierr
 
@@ -447,7 +443,6 @@ subroutine read_wfsx_index_4(fname, ispin, ik, no_u, nwf, idx, eig, state)
   real(dp), intent(out) :: eig(nwf)
   complex(sp), intent(out) :: state(2*no_u, nwf)
 
-  integer :: iwf
   ! Internal variables and arrays
   integer :: iu, ierr
 
@@ -492,9 +487,12 @@ subroutine read_wfsx_next_all_info(iu, nspin, nk, ks, kw, nwf)
 
   ! Internal variables and arrays
   integer :: ik, ispin, file_ik, file_ispin
+  integer :: l_nspin
+
+  l_nspin = size(nwf, 1)
 
   do ik = 1 , nk
-    do ispin = 1, nspin
+    do ispin = 1, l_nspin
       ! Notice that if there is more than one spin, we write more than once
       ! to the same position. It doesn't matter, since the k value and the k weight
       ! is the same for all spin indices.

--- a/sisl/io/siesta/binaries.py
+++ b/sisl/io/siesta/binaries.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from numbers import Integral
-from itertools import product, groupby
+from itertools import product
 from collections import deque
 import numpy as np
 from numpy import pi
@@ -14,10 +14,10 @@ except Exception as e:
     print(e)
     found_module = False
 
-from ..sile import add_sile, SileError
+from ..sile import add_sile, SileError, SileWarning
 from .sile import SileBinSiesta
 from sisl._internal import set_module
-from sisl.messages import warn, SislError
+from sisl.messages import info, warn, SislError
 
 from ._help import *
 import sisl._array as _a
@@ -27,6 +27,7 @@ from sisl.sparse import _ncol_to_indptr
 from sisl.unit.siesta import unit_convert
 from sisl.physics.sparse import SparseOrbitalBZ
 from sisl.physics import Hamiltonian, DensityMatrix, EnergyDensityMatrix
+from sisl.physics import BrillouinZone
 from sisl.physics.overlap import Overlap
 from sisl.physics.electron import EigenstateElectron
 
@@ -41,12 +42,6 @@ __all__ += ['tsgfSileSiesta']
 _Bohr2Ang = unit_convert('Bohr', 'Ang')
 _Ry2eV = unit_convert('Ry', 'eV')
 _eV2Ry = unit_convert('eV', 'Ry')
-
-
-def _bin_check(obj, method, message):
-    ierr = _siesta.io_m.iostat_query()
-    if ierr != 0:
-        raise SileError(f'{obj!s}.{method} {message} (ierr={ierr})')
 
 
 def _toF(array, dtype, scale=None):
@@ -142,9 +137,9 @@ class onlysSileSiesta(SileBinSiesta):
     def read_supercell(self):
         """ Returns a SuperCell object from a TranSiesta file """
         n_s = _siesta.read_tshs_sizes(self.file)[3]
-        _bin_check(self, 'read_supercell', 'could not read sizes.')
+        self._bin_check('read_supercell', 'could not read sizes.')
         arr = _siesta.read_tshs_cell(self.file, n_s)
-        _bin_check(self, 'read_supercell', 'could not read cell.')
+        self._bin_check('read_supercell', 'could not read cell.')
         nsc = np.array(arr[0], np.int32)
         # We have to transpose since the data is read *as-is*
         # The cell in fortran files are (:, A1)
@@ -162,9 +157,9 @@ class onlysSileSiesta(SileBinSiesta):
         sc = self.read_supercell()
 
         na = _siesta.read_tshs_sizes(self.file)[1]
-        _bin_check(self, 'read_geometry', 'could not read sizes.')
+        self._bin_check('read_geometry', 'could not read sizes.')
         arr = _siesta.read_tshs_geom(self.file, na)
-        _bin_check(self, 'read_geometry', 'could not read geometry.')
+        self._bin_check('read_geometry', 'could not read geometry.')
         # see onlysSileSiesta.read_supercell for .T
         xyz = arr[0].T * _Bohr2Ang
         lasto = arr[1]
@@ -216,14 +211,14 @@ class onlysSileSiesta(SileBinSiesta):
 
         # read the sizes used...
         sizes = _siesta.read_tshs_sizes(self.file)
-        _bin_check(self, 'read_overlap', 'could not read sizes.')
+        self._bin_check('read_overlap', 'could not read sizes.')
         # see onlysSileSiesta.read_supercell for .T
         isc = _siesta.read_tshs_cell(self.file, sizes[3])[2].T
-        _bin_check(self, 'read_overlap', 'could not read cell.')
+        self._bin_check('read_overlap', 'could not read cell.')
         no = sizes[2]
         nnz = sizes[4]
         ncol, col, dS = _siesta.read_tshs_s(self.file, no, nnz)
-        _bin_check(self, 'read_overlap', 'could not read overlap matrix.')
+        self._bin_check('read_overlap', 'could not read overlap matrix.')
 
         # Create the Hamiltonian container
         S = Overlap(geom, nnzpr=1)
@@ -255,7 +250,7 @@ class onlysSileSiesta(SileBinSiesta):
         Ef : fermi-level of the system
         """
         Ef = _siesta.read_tshs_ef(self.file) * _Ry2eV
-        _bin_check(self, 'read_fermi_level', 'could not read fermi-level.')
+        self._bin_check('read_fermi_level', 'could not read fermi-level.')
         return Ef
 
 
@@ -270,15 +265,15 @@ class tshsSileSiesta(onlysSileSiesta):
 
         # read the sizes used...
         sizes = _siesta.read_tshs_sizes(self.file)
-        _bin_check(self, 'read_hamiltonian', 'could not read sizes.')
+        self._bin_check('read_hamiltonian', 'could not read sizes.')
         # see onlysSileSiesta.read_supercell for .T
         isc = _siesta.read_tshs_cell(self.file, sizes[3])[2].T
-        _bin_check(self, 'read_hamiltonian', 'could not read cell.')
+        self._bin_check('read_hamiltonian', 'could not read cell.')
         spin = sizes[0]
         no = sizes[2]
         nnz = sizes[4]
         ncol, col, dH, dS = _siesta.read_tshs_hs(self.file, spin, no, nnz)
-        _bin_check(self, 'read_hamiltonian', 'could not read Hamiltonian and overlap matrix.')
+        self._bin_check('read_hamiltonian', 'could not read Hamiltonian and overlap matrix.')
 
         # Check whether it is an orthogonal basis set
         orthogonal = np.abs(dS).sum() == geom.no
@@ -362,7 +357,7 @@ class tshsSileSiesta(onlysSileSiesta):
                               csr.ncol, csr.col + 1,
                               _toF(h, np.float64, _eV2Ry), _toF(s, np.float64),
                               isc)
-        _bin_check(self, 'write_hamiltonian', 'could not write Hamiltonian and overlap matrix.')
+        self._bin_check('write_hamiltonian', 'could not write Hamiltonian and overlap matrix.')
 
 
 @set_module("sisl.io.siesta")
@@ -374,10 +369,10 @@ class dmSileSiesta(SileBinSiesta):
 
         # Now read the sizes used...
         spin, no, nsc, nnz = _siesta.read_dm_sizes(self.file)
-        _bin_check(self, 'read_density_matrix', 'could not read density matrix sizes.')
+        self._bin_check('read_density_matrix', 'could not read density matrix sizes.')
 
         ncol, col, dDM = _siesta.read_dm(self.file, spin, no, nsc, nnz)
-        _bin_check(self, 'read_density_matrix', 'could not read density matrix.')
+        self._bin_check('read_density_matrix', 'could not read density matrix.')
 
         # Try and immediately attach a geometry
         geom = kwargs.get('geometry', kwargs.get('geom', None))
@@ -448,7 +443,7 @@ class dmSileSiesta(SileBinSiesta):
         nsc = DM.geometry.sc.nsc.astype(np.int32)
 
         _siesta.write_dm(self.file, nsc, csr.ncol, csr.col + 1, _toF(dm, np.float64))
-        _bin_check(self, 'write_density_matrix', 'could not write density matrix.')
+        self._bin_check('write_density_matrix', 'could not write density matrix.')
 
 
 @set_module("sisl.io.siesta")
@@ -460,9 +455,9 @@ class tsdeSileSiesta(dmSileSiesta):
 
         # Now read the sizes used...
         spin, no, nsc, nnz = _siesta.read_tsde_sizes(self.file)
-        _bin_check(self, 'read_energy_density_matrix', 'could not read energy density matrix sizes.')
+        self._bin_check('read_energy_density_matrix', 'could not read energy density matrix sizes.')
         ncol, col, dEDM = _siesta.read_tsde_edm(self.file, spin, no, nsc, nnz)
-        _bin_check(self, 'read_energy_density_matrix', 'could not read energy density matrix.')
+        self._bin_check('read_energy_density_matrix', 'could not read energy density matrix.')
 
         # Try and immediately attach a geometry
         geom = kwargs.get('geometry', kwargs.get('geom', None))
@@ -515,7 +510,7 @@ class tsdeSileSiesta(dmSileSiesta):
         Ef : fermi-level of the system
         """
         Ef = _siesta.read_tsde_ef(self.file) * _Ry2eV
-        _bin_check(self, 'read_fermi_level', 'could not read fermi-level.')
+        self._bin_check('read_fermi_level', 'could not read fermi-level.')
         return Ef
 
     def write_density_matrices(self, DM, EDM, Ef=0., **kwargs):
@@ -567,7 +562,7 @@ class tsdeSileSiesta(dmSileSiesta):
         _siesta.write_tsde_dm_edm(self.file, nsc, DMcsr.ncol, DMcsr.col + 1,
                                   _toF(dm, np.float64),
                                   _toF(edm, np.float64, _eV2Ry), Ef * _eV2Ry)
-        _bin_check(self, 'write_density_matrices', 'could not write DM + EDM matrices.')
+        self._bin_check('write_density_matrices', 'could not write DM + EDM matrices.')
 
 
 @set_module("sisl.io.siesta")
@@ -875,7 +870,7 @@ class hsxSileSiesta(SileBinSiesta):
         """ Reads basis set and geometry information from the HSX file """
         # Now read the sizes used...
         no, na, nspecies = _siesta.read_hsx_specie_sizes(self.file)
-        _bin_check(self, 'read_geometry', 'could not read specie sizes.')
+        self._bin_check('read_geometry', 'could not read specie sizes.')
         # Read specie information
         labels, val_q, norbs, isa = _siesta.read_hsx_species(self.file, nspecies, no, na)
         # convert to proper string
@@ -884,7 +879,7 @@ class hsxSileSiesta(SileBinSiesta):
         labels = list(map(lambda s: b''.join(s).decode('utf-8').strip(),
                           labels.tolist())
         )
-        _bin_check(self, 'read_geometry', 'could not read species.')
+        self._bin_check('read_geometry', 'could not read species.')
         # to python index
         isa -= 1
 
@@ -923,7 +918,7 @@ class hsxSileSiesta(SileBinSiesta):
         atoms = []
         for ispecie in range(nspecies):
             n_l_zeta = _siesta.read_hsx_specie(self.file, ispecie+1, norbs[ispecie])
-            _bin_check(self, 'read_geometry', f'could not read specie {ispecie}.')
+            self._bin_check('read_geometry', f'could not read specie {ispecie}.')
             # create orbital
             # no shell will have l>5, so m=10 should be more than enough
             m = 10
@@ -940,11 +935,11 @@ class hsxSileSiesta(SileBinSiesta):
 
         # now read in xij to retrieve atomic positions
         Gamma, spin, no, no_s, nnz = _siesta.read_hsx_sizes(self.file)
-        _bin_check(self, 'read_geometry', 'could not read matrix sizes.')
+        self._bin_check('read_geometry', 'could not read matrix sizes.')
         ncol, col, _, dxij = _siesta.read_hsx_sx(self.file, Gamma, spin, no, no_s, nnz)
         dxij = dxij.T * _Bohr2Ang
         col -= 1
-        _bin_check(self, 'read_geometry', 'could not read xij matrix.')
+        self._bin_check('read_geometry', 'could not read xij matrix.')
 
         # now create atoms object
         atoms = Atoms([atoms[ia] for ia in isa])
@@ -956,11 +951,11 @@ class hsxSileSiesta(SileBinSiesta):
 
         # Now read the sizes used...
         Gamma, spin, no, no_s, nnz = _siesta.read_hsx_sizes(self.file)
-        _bin_check(self, 'read_hamiltonian', 'could not read Hamiltonian sizes.')
+        self._bin_check('read_hamiltonian', 'could not read Hamiltonian sizes.')
         ncol, col, dH, dS, dxij = _siesta.read_hsx_hsx(self.file, Gamma, spin, no, no_s, nnz)
         dxij = dxij.T * _Bohr2Ang
         col -= 1
-        _bin_check(self, 'read_hamiltonian', 'could not read Hamiltonian.')
+        self._bin_check('read_hamiltonian', 'could not read Hamiltonian.')
 
         ptr = _ncol_to_indptr(ncol)
         xij = SparseCSR((dxij, col, ptr), shape=(no, no_s))
@@ -997,11 +992,11 @@ class hsxSileSiesta(SileBinSiesta):
         """ Returns the overlap matrix from the siesta.HSX file """
         # Now read the sizes used...
         Gamma, spin, no, no_s, nnz = _siesta.read_hsx_sizes(self.file)
-        _bin_check(self, 'read_overlap', 'could not read overlap matrix sizes.')
+        self._bin_check('read_overlap', 'could not read overlap matrix sizes.')
         ncol, col, dS, dxij = _siesta.read_hsx_sx(self.file, Gamma, spin, no, no_s, nnz)
         dxij = dxij.T * _Bohr2Ang
         col -= 1
-        _bin_check(self, 'read_overlap', 'could not read overlap matrix.')
+        self._bin_check('read_overlap', 'could not read overlap matrix.')
 
         ptr = _ncol_to_indptr(ncol)
         xij = SparseCSR((dxij, col, ptr), shape=(no, no_s))
@@ -1035,18 +1030,485 @@ class hsxSileSiesta(SileBinSiesta):
 
 @set_module("sisl.io.siesta")
 class wfsxSileSiesta(SileBinSiesta):
-    r""" Binary WFSX file reader for Siesta """
+    r""" Binary WFSX file reader for Siesta
+    
+    All _read_next_* methods expect the fortran file unit to be handled
+    and that the position in the file is correct. 
+    """
 
-    def yield_eigenstate(self, parent=None):
+    def _open_wfsx(self, mode, rewind=False):
+        """Open the file unit for the WFSX file.
+        
+        Here we also initialize some variables to keep track of the state of the read.
+        """
+        self._open_fortran_unit(mode, rewind=rewind)
+        # Here we initialize the variables that will keep track of the state of the read.
+        # The process for identification is done on this basis:
+        #  _ik is the current (Python) index for the k-point to be read
+        #  _ispin is the current (Python) index for the spin-index to be read (only has meaning for a spin-polarized
+        #         WFSX files)
+        #  _state is:
+        #        -1 : the file-descriptor has just been opened (i.e. in front of header)
+        #         0 : it means that the file-descriptor is in front of basis information
+        #         1 : it means that the file-descriptor is in front of k point information
+        #         2 : it means that the file-descriptor is in front of k point WFSX values
+        #
+        self._state = -1
+        self._ispin = 0
+        self._ik = 0
+        
+    def _close_wfsx(self):
+        """Close the file unit for the WFSX file.
+        
+        We clean the variables used to keep track of read state.
+        """
+        self._close_fortran_unit()
+
+        # Clean variables
+        del self._state
+        del self._ik
+        del self._ispin
+        try:
+            del self._sizes
+        except:
+            pass
+        try:
+            del self._basis
+        except:
+            pass
+        try:
+            del self._funcs
+        except:
+            pass
+
+    def _get_convert_k(self, parent=None):
+        """Get the function that will parse k values.
+
+        Notice that k values read from the file are in 1/Bohr.
+
+        Parameters
+        ----------
+        parent: SuperCell or SuperCellChild, optional
+            The parent object containing the information of the cell so that
+            k values can be converted to fractional reciprocal coordinates.
+
+            If not provided, k point values will be returned as they are read
+            from the file.
+
+        Returns
+        --------
+        function:
+            The function that should be used to parse k values.
+        """
+        if parent is None:
+            def convert_k(k):
+                if not np.allclose(k, 0.):
+                    warn(f"{self.__class__.__name__}.yield_eigenstate returns a k-point in 1/Ang (not in reduced format), please pass 'parent' to ensure reduced k")
+                return k / _Bohr2Ang
+        else:
+            # We can succesfully convert to proper reduced k-points
+            if isinstance(parent, SuperCell):
+                def convert_k(k):
+                    return np.dot(k / _Bohr2Ang, parent.cell.T) / (2 * pi)
+            else:
+                def convert_k(k):
+                    return np.dot(k / _Bohr2Ang, parent.sc.cell.T) / (2 * pi)
+        
+        return convert_k
+
+    def _setup_parsing(self, close=True, skip_basis=True):
+        """Gets all the things needed to parse the wfsx file.
+        
+        Parameters
+        -----------
+        close: bool, optional
+            Whether the file unit should be closed afterwards.
+        """
+        self._open_wfsx('r')
+        # Read the sizes relevant to the file.
+        # We also read whether there's only gamma point information or there are multiple points
+        self._sizes = self._read_next_sizes(skip_basis=skip_basis)
+        if not skip_basis:
+            self._basis = self._read_next_basis()
+
+        # Get the functions that should be used to parse state values.
+        if self._sizes['nspin'] in [4, 8]:
+            # We will have twice as many coefficients.
+            self._sizes['nspin'] = 1 # only 1 spin
+            func_index = 4
+        elif self._sizes["Gamma"]:
+            # State values will be in double precision floats
+            func_index = 1
+        else:
+            # State values will be in double precision complex
+            func_index = 2
+
+        self._funcs = {
+            "read_wfsx_index": getattr(_siesta, f"read_wfsx_index_{func_index}"),
+            "read_wfsx_next": getattr(_siesta, f"read_wfsx_next_{func_index}"),
+        }
+
+        if close:
+            self._close_wfsx()
+    
+    def _read_next_sizes(self, skip_basis=False):
+        """Reads the sizes if they are the next thing to be read.
+        
+        Parameters
+        -----------
+        skip_basis: boolean, optional
+            Whether this method should also skip over the basis information.
+
+        Returns
+        --------
+        dict:
+            Dictionary containing the sizes related to the file.
+                - 'nspin': int. Number of spin components.
+                - 'nou': int. Number of orbitals in the unit cell.
+                - 'nk': int. Number of k points in the file.
+                - 'Gamma': bool. Whether the file contains only the gamma point.
+        """
+        # Check that we are in the right position in the file
+        if self._state != -1:
+            raise SileError(f"We are not in a position to read the sizes. State is: {self._state}")
+        # Read the sizes that we can find in the WFSX file
+        sizes = _siesta.read_wfsx_next_sizes(self._iu, skip_basis)
+        # Inform that we are now in front of k point information
+        self._state = 1 if skip_basis else 0
+        # Check that everything went fine
+        self._bin_check('_read_sizes', "could not read sizes")
+
+        return {k:v for k, v in zip(('nspin', 'nou', 'nk', 'Gamma'), sizes)}
+
+    def _read_next_basis(self):
+        """Reads the basis if it is the next thing to be read.
+        
+        Returns
+        -------
+        Atoms:
+            the basis read.
+        """
+        # Check that we are in the right position in the file
+        if self._state != 0:
+            raise SileError(f"We are not in a position to read the basis. State is: {self._state}")
+        # Read the basis information that we can find in the WFSX file
+        basis_info = _siesta.read_wfsx_next_basis(self._iu, self._sizes['nou'])
+        # Inform that we are now in front of k point information
+        self._state = 1
+        # Check that everything went fine
+        self._bin_check('_read_basis', "could not read basis information")
+
+        # Convert the information to a dict so that code is easier to follow.
+        basis_info = {k:v for k, v in zip(('atom_indices', 'atom_labels', 'orb_index_atom', 'orb_n', 'orb_simmetry'), basis_info)}
+
+        # Sanitize the string information
+        char_keys = ["atom_labels", "orb_simmetry"]
+        for char_key in char_keys:
+            basis_info[char_key] = np.array(["".join(label).rstrip() for label in basis_info[char_key].astype(str)])
+
+        # Find out the unique atom indices
+        unique_ats = np.unique(basis_info["atom_indices"])
+
+        def _get_atom_object(at):
+            """Given an atom index, generates an Atom object with all the information we have about it"""
+            atom_orbs = np.where(basis_info["atom_indices"] == at)[0]
+            at_label = basis_info["atom_labels"][atom_orbs[0]]
+            
+            orbitals = [
+                AtomicOrbital(f"{n}{simmetry}") 
+                    for n, simmetry in zip(basis_info["orb_n"][atom_orbs], basis_info["orb_simmetry"][atom_orbs])
+            ]
+
+            return Atom(at_label, orbitals=orbitals)
+            
+        # Generate the Atoms oject.
+        return Atoms([_get_atom_object(at) for at in unique_ats])
+
+    def _read_next_info(self, ispin, ik):
+        """Reads the next eigenstate information.
+
+        This function should only be called after reading the sizes
+        or reading the previous state's values.
+
+        Parameters
+        ----------
+        ispin: integer
+            the (python) spin index of the next eigenstate.
+        ik: integer
+            the (python) k index of the next eigenstate.
+        
+        Returns
+        -------
+        array of shape (3,):
+            The k point of the state.
+        float:
+            The weight of the k point.
+        int:
+            Number of wavefunctions that the state contains. It is needed by the
+            function that reads the eigenstates values.
+        """
+        # Store the indices of the current state
+        self._ik = ik
+        self._ispin = ispin
+        # Check that we are in a position where we will read state information
+        if self._state != 1:
+            raise SileError(f"We are not in a position to read k point information. State is: {self._state}")
+        
+        # Read the state information
+        file_ispin, file_ik, k, kw, nwf = _siesta.read_wfsx_next_info(self._iu)
+        # Inform that we are now in front of state values
+        self._state = 2
+        # Check that the read went fine
+        self._bin_check('_read_next_info', f"could not read next eigenstate info [{ispin + 1}, {ik + 1}]")
+
+        # Check that the read indices match the indices that we were expecting.
+        if file_ispin != ispin + 1 or file_ik != ik + 1:
+            self._ik = file_ik - 1
+            self._ispin = file_ispin - 1
+            raise SileError(f"WFSX indices do not match the expected ones. Expected: [{ispin + 1}, {ik + 1}], obtained [{file_ispin}, {file_ik}]")
+
+        return k, kw, nwf
+
+    def _read_next_values(self, ispin, ik, nwf):
+        """Reads the next eigenstate values.
+
+        This function should only be called after reading the state's information
+
+        Parameters
+        ----------
+        ispin: integer
+            the (python) spin index of the next eigenstate.
+        ik: integer
+            the (python) k index of the next eigenstate.
+        nwf: integer
+            The number of wavefunctions that the next eigenstate contains.
+            Should have been obtained by reading the state's info with `_read_next_info`.
+        
+        Returns
+        -------
+        array of shape (nwf,):
+            The indices of each wavefunction that the state contains.
+        array of shape (nwf,):
+            The eigenvalues (in eV) of each wavefunction that the state contains.
+        array of shape (norbitals, nwf):
+            The coefficients for each wavefunction that the state contains.
+        """
+        # Check that we are in the right position in the file
+        if self._state != 2:
+            raise SileError(f"We are not in a position to read k point WFSX values. State is: {self._state}")
+        
+        # Read the state values
+        idx, eig, state = self._funcs['read_wfsx_next'](self._iu, self._sizes['nou'], nwf)
+        # Inform that we are now in front of the next state info
+        self._state = 1
+        # Check that everything went fine
+        self._bin_check('_read_next_values', f"could not read next eigenstate values [{ispin + 1}, {ik + 1}]")
+
+        return idx, eig, state
+
+    def _read_next_eigenstate(self, ispin, ik, parent, convert_k):
+        """Reads the next eigenstate in the WFSX file.
+
+        Parameters
+        ----------
+        ispin: integer
+            the (python) spin index of the next eigenstate.
+        ik: integer
+            the (python) k index of the next eigenstate.
+        parent: SuperCell or SuperCellChild
+            The parent object containing the information of the cell so that
+            k values can be converted to fractional reciprocal coordinates.
+        convert_k: callable
+            The function used to parse the k values. Should be obtained with
+            `self._get_convert_k`.
+
+        Returns
+        --------
+        EigenstateElectron:
+            The next eigenstate.
+        """
+        # Get the information of this eigenstate
+        k, kw, nwf = self._read_next_info(ispin, ik)
+        # Now that we have the information, we can read the values because
+        # we know the number of wavefunctions stored in the k point (`nwf`)
+        idx, eig, state = self._read_next_values(ispin, ik, nwf)
+
+        # Build the info dictionary for the eigenstate to know how it was calculated
+        # We include the spin index if needed.
+        info = dict(k=convert_k(k), weight=kw, gauge="r", index=idx - 1)
+        if self._sizes['nspin'] > 1:
+            info["spin"] = ispin
+
+        # `eig` is already in eV
+        # See onlysSileSiesta.read_supercell to understand why we transpose `state`
+        return EigenstateElectron(state.T, eig, parent=parent, **info)
+
+    def read_sizes(self):
+        """Reads the sizes related to this WFSX file
+        
+        Returns
+        --------
+        dict:
+            Dictionary containing the sizes related to the file.
+                - 'nspin': int. Number of spin components.
+                - 'nou': int. Number of orbitals in the unit cell.
+                - 'nk': int. Number of k points in the file.
+                - 'Gamma': bool. Whether the file contains only the gamma point.
+        """
+        self._open_wfsx("r")
+        sizes = self._read_next_sizes()
+        self._close_wfsx()
+        return sizes
+    
+    def read_basis(self):
+        """Reads the basis contained in the WFSX file.
+        
+        The WFSX file only contains information about the atom labels, which atom
+        each orbital belongs to and the orbital quantum numbers. Therefore it should
+        probably be used only as a last resort.
+        
+        Returns
+        ---------
+        Atoms:
+            the basis read.
+        """
+        self._open_wfsx("r")
+        self._sizes = self._read_next_sizes(skip_basis=False)
+        basis = self._read_next_basis()
+        self._close_wfsx()
+        return basis
+
+    def yield_eigenstate(self, parent=None, close_on_break=True):
+        r""" Iterates over the states in the WFSX file
+
+        Parameters
+        ----------
+        parent: SuperCell or SuperCellChild, optional
+            The parent object containing the information of the cell so that
+            k values can be converted to fractional reciprocal coordinates.
+        close_on_break: bool, optional
+            Wheter the fortran file unit should be closed if the iterator
+            is used in a loop that breaks before ending.
+
+        Yields
+        -------
+        EigenstateElectron
+        """
+        # Open file and get parsing information
+        self._setup_parsing(close=False)
+        # Get the function to parse k values
+        convert_k = self._get_convert_k(parent=parent)
+
+        try:
+            # Iterate over all eigenstates in the WFSX file, yielding control to the caller at
+            # each iteration.
+            for ik, ispin in product(range(0, self._sizes['nk']), range(0, self._sizes['nspin'])):
+                yield self._read_next_eigenstate(ispin, ik, parent, convert_k)
+            else:
+                # We ran out of eigenstates
+                self._close_wfsx()
+        except GeneratorExit:
+            # The loop in which the generator was used has been broken.
+            if close_on_break:
+                self._close_wfsx()
+
+    def read_eigenstate(self, k=(0,0,0), spin=0, ktol=1e-4, parent=None):
+        """Reads a specific eigenstate from the file.
+
+        This method iterates over the states until it finds a match. Don't call
+        this method repeatedly. If you want multiple states, use `yield_eigenstate`.
+
+        Parameters
+        ----------
+        k: array-like of shape (3,), optional
+            The k point of the state you want to find.
+        spin: integer, optional
+            The spin index of the state you want to find.
+        ktol: float, optional
+            The threshold value for considering two kpoints the same (i.e. to match
+            the query k point with the state's k point).
+        parent: SuperCell or SuperCellChild, optional
+            The parent object containing the information of the cell so that
+            k values can be converted to fractional reciprocal coordinates.
+
+        Returns
+        ---------
+        EigenstateElectron or None:
+            If found, the state that was queried.
+            If not found, returns `None`.
+        """
+        # Iterate over all eigenstates in the file
+        for state in self.yield_eigenstate(parent=parent):
+            if state.info.get("spin", 0) == spin and np.allclose(state.info['k'], k, atol=ktol):
+                # This is the state that the user requested
+
+                # If the file contains not only the gamma point, states are returned in
+                # an array of complex values. However, the user might be requesting the gamma
+                # point here, and we should remove the imaginary part then.
+                if np.allclose(k, 0.):
+                    state.state = state.state.real
+
+                return state
+        else:
+            # We haven't found the state that we were looking for
+            return None
+
+    def read_info(self, parent=None):
+        """Reads the information for all the k points contained in the file
+        
+        Parameters
+        ----------
+        parent: SuperCell or SuperCellChild, optional
+            The parent object containing the information of the cell so that
+            k values can be converted to fractional reciprocal coordinates.
+
+        Returns
+        ----------
+        dict:
+            A dictionary containing all the information contained in the file.
+            It contains the following keys:
+                k: array of shape (nk, 3)
+                    k values of the k points contained in the file.
+                kw: array of shape (nk,)
+                    weight of each k point
+                nwf: array of shape (nspin, nk)
+                    number of wavefunctions that each kpoint(-spin) contains.
+        """
+        # Open file and get parsing information
+        self._setup_parsing(close=False, skip_basis=True)
+        # Get the function to parse k values
+        convert_k = self._get_convert_k(parent=parent)
+
+        # Check if we are in the correct position in the file (we should be just after the header)
+        if self._state != 1:
+            raise ValueError(f"We are not in a position to read eigenstate info in the file. State: {self._state}")
+        
+        # Read all the information. Parse here the k values obtained.
+        # Store the information that should be returned under `returns`.
+        k, kw, nwf = _siesta.read_wfsx_next_all_info(self._iu, self._sizes['nspin'], self._sizes['nk'])
+        returns = {"k": convert_k(k), "kw": kw, "nwf": nwf}
+
+        # Close the file unit
+        self._close_wfsx()
+        # Check for errors in the read.
+        self._bin_check("read_info", "could not read file information.")
+
+        return returns
+
+    def read_bz(self, parent=None):
+        file_info = self.read_info(parent=parent)
+
+        return BrillouinZone(parent=parent, k=file_info['k'], weight=file_info['kw'])
+
+    def old_yield_eigenstate(self, parent=None):
         r""" Reads eigenstates from the WFSX file
-
         Returns
         -------
         state: EigenstateElectron
         """
         # First query information
         nspin, nou, nk, Gamma = _siesta.read_wfsx_sizes(self.file)
-        _bin_check(self, 'yield_eigenstate', 'could not read sizes.')
+        self._bin_check('yield_eigenstate', 'could not read sizes.')
 
         if nspin in [4, 8]:
             nspin = 1 # only 1 spin
@@ -1074,10 +1536,10 @@ class wfsxSileSiesta(SileBinSiesta):
             k, _, nwf = _siesta.read_wfsx_index_info(self.file, ispin, ik)
             # Convert to 1/Ang
             k /= _Bohr2Ang
-            _bin_check(self, 'yield_eigenstate', f"could not read index info [{ispin}, {ik}]")
+            self._bin_check('yield_eigenstate', f"could not read index info [{ispin}, {ik}]")
 
             idx, eig, state = func(self.file, ispin, ik, nou, nwf)
-            _bin_check(self, 'yield_eigenstate', f"could not read state information [{ispin}, {ik}, {nwf}]")
+            self._bin_check('yield_eigenstate', f"could not read state information [{ispin}, {ik}, {nwf}]")
 
             # eig is already in eV
             # we probably need to add spin
@@ -1099,7 +1561,7 @@ class _gridSileSiesta(SileBinSiesta):
         r""" Return the cell contained in the file """
 
         cell = _siesta.read_grid_cell(self.file).T * _Bohr2Ang
-        _bin_check(self, 'read_supercell', 'could not read cell.')
+        self._bin_check('read_supercell', 'could not read cell.')
 
         return SuperCell(cell)
 
@@ -1114,7 +1576,7 @@ class _gridSileSiesta(SileBinSiesta):
 
         # Read the sizes
         nspin, mesh = _siesta.read_grid_sizes(self.file)
-        _bin_check(self, 'read_grid_size', 'could not read grid sizes.')
+        self._bin_check('read_grid_size', 'could not read grid sizes.')
         return nspin, mesh
 
     def read_grid(self, index=0, dtype=np.float64, *args, **kwargs):
@@ -1135,7 +1597,7 @@ class _gridSileSiesta(SileBinSiesta):
         nspin, mesh = self.read_grid_size()
         sc = self.read_supercell()
         grid = _siesta.read_grid(self.file, nspin, mesh[0], mesh[1], mesh[2])
-        _bin_check(self, 'read_grid', 'could not read grid.')
+        self._bin_check('read_grid', 'could not read grid.')
 
         if isinstance(index, Integral):
             grid = grid[:, :, :, index]
@@ -1196,22 +1658,8 @@ class _gfSileSiesta(SileBinSiesta):
         else:
             self._E_Ry2eV = _Ry2eV
 
-    def _is_open(self):
-        return self._iu != -1
-
     def _open_gf(self, mode, rewind=False):
-        if self._is_open() and mode == self._mode:
-            if rewind:
-                _siesta.io_m.rewind_file(self._iu)
-            else:
-                # retain indices
-                return
-        else:
-            if mode == 'r':
-                self._iu = _siesta.io_m.open_file_read(self.file)
-            elif mode == 'w':
-                self._iu = _siesta.io_m.open_file_write(self.file)
-        _bin_check(self, '_open_gf', 'could not open for {}.'.format({'r': 'reading', 'w': 'writing'}[mode]))
+        self._open_fortran_unit(mode, rewind=rewind)
 
         # They will at any given time
         # correspond to the current Python indices that is to be read
@@ -1236,11 +1684,7 @@ class _gfSileSiesta(SileBinSiesta):
         self._iE = 0
 
     def _close_gf(self):
-        if not self._is_open():
-            return
-        # Close it
-        _siesta.io_m.close_file(self._iu)
-        self._iu = -1
+        self._close_fortran_unit()
 
         # Clean variables
         del self._state
@@ -1401,12 +1845,12 @@ class _gfSileSiesta(SileBinSiesta):
         E : energy points in the GF file
         """
         # Ensure it is open (in read-mode)
-        if self._is_open():
+        if self._is_fortran_unit_open():
             _siesta.io_m.rewind_file(self._iu)
         else:
             self._open_gf('r')
         nspin, no_u, nkpt, NE = _siesta.read_gf_sizes(self._iu)
-        _bin_check(self, 'read_header', 'could not read sizes.')
+        self._bin_check('read_header', 'could not read sizes.')
         self._nspin = nspin
         self._nk = nkpt
         self._nE = NE
@@ -1415,7 +1859,7 @@ class _gfSileSiesta(SileBinSiesta):
         _siesta.io_m.rewind_file(self._iu)
         self._step_counter('read_header', header=True, read=True)
         k, E = _siesta.read_gf_header(self._iu, nkpt, NE)
-        _bin_check(self, 'read_header', 'could not read header information.')
+        self._bin_check('read_header', 'could not read header information.')
 
         if self._nspin > 2: # non-colinear
             self._no_u = no_u * 2
@@ -1433,7 +1877,7 @@ class _gfSileSiesta(SileBinSiesta):
         -------
         estimated disk-space used in GB
         """
-        is_open = self._is_open()
+        is_open = self._is_fortran_unit_open()
         if not is_open:
             self.read_header()
 
@@ -1462,7 +1906,7 @@ class _gfSileSiesta(SileBinSiesta):
         """
         self._step_counter('read_hamiltonian', HS=True, read=True)
         H, S = _siesta.read_gf_hs(self._iu, self._no_u)
-        _bin_check(self, 'read_hamiltonian', 'could not read Hamiltonian and overlap matrices.')
+        self._bin_check('read_hamiltonian', 'could not read Hamiltonian and overlap matrices.')
         # we don't convert to C order!
         return H * _Ry2eV, S
 
@@ -1480,7 +1924,7 @@ class _gfSileSiesta(SileBinSiesta):
         """
         self._step_counter('read_self_energy', read=True)
         SE = _siesta.read_gf_se(self._iu, self._no_u, self._iE)
-        _bin_check(self, 'read_self_energy', 'could not read self-energy.')
+        self._bin_check('read_self_energy', 'could not read self-energy.')
         # we don't convert to C order!
         return SE * _Ry2eV
 
@@ -1496,7 +1940,7 @@ class _gfSileSiesta(SileBinSiesta):
         spin : int, optional
            spin-index for the Hamiltonian and overlap matrices
         """
-        if not self._is_open():
+        if not self._is_fortran_unit_open():
             self.read_header()
 
         # find k-index that is requested
@@ -1504,7 +1948,7 @@ class _gfSileSiesta(SileBinSiesta):
         _siesta.read_gf_find(self._iu, self._nspin, self._nk, self._nE,
                              self._state, self._ispin, self._ik, self._iE, self._is_read,
                              0, spin, ik, 0)
-        _bin_check(self, 'HkSk', 'could not find Hamiltonian and overlap matrix.')
+        self._bin_check('HkSk', 'could not find Hamiltonian and overlap matrix.')
 
         self._state = 0
         self._ispin = spin
@@ -1525,7 +1969,7 @@ class _gfSileSiesta(SileBinSiesta):
         spin : int, optional
            spin-index to retrieve self-energy at
         """
-        if not self._is_open():
+        if not self._is_fortran_unit_open():
             self.read_header()
 
         ik = self.kindex(k)
@@ -1533,7 +1977,7 @@ class _gfSileSiesta(SileBinSiesta):
         _siesta.read_gf_find(self._iu, self._nspin, self._nk, self._nE,
                              self._state, self._ispin, self._ik, self._iE, self._is_read,
                              1, spin, ik, iE)
-        _bin_check(self, 'self_energy', 'could not find requested self-energy.')
+        self._bin_check('self_energy', 'could not find requested self-energy.')
 
         self._state = 1
         self._ispin = spin
@@ -1606,7 +2050,7 @@ class _gfSileSiesta(SileBinSiesta):
                                 lasto, bloch, 0, mu * _eV2Ry, _toF(k.T, np.float64),
                                 w, self._E / self._E_Ry2eV,
                                 **sizes)
-        _bin_check(self, 'write_header', 'could not write header information.')
+        self._bin_check('write_header', 'could not write header information.')
 
     def write_hamiltonian(self, H, S=None):
         """ Write the current energy, k-point and H and S to the file
@@ -1626,7 +2070,7 @@ class _gfSileSiesta(SileBinSiesta):
         _siesta.write_gf_hs(self._iu, self._ik, self._E[self._iE] / self._E_Ry2eV,
                             _toF(H, np.complex128, _eV2Ry),
                             _toF(S, np.complex128), no_u=no)
-        _bin_check(self, 'write_hamiltonian', 'could not write Hamiltonian and overlap matrices.')
+        self._bin_check('write_hamiltonian', 'could not write Hamiltonian and overlap matrices.')
 
     def write_self_energy(self, SE):
         r""" Write the current self energy, k-point and H and S to the file
@@ -1645,7 +2089,7 @@ class _gfSileSiesta(SileBinSiesta):
         self._step_counter('write_self_energy', read=True)
         _siesta.write_gf_se(self._iu, self._ik, self._iE, self._E[self._iE] / self._E_Ry2eV,
                             _toF(SE, np.complex128, _eV2Ry), no_u=no)
-        _bin_check(self, 'write_self_energy', 'could not write self-energy.')
+        self._bin_check('write_self_energy', 'could not write self-energy.')
 
     def __len__(self):
         return self._nE * self._nk * self._nspin

--- a/sisl/io/siesta/binaries.py
+++ b/sisl/io/siesta/binaries.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from numbers import Integral
 from itertools import product
-from collections import deque
+from collections import deque, namedtuple
 import numpy as np
 from numpy import pi
 
@@ -137,9 +137,9 @@ class onlysSileSiesta(SileBinSiesta):
     def read_supercell(self):
         """ Returns a SuperCell object from a TranSiesta file """
         n_s = _siesta.read_tshs_sizes(self.file)[3]
-        self._bin_check('read_supercell', 'could not read sizes.')
+        self._fortran_check('read_supercell', 'could not read sizes.')
         arr = _siesta.read_tshs_cell(self.file, n_s)
-        self._bin_check('read_supercell', 'could not read cell.')
+        self._fortran_check('read_supercell', 'could not read cell.')
         nsc = np.array(arr[0], np.int32)
         # We have to transpose since the data is read *as-is*
         # The cell in fortran files are (:, A1)
@@ -157,9 +157,9 @@ class onlysSileSiesta(SileBinSiesta):
         sc = self.read_supercell()
 
         na = _siesta.read_tshs_sizes(self.file)[1]
-        self._bin_check('read_geometry', 'could not read sizes.')
+        self._fortran_check('read_geometry', 'could not read sizes.')
         arr = _siesta.read_tshs_geom(self.file, na)
-        self._bin_check('read_geometry', 'could not read geometry.')
+        self._fortran_check('read_geometry', 'could not read geometry.')
         # see onlysSileSiesta.read_supercell for .T
         xyz = arr[0].T * _Bohr2Ang
         lasto = arr[1]
@@ -211,14 +211,14 @@ class onlysSileSiesta(SileBinSiesta):
 
         # read the sizes used...
         sizes = _siesta.read_tshs_sizes(self.file)
-        self._bin_check('read_overlap', 'could not read sizes.')
+        self._fortran_check('read_overlap', 'could not read sizes.')
         # see onlysSileSiesta.read_supercell for .T
         isc = _siesta.read_tshs_cell(self.file, sizes[3])[2].T
-        self._bin_check('read_overlap', 'could not read cell.')
+        self._fortran_check('read_overlap', 'could not read cell.')
         no = sizes[2]
         nnz = sizes[4]
         ncol, col, dS = _siesta.read_tshs_s(self.file, no, nnz)
-        self._bin_check('read_overlap', 'could not read overlap matrix.')
+        self._fortran_check('read_overlap', 'could not read overlap matrix.')
 
         # Create the Hamiltonian container
         S = Overlap(geom, nnzpr=1)
@@ -250,7 +250,7 @@ class onlysSileSiesta(SileBinSiesta):
         Ef : fermi-level of the system
         """
         Ef = _siesta.read_tshs_ef(self.file) * _Ry2eV
-        self._bin_check('read_fermi_level', 'could not read fermi-level.')
+        self._fortran_check('read_fermi_level', 'could not read fermi-level.')
         return Ef
 
 
@@ -265,15 +265,15 @@ class tshsSileSiesta(onlysSileSiesta):
 
         # read the sizes used...
         sizes = _siesta.read_tshs_sizes(self.file)
-        self._bin_check('read_hamiltonian', 'could not read sizes.')
+        self._fortran_check('read_hamiltonian', 'could not read sizes.')
         # see onlysSileSiesta.read_supercell for .T
         isc = _siesta.read_tshs_cell(self.file, sizes[3])[2].T
-        self._bin_check('read_hamiltonian', 'could not read cell.')
+        self._fortran_check('read_hamiltonian', 'could not read cell.')
         spin = sizes[0]
         no = sizes[2]
         nnz = sizes[4]
         ncol, col, dH, dS = _siesta.read_tshs_hs(self.file, spin, no, nnz)
-        self._bin_check('read_hamiltonian', 'could not read Hamiltonian and overlap matrix.')
+        self._fortran_check('read_hamiltonian', 'could not read Hamiltonian and overlap matrix.')
 
         # Check whether it is an orthogonal basis set
         orthogonal = np.abs(dS).sum() == geom.no
@@ -357,7 +357,7 @@ class tshsSileSiesta(onlysSileSiesta):
                               csr.ncol, csr.col + 1,
                               _toF(h, np.float64, _eV2Ry), _toF(s, np.float64),
                               isc)
-        self._bin_check('write_hamiltonian', 'could not write Hamiltonian and overlap matrix.')
+        self._fortran_check('write_hamiltonian', 'could not write Hamiltonian and overlap matrix.')
 
 
 @set_module("sisl.io.siesta")
@@ -369,10 +369,10 @@ class dmSileSiesta(SileBinSiesta):
 
         # Now read the sizes used...
         spin, no, nsc, nnz = _siesta.read_dm_sizes(self.file)
-        self._bin_check('read_density_matrix', 'could not read density matrix sizes.')
+        self._fortran_check('read_density_matrix', 'could not read density matrix sizes.')
 
         ncol, col, dDM = _siesta.read_dm(self.file, spin, no, nsc, nnz)
-        self._bin_check('read_density_matrix', 'could not read density matrix.')
+        self._fortran_check('read_density_matrix', 'could not read density matrix.')
 
         # Try and immediately attach a geometry
         geom = kwargs.get('geometry', kwargs.get('geom', None))
@@ -443,7 +443,7 @@ class dmSileSiesta(SileBinSiesta):
         nsc = DM.geometry.sc.nsc.astype(np.int32)
 
         _siesta.write_dm(self.file, nsc, csr.ncol, csr.col + 1, _toF(dm, np.float64))
-        self._bin_check('write_density_matrix', 'could not write density matrix.')
+        self._fortran_check('write_density_matrix', 'could not write density matrix.')
 
 
 @set_module("sisl.io.siesta")
@@ -455,9 +455,9 @@ class tsdeSileSiesta(dmSileSiesta):
 
         # Now read the sizes used...
         spin, no, nsc, nnz = _siesta.read_tsde_sizes(self.file)
-        self._bin_check('read_energy_density_matrix', 'could not read energy density matrix sizes.')
+        self._fortran_check('read_energy_density_matrix', 'could not read energy density matrix sizes.')
         ncol, col, dEDM = _siesta.read_tsde_edm(self.file, spin, no, nsc, nnz)
-        self._bin_check('read_energy_density_matrix', 'could not read energy density matrix.')
+        self._fortran_check('read_energy_density_matrix', 'could not read energy density matrix.')
 
         # Try and immediately attach a geometry
         geom = kwargs.get('geometry', kwargs.get('geom', None))
@@ -510,7 +510,7 @@ class tsdeSileSiesta(dmSileSiesta):
         Ef : fermi-level of the system
         """
         Ef = _siesta.read_tsde_ef(self.file) * _Ry2eV
-        self._bin_check('read_fermi_level', 'could not read fermi-level.')
+        self._fortran_check('read_fermi_level', 'could not read fermi-level.')
         return Ef
 
     def write_density_matrices(self, DM, EDM, Ef=0., **kwargs):
@@ -562,7 +562,7 @@ class tsdeSileSiesta(dmSileSiesta):
         _siesta.write_tsde_dm_edm(self.file, nsc, DMcsr.ncol, DMcsr.col + 1,
                                   _toF(dm, np.float64),
                                   _toF(edm, np.float64, _eV2Ry), Ef * _eV2Ry)
-        self._bin_check('write_density_matrices', 'could not write DM + EDM matrices.')
+        self._fortran_check('write_density_matrices', 'could not write DM + EDM matrices.')
 
 
 @set_module("sisl.io.siesta")
@@ -870,7 +870,7 @@ class hsxSileSiesta(SileBinSiesta):
         """ Reads basis set and geometry information from the HSX file """
         # Now read the sizes used...
         no, na, nspecies = _siesta.read_hsx_specie_sizes(self.file)
-        self._bin_check('read_geometry', 'could not read specie sizes.')
+        self._fortran_check('read_geometry', 'could not read specie sizes.')
         # Read specie information
         labels, val_q, norbs, isa = _siesta.read_hsx_species(self.file, nspecies, no, na)
         # convert to proper string
@@ -879,7 +879,7 @@ class hsxSileSiesta(SileBinSiesta):
         labels = list(map(lambda s: b''.join(s).decode('utf-8').strip(),
                           labels.tolist())
         )
-        self._bin_check('read_geometry', 'could not read species.')
+        self._fortran_check('read_geometry', 'could not read species.')
         # to python index
         isa -= 1
 
@@ -918,7 +918,7 @@ class hsxSileSiesta(SileBinSiesta):
         atoms = []
         for ispecie in range(nspecies):
             n_l_zeta = _siesta.read_hsx_specie(self.file, ispecie+1, norbs[ispecie])
-            self._bin_check('read_geometry', f'could not read specie {ispecie}.')
+            self._fortran_check('read_geometry', f'could not read specie {ispecie}.')
             # create orbital
             # no shell will have l>5, so m=10 should be more than enough
             m = 10
@@ -935,11 +935,11 @@ class hsxSileSiesta(SileBinSiesta):
 
         # now read in xij to retrieve atomic positions
         Gamma, spin, no, no_s, nnz = _siesta.read_hsx_sizes(self.file)
-        self._bin_check('read_geometry', 'could not read matrix sizes.')
+        self._fortran_check('read_geometry', 'could not read matrix sizes.')
         ncol, col, _, dxij = _siesta.read_hsx_sx(self.file, Gamma, spin, no, no_s, nnz)
         dxij = dxij.T * _Bohr2Ang
         col -= 1
-        self._bin_check('read_geometry', 'could not read xij matrix.')
+        self._fortran_check('read_geometry', 'could not read xij matrix.')
 
         # now create atoms object
         atoms = Atoms([atoms[ia] for ia in isa])
@@ -951,11 +951,11 @@ class hsxSileSiesta(SileBinSiesta):
 
         # Now read the sizes used...
         Gamma, spin, no, no_s, nnz = _siesta.read_hsx_sizes(self.file)
-        self._bin_check('read_hamiltonian', 'could not read Hamiltonian sizes.')
+        self._fortran_check('read_hamiltonian', 'could not read Hamiltonian sizes.')
         ncol, col, dH, dS, dxij = _siesta.read_hsx_hsx(self.file, Gamma, spin, no, no_s, nnz)
         dxij = dxij.T * _Bohr2Ang
         col -= 1
-        self._bin_check('read_hamiltonian', 'could not read Hamiltonian.')
+        self._fortran_check('read_hamiltonian', 'could not read Hamiltonian.')
 
         ptr = _ncol_to_indptr(ncol)
         xij = SparseCSR((dxij, col, ptr), shape=(no, no_s))
@@ -992,11 +992,11 @@ class hsxSileSiesta(SileBinSiesta):
         """ Returns the overlap matrix from the siesta.HSX file """
         # Now read the sizes used...
         Gamma, spin, no, no_s, nnz = _siesta.read_hsx_sizes(self.file)
-        self._bin_check('read_overlap', 'could not read overlap matrix sizes.')
+        self._fortran_check('read_overlap', 'could not read overlap matrix sizes.')
         ncol, col, dS, dxij = _siesta.read_hsx_sx(self.file, Gamma, spin, no, no_s, nnz)
         dxij = dxij.T * _Bohr2Ang
         col -= 1
-        self._bin_check('read_overlap', 'could not read overlap matrix.')
+        self._fortran_check('read_overlap', 'could not read overlap matrix.')
 
         ptr = _ncol_to_indptr(ncol)
         xij = SparseCSR((dxij, col, ptr), shape=(no, no_s))
@@ -1031,17 +1031,82 @@ class hsxSileSiesta(SileBinSiesta):
 @set_module("sisl.io.siesta")
 class wfsxSileSiesta(SileBinSiesta):
     r""" Binary WFSX file reader for Siesta
-    
-    All _read_next_* methods expect the fortran file unit to be handled
-    and that the position in the file is correct. 
+
+    The WFSX file assumes that users initialize the object with
+    a `parent` argument (or one of the other geometry related objects as
+    shown below).
+
+    The `parent` argument is necessary to convert WFSX k-points from 1/Ang to
+    reduced coordinates.
+    When returning `EigenstateElectron` objects the parent of these objects
+    are the equivalent of the `parent` argument upon initialization.
+    Therefore please remember to pass a correct `parent`.
+
+    Parameters
+    ----------
+    parent : obj, optional
+        a parent may contain a geometry, and/or a supercell
+    geometry : Geometry, optional
+        a geometry contains a cell with corresponding lattice vectors
+        used to convert k [1/Ang] -> [b]
+    sc : SuperCell, optional
+        a supercell contains the lattice vectors to convert k
     """
+
+    def _setup(self, *args, **kwargs):
+        """ Simple setup that needs to be overwritten
+
+        All _read_next_* methods expect the fortran file unit to be handled
+        and that the position in the file is correct.
+        """
+        super()._setup(*args, **kwargs)
+
+        # default sc
+        sc = None
+
+        # In case the instantiation was called with wfsxSileSiesta("path", geometry=geometry)
+        parent = kwargs.get("parent")
+        if parent is None:
+            geometry = None
+        elif isinstance(parent, Geometry):
+            geometry = parent
+        elif isinstance(parent, SuperCell):
+            sc = parent
+        else:
+            geometry = parent.geometry
+
+        geometry = kwargs.get("geometry", geometry)
+        if geometry is not None and sc is None:
+            sc = geometry.sc
+
+        sc = kwargs.get("sc", sc)
+        if sc is None and geometry is not None:
+            raise ValueError(f"{self.__class__.__name__}(geometry=Geometry, sc=None) is not an allowed argument combination.")
+
+        if parent is None:
+            parent = geometry
+        if parent is None:
+            parent = sc
+
+        self._parent = parent
+        self._geometry = geometry
+        self._sc = sc
+        if self._parent is None and self._geometry is None and self._sc is None:
+            def conv(k):
+                if not np.allclose(k, 0.):
+                    warn(f"{self.__class__.__name__} cannot convert stored k-points from 1/Ang to reduced coordinates. Please ensure 'parent=Hamiltonian', 'geometry=Geometry', or 'sc=SuperCell' to ensure reduced k")
+                return k / _Bohr2Ang
+        else:
+            def conv(k):
+                return (k @ sc.cell.T) / (2 * pi * _Bohr2Ang)
+        self._convert_k = conv
 
     def _open_wfsx(self, mode, rewind=False):
         """Open the file unit for the WFSX file.
-        
+
         Here we also initialize some variables to keep track of the state of the read.
         """
-        self._open_fortran_unit(mode, rewind=rewind)
+        self._fortran_open(mode, rewind=rewind)
         # Here we initialize the variables that will keep track of the state of the read.
         # The process for identification is done on this basis:
         #  _ik is the current (Python) index for the k-point to be read
@@ -1056,13 +1121,13 @@ class wfsxSileSiesta(SileBinSiesta):
         self._state = -1
         self._ispin = 0
         self._ik = 0
-        
+
     def _close_wfsx(self):
         """Close the file unit for the WFSX file.
-        
+
         We clean the variables used to keep track of read state.
         """
-        self._close_fortran_unit()
+        self._fortran_close()
 
         # Clean variables
         del self._state
@@ -1081,48 +1146,15 @@ class wfsxSileSiesta(SileBinSiesta):
         except:
             pass
 
-    def _get_convert_k(self, parent=None):
-        """Get the function that will parse k values.
-
-        Notice that k values read from the file are in 1/Bohr.
-
-        Parameters
-        ----------
-        parent: SuperCell or SuperCellChild, optional
-            The parent object containing the information of the cell so that
-            k values can be converted to fractional reciprocal coordinates.
-
-            If not provided, k point values will be returned as they are read
-            from the file.
-
-        Returns
-        --------
-        function:
-            The function that should be used to parse k values.
-        """
-        if parent is None:
-            def convert_k(k):
-                if not np.allclose(k, 0.):
-                    warn(f"{self.__class__.__name__}.yield_eigenstate returns a k-point in 1/Ang (not in reduced format), please pass 'parent' to ensure reduced k")
-                return k / _Bohr2Ang
-        else:
-            # We can succesfully convert to proper reduced k-points
-            if isinstance(parent, SuperCell):
-                def convert_k(k):
-                    return np.dot(k / _Bohr2Ang, parent.cell.T) / (2 * pi)
-            else:
-                def convert_k(k):
-                    return np.dot(k / _Bohr2Ang, parent.sc.cell.T) / (2 * pi)
-        
-        return convert_k
-
     def _setup_parsing(self, close=True, skip_basis=True):
         """Gets all the things needed to parse the wfsx file.
-        
+
         Parameters
         -----------
         close: bool, optional
             Whether the file unit should be closed afterwards.
+        skip_basis : bool, optional
+            whether to also read the basis or not
         """
         self._open_wfsx('r')
         # Read the sizes relevant to the file.
@@ -1132,39 +1164,38 @@ class wfsxSileSiesta(SileBinSiesta):
             self._basis = self._read_next_basis()
 
         # Get the functions that should be used to parse state values.
-        if self._sizes['nspin'] in [4, 8]:
+        if self._sizes.nspin in (4, 8):
             # We will have twice as many coefficients.
-            self._sizes['nspin'] = 1 # only 1 spin
             func_index = 4
-        elif self._sizes["Gamma"]:
+        elif self._sizes.Gamma:
             # State values will be in double precision floats
             func_index = 1
         else:
             # State values will be in double precision complex
             func_index = 2
 
-        self._funcs = {
-            "read_wfsx_index": getattr(_siesta, f"read_wfsx_index_{func_index}"),
-            "read_wfsx_next": getattr(_siesta, f"read_wfsx_next_{func_index}"),
-        }
+        Funcs = namedtuple("WFSXReads", ["read_index", "read_next"])
+        self._funcs = Funcs(
+            getattr(_siesta, f"read_wfsx_index_{func_index}"),
+            getattr(_siesta, f"read_wfsx_next_{func_index}")
+        )
 
         if close:
             self._close_wfsx()
-    
+
     def _read_next_sizes(self, skip_basis=False):
         """Reads the sizes if they are the next thing to be read.
-        
+
         Parameters
         -----------
         skip_basis: boolean, optional
             Whether this method should also skip over the basis information.
 
         Returns
-        --------
-        dict:
-            Dictionary containing the sizes related to the file.
+        -------
+        namedtuple :
                 - 'nspin': int. Number of spin components.
-                - 'nou': int. Number of orbitals in the unit cell.
+                - 'no_u': int. Number of orbitals in the unit cell.
                 - 'nk': int. Number of k points in the file.
                 - 'Gamma': bool. Whether the file contains only the gamma point.
         """
@@ -1172,17 +1203,18 @@ class wfsxSileSiesta(SileBinSiesta):
         if self._state != -1:
             raise SileError(f"We are not in a position to read the sizes. State is: {self._state}")
         # Read the sizes that we can find in the WFSX file
+        Sizes = namedtuple("Sizes", ["nspin", "no_u", "nk", "Gamma"])
         sizes = _siesta.read_wfsx_next_sizes(self._iu, skip_basis)
         # Inform that we are now in front of k point information
         self._state = 1 if skip_basis else 0
         # Check that everything went fine
-        self._bin_check('_read_sizes', "could not read sizes")
+        self._fortran_check('_read_sizes', "could not read sizes")
 
-        return {k:v for k, v in zip(('nspin', 'nou', 'nk', 'Gamma'), sizes)}
+        return Sizes(*sizes)
 
     def _read_next_basis(self):
         """Reads the basis if it is the next thing to be read.
-        
+
         Returns
         -------
         Atoms:
@@ -1192,18 +1224,17 @@ class wfsxSileSiesta(SileBinSiesta):
         if self._state != 0:
             raise SileError(f"We are not in a position to read the basis. State is: {self._state}")
         # Read the basis information that we can find in the WFSX file
-        basis_info = _siesta.read_wfsx_next_basis(self._iu, self._sizes['nou'])
+        basis_info = _siesta.read_wfsx_next_basis(self._iu, self._sizes.no_u)
         # Inform that we are now in front of k point information
         self._state = 1
         # Check that everything went fine
-        self._bin_check('_read_basis', "could not read basis information")
+        self._fortran_check('_read_basis', "could not read basis information")
 
         # Convert the information to a dict so that code is easier to follow.
-        basis_info = {k:v for k, v in zip(('atom_indices', 'atom_labels', 'orb_index_atom', 'orb_n', 'orb_simmetry'), basis_info)}
+        basis_info = dict(zip(('atom_indices', 'atom_labels', 'orb_index_atom', 'orb_n', 'orb_symmetry'), basis_info))
 
         # Sanitize the string information
-        char_keys = ["atom_labels", "orb_simmetry"]
-        for char_key in char_keys:
+        for char_key in ("atom_labels", "orb_symmetry"):
             basis_info[char_key] = np.array(["".join(label).rstrip() for label in basis_info[char_key].astype(str)])
 
         # Find out the unique atom indices
@@ -1213,14 +1244,14 @@ class wfsxSileSiesta(SileBinSiesta):
             """Given an atom index, generates an Atom object with all the information we have about it"""
             atom_orbs = np.where(basis_info["atom_indices"] == at)[0]
             at_label = basis_info["atom_labels"][atom_orbs[0]]
-            
+
             orbitals = [
-                AtomicOrbital(f"{n}{simmetry}") 
-                    for n, simmetry in zip(basis_info["orb_n"][atom_orbs], basis_info["orb_simmetry"][atom_orbs])
+                AtomicOrbital(f"{n}{symmetry}")
+                    for n, symmetry in zip(basis_info["orb_n"][atom_orbs], basis_info["orb_symmetry"][atom_orbs])
             ]
 
             return Atom(at_label, orbitals=orbitals)
-            
+
         # Generate the Atoms oject.
         return Atoms([_get_atom_object(at) for at in unique_ats])
 
@@ -1236,7 +1267,7 @@ class wfsxSileSiesta(SileBinSiesta):
             the (python) spin index of the next eigenstate.
         ik: integer
             the (python) k index of the next eigenstate.
-        
+
         Returns
         -------
         array of shape (3,):
@@ -1253,21 +1284,21 @@ class wfsxSileSiesta(SileBinSiesta):
         # Check that we are in a position where we will read state information
         if self._state != 1:
             raise SileError(f"We are not in a position to read k point information. State is: {self._state}")
-        
+
         # Read the state information
-        file_ispin, file_ik, k, kw, nwf = _siesta.read_wfsx_next_info(self._iu)
+        file_ispin, file_ik, k, weight, nwf = _siesta.read_wfsx_next_info(self._iu)
         # Inform that we are now in front of state values
         self._state = 2
         # Check that the read went fine
-        self._bin_check('_read_next_info', f"could not read next eigenstate info [{ispin + 1}, {ik + 1}]")
+        self._fortran_check('_read_next_info', f"could not read next eigenstate info [{ispin + 1}, {ik + 1}]")
 
         # Check that the read indices match the indices that we were expecting.
         if file_ispin != ispin + 1 or file_ik != ik + 1:
             self._ik = file_ik - 1
             self._ispin = file_ispin - 1
-            raise SileError(f"WFSX indices do not match the expected ones. Expected: [{ispin + 1}, {ik + 1}], obtained [{file_ispin}, {file_ik}]")
+            raise SileError(f"WFSX indices do not match the expected ones. Expected: [{ispin + 1}, {ik + 1}], found [{file_ispin}, {file_ik}]")
 
-        return k, kw, nwf
+        return k, weight, nwf
 
     def _read_next_values(self, ispin, ik, nwf):
         """Reads the next eigenstate values.
@@ -1283,7 +1314,7 @@ class wfsxSileSiesta(SileBinSiesta):
         nwf: integer
             The number of wavefunctions that the next eigenstate contains.
             Should have been obtained by reading the state's info with `_read_next_info`.
-        
+
         Returns
         -------
         array of shape (nwf,):
@@ -1296,17 +1327,17 @@ class wfsxSileSiesta(SileBinSiesta):
         # Check that we are in the right position in the file
         if self._state != 2:
             raise SileError(f"We are not in a position to read k point WFSX values. State is: {self._state}")
-        
+
         # Read the state values
-        idx, eig, state = self._funcs['read_wfsx_next'](self._iu, self._sizes['nou'], nwf)
+        idx, eig, state = self._funcs.read_next(self._iu, self._sizes.no_u, nwf)
         # Inform that we are now in front of the next state info
         self._state = 1
         # Check that everything went fine
-        self._bin_check('_read_next_values', f"could not read next eigenstate values [{ispin + 1}, {ik + 1}]")
+        self._fortran_check('_read_next_values', f"could not read next eigenstate values [{ispin + 1}, {ik + 1}]")
 
         return idx, eig, state
 
-    def _read_next_eigenstate(self, ispin, ik, parent, convert_k):
+    def _read_next_eigenstate(self, ispin, ik):
         """Reads the next eigenstate in the WFSX file.
 
         Parameters
@@ -1315,12 +1346,6 @@ class wfsxSileSiesta(SileBinSiesta):
             the (python) spin index of the next eigenstate.
         ik: integer
             the (python) k index of the next eigenstate.
-        parent: SuperCell or SuperCellChild
-            The parent object containing the information of the cell so that
-            k values can be converted to fractional reciprocal coordinates.
-        convert_k: callable
-            The function used to parse the k values. Should be obtained with
-            `self._get_convert_k`.
 
         Returns
         --------
@@ -1328,47 +1353,45 @@ class wfsxSileSiesta(SileBinSiesta):
             The next eigenstate.
         """
         # Get the information of this eigenstate
-        k, kw, nwf = self._read_next_info(ispin, ik)
+        k, weight, nwf = self._read_next_info(ispin, ik)
         # Now that we have the information, we can read the values because
         # we know the number of wavefunctions stored in the k point (`nwf`)
         idx, eig, state = self._read_next_values(ispin, ik, nwf)
 
         # Build the info dictionary for the eigenstate to know how it was calculated
         # We include the spin index if needed.
-        info = dict(k=convert_k(k), weight=kw, gauge="r", index=idx - 1)
-        if self._sizes['nspin'] > 1:
+        info = dict(k=self._convert_k(k), weight=weight, gauge="r", index=idx - 1)
+        if self._sizes.nspin == 2:
             info["spin"] = ispin
 
         # `eig` is already in eV
         # See onlysSileSiesta.read_supercell to understand why we transpose `state`
-        return EigenstateElectron(state.T, eig, parent=parent, **info)
+        return EigenstateElectron(state.T, eig, parent=self._parent, **info)
 
     def read_sizes(self):
         """Reads the sizes related to this WFSX file
-        
+
         Returns
-        --------
-        dict:
-            Dictionary containing the sizes related to the file.
-                - 'nspin': int. Number of spin components.
-                - 'nou': int. Number of orbitals in the unit cell.
-                - 'nk': int. Number of k points in the file.
-                - 'Gamma': bool. Whether the file contains only the gamma point.
+        -------
+        int : number of spin components
+        int : number of orbitals in the unit-cell
+        int : number of k-points
+        bool : True if the file only contains the Gamma-point
         """
         self._open_wfsx("r")
         sizes = self._read_next_sizes()
         self._close_wfsx()
         return sizes
-    
+
     def read_basis(self):
         """Reads the basis contained in the WFSX file.
-        
+
         The WFSX file only contains information about the atom labels, which atom
-        each orbital belongs to and the orbital quantum numbers. Therefore it should
-        probably be used only as a last resort.
-        
+        each orbital belongs to and the orbital quantum numbers. It is thus not
+        complete in every sense.
+
         Returns
-        ---------
+        -------
         Atoms:
             the basis read.
         """
@@ -1378,175 +1401,103 @@ class wfsxSileSiesta(SileBinSiesta):
         self._close_wfsx()
         return basis
 
-    def yield_eigenstate(self, parent=None, close_on_break=True):
+    def yield_eigenstate(self):
         r""" Iterates over the states in the WFSX file
 
-        Parameters
-        ----------
-        parent: SuperCell or SuperCellChild, optional
-            The parent object containing the information of the cell so that
-            k values can be converted to fractional reciprocal coordinates.
-        close_on_break: bool, optional
-            Wheter the fortran file unit should be closed if the iterator
-            is used in a loop that breaks before ending.
-
         Yields
-        -------
+        ------
         EigenstateElectron
         """
         # Open file and get parsing information
         self._setup_parsing(close=False)
-        # Get the function to parse k values
-        convert_k = self._get_convert_k(parent=parent)
+
+        if self._sizes.nspin == 2:
+            itt_spin = range(2)
+        else:
+            itt_spin = range(1)
 
         try:
             # Iterate over all eigenstates in the WFSX file, yielding control to the caller at
             # each iteration.
-            for ik, ispin in product(range(0, self._sizes['nk']), range(0, self._sizes['nspin'])):
-                yield self._read_next_eigenstate(ispin, ik, parent, convert_k)
-            else:
-                # We ran out of eigenstates
-                self._close_wfsx()
+            for ik, ispin in product(range(self._sizes.nk), itt_spin):
+                yield self._read_next_eigenstate(ispin, ik)
+            # We ran out of eigenstates
+            self._close_wfsx()
         except GeneratorExit:
             # The loop in which the generator was used has been broken.
-            if close_on_break:
-                self._close_wfsx()
+            self._close_wfsx()
 
-    def read_eigenstate(self, k=(0,0,0), spin=0, ktol=1e-4, parent=None):
+    def read_eigenstate(self, k=(0, 0, 0), spin=0, ktol=1e-4):
         """Reads a specific eigenstate from the file.
 
         This method iterates over the states until it finds a match. Don't call
-        this method repeatedly. If you want multiple states, use `yield_eigenstate`.
+        this method repeatedly. If you want to loop eigenstates, use `yield_eigenstate`.
 
         Parameters
         ----------
         k: array-like of shape (3,), optional
             The k point of the state you want to find.
         spin: integer, optional
-            The spin index of the state you want to find.
+            The spin index of the state you want to find. Only meaningful for polarized
+            calculations.
         ktol: float, optional
-            The threshold value for considering two kpoints the same (i.e. to match
+            The threshold value for considering two k-points the same (i.e. to match
             the query k point with the state's k point).
-        parent: SuperCell or SuperCellChild, optional
-            The parent object containing the information of the cell so that
-            k values can be converted to fractional reciprocal coordinates.
+
+        See Also
+        --------
+        yield_eigenstate
 
         Returns
-        ---------
+        -------
         EigenstateElectron or None:
             If found, the state that was queried.
-            If not found, returns `None`.
+            If not found, returns `None`. NOTE this may change to an exception in the future
         """
         # Iterate over all eigenstates in the file
-        for state in self.yield_eigenstate(parent=parent):
+        for state in self.yield_eigenstate():
             if state.info.get("spin", 0) == spin and np.allclose(state.info['k'], k, atol=ktol):
                 # This is the state that the user requested
-
-                # If the file contains not only the gamma point, states are returned in
-                # an array of complex values. However, the user might be requesting the gamma
-                # point here, and we should remove the imaginary part then.
-                if np.allclose(k, 0.):
-                    state.state = state.state.real
-
                 return state
-        else:
-            # We haven't found the state that we were looking for
-            return None
+        return None
 
-    def read_info(self, parent=None):
+    def read_info(self):
         """Reads the information for all the k points contained in the file
-        
-        Parameters
-        ----------
-        parent: SuperCell or SuperCellChild, optional
-            The parent object containing the information of the cell so that
-            k values can be converted to fractional reciprocal coordinates.
 
         Returns
-        ----------
-        dict:
-            A dictionary containing all the information contained in the file.
-            It contains the following keys:
-                k: array of shape (nk, 3)
-                    k values of the k points contained in the file.
-                kw: array of shape (nk,)
-                    weight of each k point
-                nwf: array of shape (nspin, nk)
-                    number of wavefunctions that each kpoint(-spin) contains.
+        -------
+        k: array of shape (nk, 3)
+            k values of the k points contained in the file.
+        weight: array of shape (nk,)
+            weight of each k point
+        nwf: array of shape (nspin, nk)
+            number of wavefunctions that each kpoint(-spin) contains.
         """
         # Open file and get parsing information
         self._setup_parsing(close=False, skip_basis=True)
-        # Get the function to parse k values
-        convert_k = self._get_convert_k(parent=parent)
 
         # Check if we are in the correct position in the file (we should be just after the header)
         if self._state != 1:
             raise ValueError(f"We are not in a position to read eigenstate info in the file. State: {self._state}")
-        
+
         # Read all the information. Parse here the k values obtained.
         # Store the information that should be returned under `returns`.
-        k, kw, nwf = _siesta.read_wfsx_next_all_info(self._iu, self._sizes['nspin'], self._sizes['nk'])
-        returns = {"k": convert_k(k), "kw": kw, "nwf": nwf}
+        if self._sizes.nspin == 2:
+            nspin = 2
+        else:
+            nspin = 1
+        k, kw, nwf = _siesta.read_wfsx_next_all_info(self._iu, 1, self._sizes.nk)
 
         # Close the file unit
         self._close_wfsx()
         # Check for errors in the read.
-        self._bin_check("read_info", "could not read file information.")
+        self._fortran_check("read_info", "could not read file information.")
+        return self._convert_k(k), kw, nwf
 
-        return returns
-
-    def read_bz(self, parent=None):
-        file_info = self.read_info(parent=parent)
-
-        return BrillouinZone(parent=parent, k=file_info['k'], weight=file_info['kw'])
-
-    def old_yield_eigenstate(self, parent=None):
-        r""" Reads eigenstates from the WFSX file
-        Returns
-        -------
-        state: EigenstateElectron
-        """
-        # First query information
-        nspin, nou, nk, Gamma = _siesta.read_wfsx_sizes(self.file)
-        self._bin_check('yield_eigenstate', 'could not read sizes.')
-
-        if nspin in [4, 8]:
-            nspin = 1 # only 1 spin
-            func = _siesta.read_wfsx_index_4
-        elif Gamma:
-            func = _siesta.read_wfsx_index_1
-        else:
-            func = _siesta.read_wfsx_index_2
-
-        if parent is None:
-            def convert_k(k):
-                if not np.allclose(k, 0.):
-                    warn(f"{self.__class__.__name__}.yield_eigenstate returns a k-point in 1/Ang (not in reduced format), please pass 'parent' to ensure reduced k")
-                return k
-        else:
-            # We can succesfully convert to proper reduced k-points
-            if isinstance(parent, SuperCell):
-                def convert_k(k):
-                    return np.dot(k, parent.cell.T) / (2 * pi)
-            else:
-                def convert_k(k):
-                    return np.dot(k, parent.sc.cell.T) / (2 * pi)
-
-        for ispin, ik in product(range(1, nspin + 1), range(1, nk + 1)):
-            k, _, nwf = _siesta.read_wfsx_index_info(self.file, ispin, ik)
-            # Convert to 1/Ang
-            k /= _Bohr2Ang
-            self._bin_check('yield_eigenstate', f"could not read index info [{ispin}, {ik}]")
-
-            idx, eig, state = func(self.file, ispin, ik, nou, nwf)
-            self._bin_check('yield_eigenstate', f"could not read state information [{ispin}, {ik}, {nwf}]")
-
-            # eig is already in eV
-            # we probably need to add spin
-            # see onlysSileSiesta.read_supercell for .T
-            es = EigenstateElectron(state.T, eig, parent=parent,
-                                    k=convert_k(k), gauge="r", index=idx - 1)
-            yield es
+    def read_brillouinzone(self):
+        """ Read the brillouin zone object """
+        k, weight, _ = self.read_info()
+        return BrillouinZone(self._parent, k=k, weight=weight)
 
 
 @set_module("sisl.io.siesta")
@@ -1561,7 +1512,7 @@ class _gridSileSiesta(SileBinSiesta):
         r""" Return the cell contained in the file """
 
         cell = _siesta.read_grid_cell(self.file).T * _Bohr2Ang
-        self._bin_check('read_supercell', 'could not read cell.')
+        self._fortran_check('read_supercell', 'could not read cell.')
 
         return SuperCell(cell)
 
@@ -1576,7 +1527,7 @@ class _gridSileSiesta(SileBinSiesta):
 
         # Read the sizes
         nspin, mesh = _siesta.read_grid_sizes(self.file)
-        self._bin_check('read_grid_size', 'could not read grid sizes.')
+        self._fortran_check('read_grid_size', 'could not read grid sizes.')
         return nspin, mesh
 
     def read_grid(self, index=0, dtype=np.float64, *args, **kwargs):
@@ -1597,7 +1548,7 @@ class _gridSileSiesta(SileBinSiesta):
         nspin, mesh = self.read_grid_size()
         sc = self.read_supercell()
         grid = _siesta.read_grid(self.file, nspin, mesh[0], mesh[1], mesh[2])
-        self._bin_check('read_grid', 'could not read grid.')
+        self._fortran_check('read_grid', 'could not read grid.')
 
         if isinstance(index, Integral):
             grid = grid[:, :, :, index]
@@ -1646,20 +1597,22 @@ class _gfSileSiesta(SileBinSiesta):
     ...        if new_k:
     ...            f.write_hamiltonian(H, S)
     ...        f.write_self_energy(SeHSE)
+
     """
 
     def _setup(self, *args, **kwargs):
         """ Simple setup that needs to be overwritten """
-        self._iu = -1
+        super()._setup(*args, **kwargs)
+
         # The unit convention used for energy-points
         # This is necessary until Siesta uses CODATA values
-        if kwargs.get("unit", "old").lower() in ("old", "4.1"):
+        if kwargs.get("version", "old").lower() in ("old", "4.1"):
             self._E_Ry2eV = 13.60580
         else:
             self._E_Ry2eV = _Ry2eV
 
     def _open_gf(self, mode, rewind=False):
-        self._open_fortran_unit(mode, rewind=rewind)
+        self._fortran_open(mode, rewind=rewind)
 
         # They will at any given time
         # correspond to the current Python indices that is to be read
@@ -1684,7 +1637,9 @@ class _gfSileSiesta(SileBinSiesta):
         self._iE = 0
 
     def _close_gf(self):
-        self._close_fortran_unit()
+        if not self._fortran_is_open():
+            return
+        self._fortran_close()
 
         # Clean variables
         del self._state
@@ -1845,12 +1800,12 @@ class _gfSileSiesta(SileBinSiesta):
         E : energy points in the GF file
         """
         # Ensure it is open (in read-mode)
-        if self._is_fortran_unit_open():
+        if self._fortran_is_open():
             _siesta.io_m.rewind_file(self._iu)
         else:
             self._open_gf('r')
         nspin, no_u, nkpt, NE = _siesta.read_gf_sizes(self._iu)
-        self._bin_check('read_header', 'could not read sizes.')
+        self._fortran_check('read_header', 'could not read sizes.')
         self._nspin = nspin
         self._nk = nkpt
         self._nE = NE
@@ -1859,7 +1814,7 @@ class _gfSileSiesta(SileBinSiesta):
         _siesta.io_m.rewind_file(self._iu)
         self._step_counter('read_header', header=True, read=True)
         k, E = _siesta.read_gf_header(self._iu, nkpt, NE)
-        self._bin_check('read_header', 'could not read header information.')
+        self._fortran_check('read_header', 'could not read header information.')
 
         if self._nspin > 2: # non-colinear
             self._no_u = no_u * 2
@@ -1877,7 +1832,7 @@ class _gfSileSiesta(SileBinSiesta):
         -------
         estimated disk-space used in GB
         """
-        is_open = self._is_fortran_unit_open()
+        is_open = self._fortran_is_open()
         if not is_open:
             self.read_header()
 
@@ -1906,7 +1861,7 @@ class _gfSileSiesta(SileBinSiesta):
         """
         self._step_counter('read_hamiltonian', HS=True, read=True)
         H, S = _siesta.read_gf_hs(self._iu, self._no_u)
-        self._bin_check('read_hamiltonian', 'could not read Hamiltonian and overlap matrices.')
+        self._fortran_check('read_hamiltonian', 'could not read Hamiltonian and overlap matrices.')
         # we don't convert to C order!
         return H * _Ry2eV, S
 
@@ -1924,7 +1879,7 @@ class _gfSileSiesta(SileBinSiesta):
         """
         self._step_counter('read_self_energy', read=True)
         SE = _siesta.read_gf_se(self._iu, self._no_u, self._iE)
-        self._bin_check('read_self_energy', 'could not read self-energy.')
+        self._fortran_check('read_self_energy', 'could not read self-energy.')
         # we don't convert to C order!
         return SE * _Ry2eV
 
@@ -1940,7 +1895,7 @@ class _gfSileSiesta(SileBinSiesta):
         spin : int, optional
            spin-index for the Hamiltonian and overlap matrices
         """
-        if not self._is_fortran_unit_open():
+        if not self._fortran_is_open():
             self.read_header()
 
         # find k-index that is requested
@@ -1948,7 +1903,7 @@ class _gfSileSiesta(SileBinSiesta):
         _siesta.read_gf_find(self._iu, self._nspin, self._nk, self._nE,
                              self._state, self._ispin, self._ik, self._iE, self._is_read,
                              0, spin, ik, 0)
-        self._bin_check('HkSk', 'could not find Hamiltonian and overlap matrix.')
+        self._fortran_check('HkSk', 'could not find Hamiltonian and overlap matrix.')
 
         self._state = 0
         self._ispin = spin
@@ -1969,7 +1924,7 @@ class _gfSileSiesta(SileBinSiesta):
         spin : int, optional
            spin-index to retrieve self-energy at
         """
-        if not self._is_fortran_unit_open():
+        if not self._fortran_is_open():
             self.read_header()
 
         ik = self.kindex(k)
@@ -1977,7 +1932,7 @@ class _gfSileSiesta(SileBinSiesta):
         _siesta.read_gf_find(self._iu, self._nspin, self._nk, self._nE,
                              self._state, self._ispin, self._ik, self._iE, self._is_read,
                              1, spin, ik, iE)
-        self._bin_check('self_energy', 'could not find requested self-energy.')
+        self._fortran_check('self_energy', 'could not find requested self-energy.')
 
         self._state = 1
         self._ispin = spin
@@ -2050,7 +2005,7 @@ class _gfSileSiesta(SileBinSiesta):
                                 lasto, bloch, 0, mu * _eV2Ry, _toF(k.T, np.float64),
                                 w, self._E / self._E_Ry2eV,
                                 **sizes)
-        self._bin_check('write_header', 'could not write header information.')
+        self._fortran_check('write_header', 'could not write header information.')
 
     def write_hamiltonian(self, H, S=None):
         """ Write the current energy, k-point and H and S to the file
@@ -2070,7 +2025,7 @@ class _gfSileSiesta(SileBinSiesta):
         _siesta.write_gf_hs(self._iu, self._ik, self._E[self._iE] / self._E_Ry2eV,
                             _toF(H, np.complex128, _eV2Ry),
                             _toF(S, np.complex128), no_u=no)
-        self._bin_check('write_hamiltonian', 'could not write Hamiltonian and overlap matrices.')
+        self._fortran_check('write_hamiltonian', 'could not write Hamiltonian and overlap matrices.')
 
     def write_self_energy(self, SE):
         r""" Write the current self energy, k-point and H and S to the file
@@ -2089,7 +2044,7 @@ class _gfSileSiesta(SileBinSiesta):
         self._step_counter('write_self_energy', read=True)
         _siesta.write_gf_se(self._iu, self._ik, self._iE, self._E[self._iE] / self._E_Ry2eV,
                             _toF(SE, np.complex128, _eV2Ry), no_u=no)
-        self._bin_check('write_self_energy', 'could not write self-energy.')
+        self._fortran_check('write_self_energy', 'could not write self-energy.')
 
     def __len__(self):
         return self._nE * self._nk * self._nspin
@@ -2104,17 +2059,19 @@ class _gfSileSiesta(SileBinSiesta):
         # get everything
         e = self._E
         if self._nspin in [1, 2]:
+            GFStep = namedtuple("GFStep", ["spin", "do_HS", "k", "E"])
             for ispin in range(self._nspin):
                 for k in self._k:
-                    yield ispin, True, k, e[0]
+                    yield GFStep(ispin, True, k, e[0])
                     for E in e[1:]:
-                        yield ispin, False, k, E
+                        yield GFStep(ispin, False, k, E)
 
         else:
+            GFStep = namedtuple("GFStep", ["do_HS", "k", "E"])
             for k in self._k:
-                yield True, k, e[0]
+                yield GFStep(True, k, e[0])
                 for E in e[1:]:
-                    yield False, k, E
+                    yield GFStep(False, k, E)
 
         # We will automatically close once we hit the end
         self._close_gf()

--- a/sisl/io/siesta/sile.py
+++ b/sisl/io/siesta/sile.py
@@ -25,6 +25,8 @@ class SileCDFSiesta(SileCDF):
 
     # all netcdf output should not be masked
     def _setup(self, *args, **kwargs):
+        super()._setup(*args, **kwargs)
+
         # all NetCDF routines actually returns masked arrays
         # this is to prevent Siesta CDF files from doing this.
         if hasattr(self, "fh"):
@@ -36,18 +38,19 @@ class SileBinSiesta(SileBin):
 
     def _setup(self, *args, **kwargs):
         """We set up everything to handle the fortran I/O unit"""
+        super()._setup(*args, **kwargs)
         self._iu = -1
 
-    def _bin_check(self, method, message):
+    def _fortran_check(self, method, message):
         ierr = _siesta.io_m.iostat_query()
         if ierr != 0:
             raise SileError(f'{self!s}.{method} {message} (ierr={ierr})')
 
-    def _is_fortran_unit_open(self):
+    def _fortran_is_open(self):
         return self._iu != -1
 
-    def _open_fortran_unit(self, mode, rewind=False):
-        if self._is_fortran_unit_open() and mode == self._mode:
+    def _fortran_open(self, mode, rewind=False):
+        if self._fortran_is_open() and mode == self._mode:
             if rewind:
                 _siesta.io_m.rewind_file(self._iu)
             else:
@@ -60,10 +63,10 @@ class SileBinSiesta(SileBin):
                 self._iu = _siesta.io_m.open_file_write(self.file)
             else:
                 raise SileError(f"Mode '{mode}' is not an accepted mode to open a fortran file unit. Use only 'r' or 'w'")
-        self._bin_check('_open_fortran_unit', 'could not open for {}.'.format({'r': 'reading', 'w': 'writing'}[mode]))
-        
-    def _close_fortran_unit(self):
-        if not self._is_fortran_unit_open():
+        self._fortran_check('_fortran_open', 'could not open for {}.'.format({'r': 'reading', 'w': 'writing'}[mode]))
+
+    def _fortran_close(self):
+        if not self._fortran_is_open():
             return
         # Close it
         _siesta.io_m.close_file(self._iu)

--- a/sisl/io/siesta/tests/test_gf.py
+++ b/sisl/io/siesta/tests/test_gf.py
@@ -90,7 +90,7 @@ def test_gf_write_read_spin(sisl_tmp, sisl_system):
         gf.write_self_energy(S * e - Hk)
 
     # Check it isn't opened
-    assert not gf._is_open()
+    assert not gf._fortran_is_open()
 
     nspin, no_u, k, E_file = gf.read_header()
     assert nspin == 2
@@ -132,7 +132,7 @@ def test_gf_write_read_direct(sisl_tmp, sisl_system):
         gf.write_self_energy(S * e - Hk)
 
     # ensure it is not opened
-    assert not gf._is_open()
+    assert not gf._fortran_is_open()
 
     # First try from beginning
     for e in [0, 1, E[1], 0, E[0]]:

--- a/sisl/io/siesta/tests/test_wfsx.py
+++ b/sisl/io/siesta/tests/test_wfsx.py
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import pytest
+import os.path as osp
+import sisl
+import numpy as np
+
+pytestmark = [pytest.mark.io, pytest.mark.siesta]
+_dir = osp.join('sisl', 'io', 'siesta')
+
+
+def test_wfsx_read(sisl_files):
+    fdf = sisl.get_sile(sisl_files(_dir, 'bi2se3_3ql.fdf'))
+    wfsx = sisl.get_sile(sisl_files(_dir, 'bi2se3_3ql.bands.WFSX'), parent=fdf.read_geometry())
+
+    info = wfsx.read_info()
+    sizes = wfsx.read_sizes()
+    basis = wfsx.read_basis()
+
+    # yield states
+    nstates = 0
+    nstates_total = 0
+    for state in wfsx.yield_eigenstate():
+        nstates += 1
+        nstates_total += len(state)
+    # in this example we a SOC calculation, so we should not muliply by spin
+    assert nstates == len(info[0])
+    assert nstates_total == info[2].sum()
+
+    bz = wfsx.read_brillouinzone()
+    assert len(bz) == 16

--- a/sisl/viz/plots/bands.py
+++ b/sisl/viz/plots/bands.py
@@ -36,84 +36,84 @@ class BandsPlot(Plot):
     Parameters
     -------------
     bands_file: bandsSileSiesta, optional
-    	This parameter explicitly sets a .bands file. Otherwise, the bands
-    	file is attempted to read from the fdf file
+        This parameter explicitly sets a .bands file. Otherwise, the bands
+        file is attempted to read from the fdf file
     band_structure: BandStructure, optional
-    	A band structure. it can either be provided as a sisl.BandStructure
-    	object or         as a list of points, which will be parsed into a
-    	band structure object.            Each item is a dict.    Structure
-    	of the dict: {         'x':          'y':          'z':
-    	'divisions':          'name': Tick that should be displayed at this
-    	corner of the path. }
+        A band structure. it can either be provided as a sisl.BandStructure
+        object or         as a list of points, which will be parsed into a
+        band structure object.            Each item is a dict.    Structure
+        of the dict: {         'x':          'y':          'z':
+        'divisions':          'name': Tick that should be displayed at this
+        corner of the path. }
     wfsx_file: wfsxSileSiesta, optional
-    	The WFSX file to get the eigenstates.             In standard SIESTA
-    	nomenclature, this should probably be the *.bands.WFSX file, as it is
-    	the one             that contains the eigenstates for the band
-    	structure.
+        The WFSX file to get the eigenstates.             In standard SIESTA
+        nomenclature, this should probably be the *.bands.WFSX file, as it is
+        the one             that contains the eigenstates for the band
+        structure.
     aiida_bands:  optional
-    	An aiida BandsData node.
+        An aiida BandsData node.
     add_band_data:  optional
-    	This function receives each band and should return a dictionary with
-    	additional arguments              that are passed to the band drawing
-    	routine. It also receives the plot as the second argument.
-    	See the docs of `sisl.viz.backends.templates.Backend.draw_line` to
-    	understand what are the supported arguments             to be
-    	returned. Notice that the arguments that the backend is able to
-    	process can be very framework dependant.
+        This function receives each band and should return a dictionary with
+        additional arguments              that are passed to the band drawing
+        routine. It also receives the plot as the second argument.
+        See the docs of `sisl.viz.backends.templates.Backend.draw_line` to
+        understand what are the supported arguments             to be
+        returned. Notice that the arguments that the backend is able to
+        process can be very framework dependant.
     Erange: array-like of shape (2,), optional
-    	Energy range where the bands are displayed.
+        Energy range where the bands are displayed.
     E0: float, optional
-    	The energy to which all energies will be referenced (including
-    	Erange).
+        The energy to which all energies will be referenced (including
+        Erange).
     bands_range: array-like of shape (2,), optional
-    	The bands that should be displayed. Only relevant if Erange is None.
+        The bands that should be displayed. Only relevant if Erange is None.
     spin:  optional
-    	Determines how the different spin configurations should be displayed.
-    	In spin polarized calculations, it allows you to choose between spin
-    	0 and 1.             In non-colinear spin calculations, it allows you
-    	to ask for a given spin texture,             by specifying the
-    	direction.
+        Determines how the different spin configurations should be displayed.
+        In spin polarized calculations, it allows you to choose between spin
+        0 and 1.             In non-colinear spin calculations, it allows you
+        to ask for a given spin texture,             by specifying the
+        direction.
     spin_texture_colorscale: str, optional
-    	The plotly colorscale to use for the spin texture (if displayed)
+        The plotly colorscale to use for the spin texture (if displayed)
     gap: bool, optional
-    	Whether the gap should be displayed in the plot
+        Whether the gap should be displayed in the plot
     direct_gaps_only: bool, optional
-    	Whether to show only gaps that are direct, according to the gap
-    	tolerance
+        Whether to show only gaps that are direct, according to the gap
+        tolerance
     gap_tol: float, optional
-    	The difference in k that must exist to consider to gaps
-    	different.             If two gaps' positions differ in less than
-    	this, only one gap will be drawn.             Useful in cases
-    	where there are degenerated bands with exactly the same values.
+        The difference in k that must exist to consider to gaps
+        different.             If two gaps' positions differ in less than
+        this, only one gap will be drawn.             Useful in cases
+        where there are degenerated bands with exactly the same values.
     gap_color: str, optional
-    	Color to display the gap
+        Color to display the gap
     custom_gaps: array-like of dict, optional
-    	List of all the gaps that you want to display.   Each item is a dict.
-    	Structure of the dict: {         'from': K value where to start
-    	measuring the gap.                      It can be either the label of
-    	the k-point or the numeric value in the plot.         'to': K value
-    	where to end measuring the gap.                      It can be either
-    	the label of the k-point or the numeric value in the plot.
-    	'color': The color with which the gap should be displayed
-    	'spin': The spin components where the gap should be calculated. }
+        List of all the gaps that you want to display.   Each item is a dict.
+        Structure of the dict: {         'from': K value where to start
+        measuring the gap.                      It can be either the label of
+        the k-point or the numeric value in the plot.         'to': K value
+        where to end measuring the gap.                      It can be either
+        the label of the k-point or the numeric value in the plot.
+        'color': The color with which the gap should be displayed
+        'spin': The spin components where the gap should be calculated. }
     bands_width: float, optional
-    	Width of the lines that represent the bands
+        Width of the lines that represent the bands
     bands_color: str, optional
-    	Choose the color to display the bands.  This will be used for the
-    	spin up bands if the calculation is spin polarized
+        Choose the color to display the bands.  This will be used for the
+        spin up bands if the calculation is spin polarized
     spindown_color: str, optional
-    	Choose the color for the spin down bands.Only used if the
-    	calculation is spin polarized.
+        Choose the color for the spin down bands.Only used if the
+        calculation is spin polarized.
     root_fdf: fdfSileSiesta, optional
-    	Path to the fdf file that is the 'parent' of the results.
+        Path to the fdf file that is the 'parent' of the results.
     results_path: str, optional
-    	Directory where the files with the simulations results are
-    	located. This path has to be relative to the root fdf.
+        Directory where the files with the simulations results are
+        located. This path has to be relative to the root fdf.
     entry_points_order: array-like, optional
-    	Order with which entry points will be attempted.
+        Order with which entry points will be attempted.
     backend:  optional
-    	Directory where the files with the simulations results are
-    	located. This path has to be relative to the root fdf.
+        Directory where the files with the simulations results are
+        located. This path has to be relative to the root fdf.
     """
 
     _plot_type = "Bands"
@@ -349,7 +349,7 @@ class BandsPlot(Plot):
 
     def _get_eigenstate_wrapper(self, k_vals, extra_vars=()):
         """Helper function to build the function to call on each eigenstate.
-        
+
         Parameters
         ----------
         k_vals: array_like of shape (nk,)
@@ -408,7 +408,7 @@ class BandsPlot(Plot):
             "name": "E", "getter": lambda eigenstate, self, spin: eigenstate.eig},
             *extra_vars
         )
-        
+
         # Now build the function that will be called for each eigenstate and will
         # return the values for each variable.
         def bands_wrapper(eigenstate, spin_index):
@@ -424,7 +424,7 @@ class BandsPlot(Plot):
     @entry_point('wfsx file', 2)
     def _read_from_wfsx(self, root_fdf, wfsx_file, extra_vars=()):
         """Plots bands from the eigenvalues contained in a WFSX file.
-        
+
         It also needs to get a geometry.
         """
         # Get the fdf sile
@@ -434,7 +434,7 @@ class BandsPlot(Plot):
 
         # Get the wfsx file
         wfsx_sile = self.get_sile(wfsx_file or "wfsx_file")
-        
+
         # Now read all the information of the k points from the WFSX file
         wfsx_info = wfsx_sile.read_info(parent=self.geometry)
         # Get the number of wavefunctions in the file while performing a quick check
@@ -497,7 +497,7 @@ class BandsPlot(Plot):
                     # Note that we already checked previously that they all have the same
                     # number of wfs, so this is a fair assumption.
                     coords_values['band'] = eigenstate.info['index']
-            
+
             # Get all the values for this eigenstate.
             returns = bands_wrapper(eigenstate, spin_index=spin)
             # And store them in the respective arrays.
@@ -538,7 +538,7 @@ class BandsPlot(Plot):
         bands_wrapper, all_vars, coords_values= self._get_eigenstate_wrapper(
             band_structure.lineark(), extra_vars=extra_vars
         )
-        
+
         # Get a dataset with all values for all spin indices
         spin_datasets = []
         coords = [var['coords'] for var in all_vars]

--- a/sisl/viz/plots/fatbands.py
+++ b/sisl/viz/plots/fatbands.py
@@ -190,7 +190,7 @@ class FatbandsPlot(BandsPlot):
     def _read_from_H(self):
         """Calculates the fatbands from a sisl hamiltonian."""
         self._entry_point_with_extra_vars(super()._read_from_H)
-        
+
     def _entry_point_with_extra_vars(self, entry_point):
         # Define the function that will "catch" each eigenstate and
         # build the weights array. See BandsPlot._read_from_H to understand where

--- a/sisl/viz/plots/fatbands.py
+++ b/sisl/viz/plots/fatbands.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 import sisl
+from sisl.physics.spin import Spin
 from ..plot import entry_point
 from .bands import BandsPlot
 from ..plotutils import random_color
@@ -126,20 +127,6 @@ class FatbandsPlot(BandsPlot):
 
     _parameters = (
 
-        SileInput(key='wfsx_file', name='Path to WFSX file',
-            dtype=sisl.io.siesta.wfsxSileSiesta,
-            default=None,
-            help="""The WFSX file to get the weights of the different orbitals in the bands.
-            In standard SIESTA nomenclature, this should be the *.bands.WFSX file, as it is the one
-            that contains the weights that correspond to the bands.
-            
-            This file is only meaningful (and required) if fatbands are plotted from the .bands file.
-            Otherwise, the bands and weights will be generated from the hamiltonian by sisl.
-            If the *.bands file is provided but the wfsx one isn't, we will try to find it.
-            If `bands_file` is SystemLabel.bands, we will look for SystemLabel.bands.WFSX
-            """
-        ),
-
         FloatInput(key='scale', name='Scale factor',
             default=None,
             help="""The factor by which the width of all fatbands should be multiplied.
@@ -190,83 +177,21 @@ class FatbandsPlot(BandsPlot):
     def weights(self):
         return self.bands_data["weight"]
 
-    @entry_point("siesta output", 0)
-    def _read_siesta_output(self, wfsx_file, bands_file, root_fdf):
+    @entry_point("wfsx file", 0)
+    def _read_from_wfsx(self, root_fdf, wfsx_file):
         """Generates fatbands from SIESTA output.
 
-        Uses the `.bands` file to read the bands and a `.wfsx` file to
-        retrieve the wavefunctions coefficients. 
+        Uses the `.wfsx` file to retrieve the eigenstates. From them, it computes
+        all the needed quantities (eigenvalues, orbital contribution, ...). 
         """
-        from xarray import DataArray, Dataset
-
-        # Try to get the wfsx file either by user input or by guessing it
-        # from bands_file
-        bands_file = self.get_sile(bands_file or "bands_file").file
-        if wfsx_file is None:
-            wfsx_file = bands_file.with_suffix(bands_file.suffix + ".WFSX")
-
-        # We will need the overlap matrix from the hamiltonian to get the correct
-        # weights.
-        # If there is no root_fdf we will try to guess it from bands_file
-        if root_fdf is None and not hasattr(self, "H"):
-            possible_fdf = bands_file.with_suffix(".fdf")
-            print(f"We are assuming that the fdf associated to {bands_file} is {possible_fdf}."+
-            ' If it is not, please provide a "root_fdf" by using the update_settings method.')
-            self.update_settings(root_fdf=root_fdf, run_updates=False)
-
-        self.setup_hamiltonian()
-
-        # If the wfsx doesn't exist, we will not even bother to read the bands
-        if not wfsx_file.exists():
-            raise ValueError(f"We did not find a WFSX file in the location {wfsx_file}")
-
-        # Otherwise we will make BandsPlot read the bands
-        super()._read_siesta_output()
-
-        # And then read the weights from the wfsx file
-        wfsx_sile = self.get_sile(wfsx_file)
-
-        weights = []
-        for i, state in enumerate(wfsx_sile.yield_eigenstate(self.H)):
-            # Each eigenstate represents all the states for a given k-point
-
-            # Get the band indices to which these states correspond
-            if i == 0:
-                bands = state.info["indices"]
-
-            # Get the weights for this eigenstate
-            weights.append(state.norm2(sum=False))
-
-        weights = np.array(weights).real
-
-        # Finally, build the weights dataarray so that it can be used by _set_data
-        weights = DataArray(
-            weights,
-            coords={
-                "k": self.bands.k,
-                "band": bands,
-                "orb": np.arange(0, weights.shape[2]),
-            },
-            dims=("k", "band", "orb")
-        )
-
-        # Add the spin dimension so that the weights array is normalized,
-        # even though spin is not yet supported by this entrypoint
-        weights = weights.expand_dims("spin")
-
-        # Merge everything into a dataset
-        attrs = self.bands_data.attrs
-        self.bands_data = Dataset({"E": self.bands_data, "weight": weights})
-        self.bands_data.attrs = attrs
-
-        # Set up the options for the 'groups' setting based on the plot's associated geometry
-        self._set_group_options()
+        self._entry_point_with_extra_vars(super()._read_from_wfsx)
 
     @entry_point("hamiltonian", 1)
     def _read_from_H(self):
-        """
-        Calculates the fatbands from a sisl hamiltonian.
-        """
+        """Calculates the fatbands from a sisl hamiltonian."""
+        self._entry_point_with_extra_vars(super()._read_from_H)
+        
+    def _entry_point_with_extra_vars(self, entry_point):
         # Define the function that will "catch" each eigenstate and
         # build the weights array. See BandsPlot._read_from_H to understand where
         # this will go exactly
@@ -286,7 +211,7 @@ class FatbandsPlot(BandsPlot):
         # thanks to the above step
         bands_read = False; err = None
         try:
-            super()._read_from_H(extra_vars=[{"coords": ("band", "orb"), "name": "weight", "getter": _weights_from_eigenstate}])
+            entry_point(extra_vars=[{"coords": ("band", "orb"), "name": "weight", "getter": _weights_from_eigenstate}])
             bands_read = True
         except Exception as e:
             # Let's keep this error, we are going to at least set the group options so that the
@@ -307,13 +232,7 @@ class FatbandsPlot(BandsPlot):
             if band_struct is not None:
                 self.geometry = band_struct.parent.geometry
 
-        if getattr(self, "H", None) is not None:
-            spin = self.H.spin
-        else:
-            # There is yet no spin support reading from bands.WFSX
-            spin = sisl.Spin.UNPOLARIZED
-
-        self.get_param('groups').update_options(self.geometry, spin)
+        self.get_param('groups').update_options(self.geometry, self.spin)
 
     def _set_data(self):
         # We get the information that the Bandsplot wants to send to the drawer

--- a/sisl/viz/plots/grid.py
+++ b/sisl/viz/plots/grid.py
@@ -1262,132 +1262,132 @@ class WavefunctionPlot(GridPlot):
     Parameters
     -----------
     eigenstate: EigenstateElectron, optional
-    	The eigenstate that contains the coefficients of the wavefunction.
-    	Note that an eigenstate can contain coefficients for multiple states.
+        The eigenstate that contains the coefficients of the wavefunction.
+        Note that an eigenstate can contain coefficients for multiple states.
     wfsx_file: wfsxSileSiesta, optional
-    	Siesta WFSX file to directly read the coefficients from.
-    	If the root_fdf file is provided but the wfsx one isn't, we will try
-    	to find it             as SystemLabel.WFSX.
+        Siesta WFSX file to directly read the coefficients from.
+        If the root_fdf file is provided but the wfsx one isn't, we will try
+        to find it             as SystemLabel.WFSX.
     geometry: Geometry, optional
-    	Necessary to generate the grid and to plot the wavefunctions, since
-    	the basis orbitals are needed.             If you provide a
-    	hamiltonian, the geometry is probably inside the hamiltonian, so you
-    	don't need to provide it.             However, this field is
-    	compulsory if you are providing the eigenstate directly.
+        Necessary to generate the grid and to plot the wavefunctions, since
+        the basis orbitals are needed.             If you provide a
+        hamiltonian, the geometry is probably inside the hamiltonian, so you
+        don't need to provide it.             However, this field is
+        compulsory if you are providing the eigenstate directly.
     k: array-like, optional
-    	If the eigenstates need to be calculated from a hamiltonian, the k
-    	point for which you want them to be calculated
+        If the eigenstates need to be calculated from a hamiltonian, the k
+        point for which you want them to be calculated
     spin:  optional
-    	The spin component where the eigenstate should be calculated.
-    	Only meaningful if the state needs to be calculated from the
-    	hamiltonian.
+        The spin component where the eigenstate should be calculated.
+        Only meaningful if the state needs to be calculated from the
+        hamiltonian.
     grid_prec: float, optional
-    	The spacing between points of the grid where the wavefunction will be
-    	projected (in Ang).             If you are plotting a 3D
-    	representation, take into account that a very fine and big grid could
-    	result in             your computer crashing on render. If it's the
-    	first time you are using this function,             assess the
-    	capabilities of your computer by first using a low-precision grid and
-    	increase             it gradually.
+        The spacing between points of the grid where the wavefunction will be
+        projected (in Ang).             If you are plotting a 3D
+        representation, take into account that a very fine and big grid could
+        result in             your computer crashing on render. If it's the
+        first time you are using this function,             assess the
+        capabilities of your computer by first using a low-precision grid and
+        increase             it gradually.
     i: int, optional
-    	The index of the wavefunction
+        The index of the wavefunction
     grid: Grid, optional
-    	A sisl.Grid object. If provided, grid_file is ignored.
+        A sisl.Grid object. If provided, grid_file is ignored.
     grid_file: cubeSile or rhoSileSiesta or ldosSileSiesta or rhoinitSileSiesta or rhoxcSileSiesta or drhoSileSiesta or baderSileSiesta or iorhoSileSiesta or totalrhoSileSiesta or stsSileSiesta or stmldosSileSiesta or hartreeSileSiesta or neutralatomhartreeSileSiesta or totalhartreeSileSiesta or gridncSileSiesta or ncSileSiesta or fdfSileSiesta or tsvncSileSiesta or chgSileVASP or locpotSileVASP, optional
-    	A filename that can be return a Grid through `read_grid`.
+        A filename that can be return a Grid through `read_grid`.
     represent:  optional
-    	The representation of the grid that should be displayed
+        The representation of the grid that should be displayed
     transforms:  optional
-    	Transformations to apply to the whole grid.             It can be a
-    	function, or a string that represents the path             to a
-    	function (e.g. "scipy.exp"). If a string that is a single
-    	word is provided, numpy will be assumed to be the module (e.g.
-    	"square" will be converted into "np.square").              Note that
-    	transformations will be applied in the order provided. Some
-    	transforms might not be necessarily commutable (e.g. "abs" and
-    	"cos").
+        Transformations to apply to the whole grid.             It can be a
+        function, or a string that represents the path             to a
+        function (e.g. "scipy.exp"). If a string that is a single
+        word is provided, numpy will be assumed to be the module (e.g.
+        "square" will be converted into "np.square").              Note that
+        transformations will be applied in the order provided. Some
+        transforms might not be necessarily commutable (e.g. "abs" and
+        "cos").
     axes:  optional
-    	The axis along you want to see the grid, it will be reduced along the
-    	other ones, according to the the `reduce_method` setting.
+        The axis along you want to see the grid, it will be reduced along the
+        other ones, according to the the `reduce_method` setting.
     zsmooth:  optional
-    	Parameter that smoothens how data looks in a heatmap.
-    	'best' interpolates data, 'fast' interpolates pixels, 'False'
-    	displays the data as is.
+        Parameter that smoothens how data looks in a heatmap.
+        'best' interpolates data, 'fast' interpolates pixels, 'False'
+        displays the data as is.
     interp: array-like, optional
-    	Interpolation factors to make the grid finer on each axis.See the
-    	zsmooth setting for faster smoothing of 2D heatmap.
+        Interpolation factors to make the grid finer on each axis.See the
+        zsmooth setting for faster smoothing of 2D heatmap.
     transform_bc:  optional
-    	The boundary conditions when a cell transform is applied to the grid.
-    	Cell transforms are only             applied when the grid's cell
-    	doesn't follow the cartesian coordinates and the requested display is
-    	2D or 1D.
+        The boundary conditions when a cell transform is applied to the grid.
+        Cell transforms are only             applied when the grid's cell
+        doesn't follow the cartesian coordinates and the requested display is
+        2D or 1D.
     nsc: array-like, optional
-    	Number of times the grid should be repeated
+        Number of times the grid should be repeated
     offset: array-like, optional
-    	The offset of the grid along each axis. This is important if you are
-    	planning to match this grid with other geometry related plots.
+        The offset of the grid along each axis. This is important if you are
+        planning to match this grid with other geometry related plots.
     trace_name: str, optional
-    	The name that the trace will show in the legend. Good when merging
-    	with other plots to be able to toggle the trace in the legend
+        The name that the trace will show in the legend. Good when merging
+        with other plots to be able to toggle the trace in the legend
     x_range: array-like of shape (2,), optional
-    	Range where the X is displayed. Should be inside the unit cell,
-    	otherwise it will fail.
+        Range where the X is displayed. Should be inside the unit cell,
+        otherwise it will fail.
     y_range: array-like of shape (2,), optional
-    	Range where the Y is displayed. Should be inside the unit cell,
-    	otherwise it will fail.
+        Range where the Y is displayed. Should be inside the unit cell,
+        otherwise it will fail.
     z_range: array-like of shape (2,), optional
-    	Range where the Z is displayed. Should be inside the unit cell,
-    	otherwise it will fail.
+        Range where the Z is displayed. Should be inside the unit cell,
+        otherwise it will fail.
     crange: array-like of shape (2,), optional
-    	The range of values that the colorbar must enclose. This controls
-    	saturation and hides below threshold values.
+        The range of values that the colorbar must enclose. This controls
+        saturation and hides below threshold values.
     cmid: int, optional
-    	The value to set at the center of the colorbar. If not provided, the
-    	color range is used
+        The value to set at the center of the colorbar. If not provided, the
+        color range is used
     colorscale: str, optional
-    	A valid plotly colorscale. See https://plotly.com/python/colorscales/
+        A valid plotly colorscale. See https://plotly.com/python/colorscales/
     reduce_method:  optional
-    	The method used to reduce the dimensions that will not be displayed
-    	in the plot.
+        The method used to reduce the dimensions that will not be displayed
+        in the plot.
     isos: array-like of dict, optional
-    	The isovalues that you want to represent.             The way they
-    	will be represented is of course dependant on the type of
-    	representation:                 - 2D representations: A contour (i.e.
-    	a line)                 - 3D representations: A surface
-    	Each item is a dict.    Structure of the dict: {         'name': The
-    	name of the iso query. Note that you can use $isoval$ as a template
-    	to indicate where the isoval should go.         'val': The iso value.
-    	If not provided, it will be infered from `frac`         'frac': If
-    	val is not provided, this is used to calculate where the isosurface
-    	should be drawn.                     It calculates them from the
-    	minimum and maximum values of the grid like so:
-    	If iso_frac = 0.3:                     (min_value-----
-    	ISOVALUE(30%)-----------max_value)                     Therefore, it
-    	should be a number between 0 and 1.
-    	'step_size': The step size to use to calculate the isosurface in case
-    	it's a 3D representation                     A bigger step-size can
-    	speed up the process dramatically, specially the rendering part
-    	and the resolution may still be more than satisfactory (try to use
-    	step_size=2). For very big                     grids your computer
-    	may not even be able to render very fine surfaces, so it's worth
-    	keeping                     this setting in mind.         'color':
-    	The color of the surface/contour.         'opacity': Opacity of the
-    	surface/contour. Between 0 (transparent) and 1 (opaque). }
+        The isovalues that you want to represent.             The way they
+        will be represented is of course dependant on the type of
+        representation:                 - 2D representations: A contour (i.e.
+        a line)                 - 3D representations: A surface
+        Each item is a dict.    Structure of the dict: {         'name': The
+        name of the iso query. Note that you can use $isoval$ as a template
+        to indicate where the isoval should go.         'val': The iso value.
+        If not provided, it will be infered from `frac`         'frac': If
+        val is not provided, this is used to calculate where the isosurface
+        should be drawn.                     It calculates them from the
+        minimum and maximum values of the grid like so:
+        If iso_frac = 0.3:                     (min_value-----
+        ISOVALUE(30%)-----------max_value)                     Therefore, it
+        should be a number between 0 and 1.
+        'step_size': The step size to use to calculate the isosurface in case
+        it's a 3D representation                     A bigger step-size can
+        speed up the process dramatically, specially the rendering part
+        and the resolution may still be more than satisfactory (try to use
+        step_size=2). For very big                     grids your computer
+        may not even be able to render very fine surfaces, so it's worth
+        keeping                     this setting in mind.         'color':
+        The color of the surface/contour.         'opacity': Opacity of the
+        surface/contour. Between 0 (transparent) and 1 (opaque). }
     plot_geom: bool, optional
-    	If True the geometry associated to the grid will also be plotted
+        If True the geometry associated to the grid will also be plotted
     geom_kwargs: dict, optional
-    	Extra arguments that are passed to geom.plot() if plot_geom is set to
-    	True
+        Extra arguments that are passed to geom.plot() if plot_geom is set to
+        True
     root_fdf: fdfSileSiesta, optional
-    	Path to the fdf file that is the 'parent' of the results.
+        Path to the fdf file that is the 'parent' of the results.
     results_path: str, optional
-    	Directory where the files with the simulations results are
-    	located. This path has to be relative to the root fdf.
+        Directory where the files with the simulations results are
+        located. This path has to be relative to the root fdf.
     entry_points_order: array-like, optional
-    	Order with which entry points will be attempted.
+        Order with which entry points will be attempted.
     backend:  optional
-    	Directory where the files with the simulations results are
-    	located. This path has to be relative to the root fdf.
+        Directory where the files with the simulations results are
+        located. This path has to be relative to the root fdf.
     """
 
     _plot_type = 'Wavefunction'
@@ -1462,7 +1462,7 @@ class WavefunctionPlot(GridPlot):
             raise ValueError('No eigenstate was provided')
 
         self.eigenstate = eigenstate
-    
+
     @entry_point('Siesta WFSX file', 1)
     def _read_from_WFSX_file(self, wfsx_file, k, spin, root_fdf):
         """Reads the wavefunction coefficients from a SIESTA WFSX file"""

--- a/sisl/viz/plots/grid.py
+++ b/sisl/viz/plots/grid.py
@@ -1262,128 +1262,132 @@ class WavefunctionPlot(GridPlot):
     Parameters
     -----------
     eigenstate: EigenstateElectron, optional
-        The eigenstate that contains the coefficients of the wavefunction.
-        Note that an eigenstate can contain coefficients for multiple states.
+    	The eigenstate that contains the coefficients of the wavefunction.
+    	Note that an eigenstate can contain coefficients for multiple states.
+    wfsx_file: wfsxSileSiesta, optional
+    	Siesta WFSX file to directly read the coefficients from.
+    	If the root_fdf file is provided but the wfsx one isn't, we will try
+    	to find it             as SystemLabel.WFSX.
     geometry: Geometry, optional
-        Necessary to generate the grid and to plot the wavefunctions, since
-        the basis orbitals are needed.             If you provide a
-        hamiltonian, the geometry is probably inside the hamiltonian, so you
-        don't need to provide it.             However, this field is
-        compulsory if you are providing the eigenstate directly.
+    	Necessary to generate the grid and to plot the wavefunctions, since
+    	the basis orbitals are needed.             If you provide a
+    	hamiltonian, the geometry is probably inside the hamiltonian, so you
+    	don't need to provide it.             However, this field is
+    	compulsory if you are providing the eigenstate directly.
     k: array-like, optional
-        If the eigenstates need to be calculated from a hamiltonian, the k
-        point for which you want them to be calculated
+    	If the eigenstates need to be calculated from a hamiltonian, the k
+    	point for which you want them to be calculated
     spin:  optional
-        The spin component where the eigenstate should be calculated.
-        Only meaningful if the state needs to be calculated from the
-        hamiltonian.
+    	The spin component where the eigenstate should be calculated.
+    	Only meaningful if the state needs to be calculated from the
+    	hamiltonian.
     grid_prec: float, optional
-        The spacing between points of the grid where the wavefunction will be
-        projected (in Ang).             If you are plotting a 3D
-        representation, take into account that a very fine and big grid could
-        result in             your computer crashing on render. If it's the
-        first time you are using this function,             assess the
-        capabilities of your computer by first using a low-precision grid and
-        increase             it gradually.
+    	The spacing between points of the grid where the wavefunction will be
+    	projected (in Ang).             If you are plotting a 3D
+    	representation, take into account that a very fine and big grid could
+    	result in             your computer crashing on render. If it's the
+    	first time you are using this function,             assess the
+    	capabilities of your computer by first using a low-precision grid and
+    	increase             it gradually.
     i: int, optional
-        The index of the wavefunction
+    	The index of the wavefunction
     grid: Grid, optional
-        A sisl.Grid object. If provided, grid_file is ignored.
+    	A sisl.Grid object. If provided, grid_file is ignored.
     grid_file: cubeSile or rhoSileSiesta or ldosSileSiesta or rhoinitSileSiesta or rhoxcSileSiesta or drhoSileSiesta or baderSileSiesta or iorhoSileSiesta or totalrhoSileSiesta or stsSileSiesta or stmldosSileSiesta or hartreeSileSiesta or neutralatomhartreeSileSiesta or totalhartreeSileSiesta or gridncSileSiesta or ncSileSiesta or fdfSileSiesta or tsvncSileSiesta or chgSileVASP or locpotSileVASP, optional
-        A filename that can be return a Grid through `read_grid`.
+    	A filename that can be return a Grid through `read_grid`.
     represent:  optional
-        The representation of the grid that should be displayed
+    	The representation of the grid that should be displayed
     transforms:  optional
-        Transformations to apply to the whole grid.             It can be a
-        function, or a string that represents the path             to a
-        function (e.g. "scipy.exp"). If a string that is a single
-        word is provided, numpy will be assumed to be the module (e.g.
-        "square" will be converted into "np.square").              Note that
-        transformations will be applied in the order provided. Some
-        transforms might not be necessarily commutable (e.g. "abs" and
-        "cos").
+    	Transformations to apply to the whole grid.             It can be a
+    	function, or a string that represents the path             to a
+    	function (e.g. "scipy.exp"). If a string that is a single
+    	word is provided, numpy will be assumed to be the module (e.g.
+    	"square" will be converted into "np.square").              Note that
+    	transformations will be applied in the order provided. Some
+    	transforms might not be necessarily commutable (e.g. "abs" and
+    	"cos").
     axes:  optional
-        The axis along you want to see the grid, it will be reduced along the
-        other ones, according to the the `reduce_method` setting.
+    	The axis along you want to see the grid, it will be reduced along the
+    	other ones, according to the the `reduce_method` setting.
     zsmooth:  optional
-        Parameter that smoothens how data looks in a heatmap.
-        'best' interpolates data, 'fast' interpolates pixels, 'False'
-        displays the data as is.
+    	Parameter that smoothens how data looks in a heatmap.
+    	'best' interpolates data, 'fast' interpolates pixels, 'False'
+    	displays the data as is.
     interp: array-like, optional
-        Interpolation factors to make the grid finer on each axis.See the
-        zsmooth setting for faster smoothing of 2D heatmap.
+    	Interpolation factors to make the grid finer on each axis.See the
+    	zsmooth setting for faster smoothing of 2D heatmap.
     transform_bc:  optional
-        The boundary conditions when a cell transform is applied to the grid.
-        Cell transforms are only             applied when the grid's cell
-        doesn't follow the cartesian coordinates and the requested display is
-        2D or 1D.
+    	The boundary conditions when a cell transform is applied to the grid.
+    	Cell transforms are only             applied when the grid's cell
+    	doesn't follow the cartesian coordinates and the requested display is
+    	2D or 1D.
     nsc: array-like, optional
-        Number of times the grid should be repeated
+    	Number of times the grid should be repeated
     offset: array-like, optional
-        The offset of the grid along each axis. This is important if you are
-        planning to match this grid with other geometry related plots.
+    	The offset of the grid along each axis. This is important if you are
+    	planning to match this grid with other geometry related plots.
     trace_name: str, optional
-        The name that the trace will show in the legend. Good when merging
-        with other plots to be able to toggle the trace in the legend
+    	The name that the trace will show in the legend. Good when merging
+    	with other plots to be able to toggle the trace in the legend
     x_range: array-like of shape (2,), optional
-        Range where the X is displayed. Should be inside the unit cell,
-        otherwise it will fail.
+    	Range where the X is displayed. Should be inside the unit cell,
+    	otherwise it will fail.
     y_range: array-like of shape (2,), optional
-        Range where the Y is displayed. Should be inside the unit cell,
-        otherwise it will fail.
+    	Range where the Y is displayed. Should be inside the unit cell,
+    	otherwise it will fail.
     z_range: array-like of shape (2,), optional
-        Range where the Z is displayed. Should be inside the unit cell,
-        otherwise it will fail.
+    	Range where the Z is displayed. Should be inside the unit cell,
+    	otherwise it will fail.
     crange: array-like of shape (2,), optional
-        The range of values that the colorbar must enclose. This controls
-        saturation and hides below threshold values.
+    	The range of values that the colorbar must enclose. This controls
+    	saturation and hides below threshold values.
     cmid: int, optional
-        The value to set at the center of the colorbar. If not provided, the
-        color range is used
+    	The value to set at the center of the colorbar. If not provided, the
+    	color range is used
     colorscale: str, optional
-        A valid plotly colorscale. See https://plotly.com/python/colorscales/
+    	A valid plotly colorscale. See https://plotly.com/python/colorscales/
     reduce_method:  optional
-        The method used to reduce the dimensions that will not be displayed
-        in the plot.
+    	The method used to reduce the dimensions that will not be displayed
+    	in the plot.
     isos: array-like of dict, optional
-        The isovalues that you want to represent.             The way they
-        will be represented is of course dependant on the type of
-        representation:                 - 2D representations: A contour (i.e.
-        a line)                 - 3D representations: A surface
-        Each item is a dict.    Structure of the dict: {         'name': The
-        name of the iso query. Note that you can use $isoval$ as a template
-        to indicate where the isoval should go.         'val': The iso value.
-        If not provided, it will be infered from `frac`         'frac': If
-        val is not provided, this is used to calculate where the isosurface
-        should be drawn.                     It calculates them from the
-        minimum and maximum values of the grid like so:
-        If iso_frac = 0.3:                     (min_value-----
-        ISOVALUE(30%)-----------max_value)                     Therefore, it
-        should be a number between 0 and 1.
-        'step_size': The step size to use to calculate the isosurface in case
-        it's a 3D representation                     A bigger step-size can
-        speed up the process dramatically, specially the rendering part
-        and the resolution may still be more than satisfactory (try to use
-        step_size=2). For very big                     grids your computer
-        may not even be able to render very fine surfaces, so it's worth
-        keeping                     this setting in mind.         'color':
-        The color of the surface/contour.         'opacity': Opacity of the
-        surface/contour. Between 0 (transparent) and 1 (opaque). }
+    	The isovalues that you want to represent.             The way they
+    	will be represented is of course dependant on the type of
+    	representation:                 - 2D representations: A contour (i.e.
+    	a line)                 - 3D representations: A surface
+    	Each item is a dict.    Structure of the dict: {         'name': The
+    	name of the iso query. Note that you can use $isoval$ as a template
+    	to indicate where the isoval should go.         'val': The iso value.
+    	If not provided, it will be infered from `frac`         'frac': If
+    	val is not provided, this is used to calculate where the isosurface
+    	should be drawn.                     It calculates them from the
+    	minimum and maximum values of the grid like so:
+    	If iso_frac = 0.3:                     (min_value-----
+    	ISOVALUE(30%)-----------max_value)                     Therefore, it
+    	should be a number between 0 and 1.
+    	'step_size': The step size to use to calculate the isosurface in case
+    	it's a 3D representation                     A bigger step-size can
+    	speed up the process dramatically, specially the rendering part
+    	and the resolution may still be more than satisfactory (try to use
+    	step_size=2). For very big                     grids your computer
+    	may not even be able to render very fine surfaces, so it's worth
+    	keeping                     this setting in mind.         'color':
+    	The color of the surface/contour.         'opacity': Opacity of the
+    	surface/contour. Between 0 (transparent) and 1 (opaque). }
     plot_geom: bool, optional
-        If True the geometry associated to the grid will also be plotted
+    	If True the geometry associated to the grid will also be plotted
     geom_kwargs: dict, optional
-        Extra arguments that are passed to geom.plot() if plot_geom is set to
-        True
+    	Extra arguments that are passed to geom.plot() if plot_geom is set to
+    	True
     root_fdf: fdfSileSiesta, optional
-        Path to the fdf file that is the 'parent' of the results.
+    	Path to the fdf file that is the 'parent' of the results.
     results_path: str, optional
-        Directory where the files with the simulations results are
-        located. This path has to be relative to the root fdf.
+    	Directory where the files with the simulations results are
+    	located. This path has to be relative to the root fdf.
     entry_points_order: array-like, optional
-        Order with which entry points will be attempted.
+    	Order with which entry points will be attempted.
     backend:  optional
-        Directory where the files with the simulations results are
-        located. This path has to be relative to the root fdf.
+    	Directory where the files with the simulations results are
+    	located. This path has to be relative to the root fdf.
     """
 
     _plot_type = 'Wavefunction'
@@ -1395,6 +1399,15 @@ class WavefunctionPlot(GridPlot):
             dtype=sisl.EigenstateElectron,
             help="""The eigenstate that contains the coefficients of the wavefunction.
             Note that an eigenstate can contain coefficients for multiple states.
+            """
+        ),
+
+        SileInput(key='wfsx_file', name='Path to WFSX file',
+            dtype=sisl.io.siesta.wfsxSileSiesta,
+            default=None,
+            help="""Siesta WFSX file to directly read the coefficients from.
+            If the root_fdf file is provided but the wfsx one isn't, we will try to find it
+            as SystemLabel.WFSX.
             """
         ),
 
@@ -1449,8 +1462,28 @@ class WavefunctionPlot(GridPlot):
             raise ValueError('No eigenstate was provided')
 
         self.eigenstate = eigenstate
+    
+    @entry_point('Siesta WFSX file', 1)
+    def _read_from_WFSX_file(self, wfsx_file, k, spin, root_fdf):
+        """Reads the wavefunction coefficients from a SIESTA WFSX file"""
+        # Try to read the geometry
+        fdf = self.get_sile(root_fdf or "root_fdf")
+        if fdf is None:
+            raise ValueError("The setting 'root_fdf' needs to point to an fdf file with a geometry")
+        geometry = fdf.read_geometry(output=True)
 
-    @entry_point('hamiltonian', 1)
+        # Get the WFSX file. If not provided, it is inferred from the fdf.
+        wfsx = self.get_sile(wfsx_file or "wfsx_file")
+        if not wfsx.file.exists():
+            raise ValueError(f"File '{wfsx.file}' does not exist.")
+
+        # Try to find the eigenstate that we need
+        self.eigenstate = wfsx.read_eigenstate(k=k, spin=spin[0], parent=geometry)
+        if self.eigenstate is None:
+            # We have not found it.
+            raise ValueError(f"A state with k={k} was not found in file {wfsx.file}.")
+
+    @entry_point('hamiltonian', 2)
     def _read_from_H(self, k, spin):
         """
         Calculates the eigenstates from a Hamiltonian and then generates the wavefunctions.
@@ -1463,6 +1496,23 @@ class WavefunctionPlot(GridPlot):
         # Just avoid here GridPlot's _after_grid. Note that we are
         # calling it later in _set_data
         pass
+
+    def _get_eigenstate(self, i):
+
+        if "index" in self.eigenstate.info:
+            wf_i = np.nonzero(self.eigenstate.info["index"] == i)[0]
+            if len(wf_i) == 0:
+                raise ValueError(f"Wavefunction with index {i} is not present in the eigenstate. Available indices: {self.eigenstate.info['index']}."
+                    f"Entry point used: {self.source._name}")
+            wf_i = wf_i[0]
+        else:
+            max_index = len(self.eigenstate)
+            if i > max_index:
+                raise ValueError(f"Wavefunction with index {i} is not present in the eigenstate. Available range: [0, {max_index}]."
+                    f"Entry point used: {self.source._name}")
+            wf_i = i
+
+        return self.eigenstate[wf_i]
 
     def _set_data(self, i, geometry, grid, k, grid_prec, nsc):
 
@@ -1498,16 +1548,18 @@ class WavefunctionPlot(GridPlot):
                 tiled_geometry = tiled_geometry.tile(sc_i, ax)
                 nsc[ax] = 1
 
+        is_gamma = (np.array(k) == 0).all()
         if grid is None:
-            dtype = np.float64 if (np.array(k) == 0).all() else np.complex128
+            dtype = np.float64 if is_gamma else np.complex128
             self.grid = sisl.Grid(grid_prec, geometry=tiled_geometry, dtype=dtype)
 
         # GridPlot's after_read basically sets the x_range, y_range and z_range options
         # which need to know what the grid is, that's why we are calling it here
         super()._after_read()
 
-        self.eigenstate[i].wavefunction(self.grid)
+        state = self._get_eigenstate(i)
+        state.wavefunction(self.grid)
 
-        return super()._set_data(nsc=nsc)
+        return super()._set_data(nsc=nsc, trace_name=f"WF {i} ({state.eig[0]:.2f} eV)")
 
 GridPlot.backends.register_child(WavefunctionPlot.backends)

--- a/sisl/viz/plots/pdos.py
+++ b/sisl/viz/plots/pdos.py
@@ -29,66 +29,66 @@ class PdosPlot(Plot):
     Parameters
     -------------
     pdos_file: pdosSileSiesta, optional
-    	This parameter explicitly sets a .PDOS file. Otherwise, the PDOS file
-    	is attempted to read from the fdf file
+        This parameter explicitly sets a .PDOS file. Otherwise, the PDOS file
+        is attempted to read from the fdf file
     tbt_nc: tbtncSileTBtrans, optional
-    	This parameter explicitly sets a .TBT.nc file. Otherwise, the PDOS
-    	file is attempted to read from the fdf file
+        This parameter explicitly sets a .TBT.nc file. Otherwise, the PDOS
+        file is attempted to read from the fdf file
     wfsx_file: wfsxSileSiesta, optional
-    	The WFSX file to get the eigenstates.             In standard SIESTA
-    	nomenclature, this should probably be the *.fullBZ.WFSX file, as it
-    	is the one             that contains the eigenstates from the full
-    	brillouin zone.
+        The WFSX file to get the eigenstates.             In standard SIESTA
+        nomenclature, this should probably be the *.fullBZ.WFSX file, as it
+        is the one             that contains the eigenstates from the full
+        brillouin zone.
     geometry: Geometry or sile (or path to file) that contains a geometry, optional
-    	If this is passed, the geometry that has been read is ignored and
-    	this one is used instead.
+        If this is passed, the geometry that has been read is ignored and
+        this one is used instead.
     Erange: array-like of shape (2,), optional
-    	Energy range where PDOS is displayed.
+        Energy range where PDOS is displayed.
     distribution: dict, optional
-    	The distribution used for the smearing of the PDOS if calculated by
-    	sisl.             It accepts the same types of values as the
-    	`distribution` argument of `EigenstateElectron.PDOS`.
-    	Additionally, it accepts a dictionary containing arguments that are
-    	passed directly             to
-    	`sisl.physics.distribution.get_distribution`. E.g.: {"method":
-    	"gaussian",              "smearing": 0.01, "x0": 0.0}
-    	Structure of the dict: {         'method':          'smearing':
-    	'x0':  }
+        The distribution used for the smearing of the PDOS if calculated by
+        sisl.             It accepts the same types of values as the
+        `distribution` argument of `EigenstateElectron.PDOS`.
+        Additionally, it accepts a dictionary containing arguments that are
+        passed directly             to
+        `sisl.physics.distribution.get_distribution`. E.g.: {"method":
+        "gaussian",              "smearing": 0.01, "x0": 0.0}
+        Structure of the dict: {         'method':          'smearing':
+        'x0':  }
     nE: int, optional
-    	If calculating the PDOS from a hamiltonian, the number of energy
-    	points used
+        If calculating the PDOS from a hamiltonian, the number of energy
+        points used
     kgrid: array-like, optional
-    	The number of kpoints in each reciprocal direction.              A
-    	Monkhorst-Pack grid will be generated to calculate the PDOS.
-    	If not provided, it will be set to 3 for the periodic directions
-    	and 1 for the non-periodic ones.
+        The number of kpoints in each reciprocal direction.              A
+        Monkhorst-Pack grid will be generated to calculate the PDOS.
+        If not provided, it will be set to 3 for the periodic directions
+        and 1 for the non-periodic ones.
     kgrid_displ: array-like, optional
-    	Displacement of the Monkhorst-Pack grid
+        Displacement of the Monkhorst-Pack grid
     E0: float, optional
-    	The energy to which all energies will be referenced (including
-    	Erange).
+        The energy to which all energies will be referenced (including
+        Erange).
     requests: array-like of dict, optional
-    	Here you can ask for the specific PDOS that you need.
-    	TIP: Queries can be activated and deactivated.   Each item is a
-    	dict.    Structure of the dict: {         'name':          'species':
-    	'atoms':    Structure of the dict: {         'index':    Structure of
-    	the dict: {         'in':  }         'fx':          'fy':
-    	'fz':          'x':          'y':          'z':          'Z':
-    	'neighbours':    Structure of the dict: {         'range':
-    	'R':          'neigh_tag':  }         'tag':          'seq':  }
-    	'orbitals':          'spin':          'normalize':          'color':
-    	'linewidth':          'dash':          'split_on':          'scale':
-    	The final DOS will be multiplied by this number. }
+        Here you can ask for the specific PDOS that you need.
+        TIP: Queries can be activated and deactivated.   Each item is a
+        dict.    Structure of the dict: {         'name':          'species':
+        'atoms':    Structure of the dict: {         'index':    Structure of
+        the dict: {         'in':  }         'fx':          'fy':
+        'fz':          'x':          'y':          'z':          'Z':
+        'neighbours':    Structure of the dict: {         'range':
+        'R':          'neigh_tag':  }         'tag':          'seq':  }
+        'orbitals':          'spin':          'normalize':          'color':
+        'linewidth':          'dash':          'split_on':          'scale':
+        The final DOS will be multiplied by this number. }
     root_fdf: fdfSileSiesta, optional
-    	Path to the fdf file that is the 'parent' of the results.
+        Path to the fdf file that is the 'parent' of the results.
     results_path: str, optional
-    	Directory where the files with the simulations results are
-    	located. This path has to be relative to the root fdf.
+        Directory where the files with the simulations results are
+        located. This path has to be relative to the root fdf.
     entry_points_order: array-like, optional
-    	Order with which entry points will be attempted.
+        Order with which entry points will be attempted.
     backend:  optional
-    	Directory where the files with the simulations results are
-    	located. This path has to be relative to the root fdf.
+        Directory where the files with the simulations results are
+        located. This path has to be relative to the root fdf.
     """
 
     #Define all the class attributes

--- a/sisl/viz/plots/pdos.py
+++ b/sisl/viz/plots/pdos.py
@@ -29,61 +29,66 @@ class PdosPlot(Plot):
     Parameters
     -------------
     pdos_file: pdosSileSiesta, optional
-        This parameter explicitly sets a .PDOS file. Otherwise, the PDOS file
-        is attempted to read from the fdf file
+    	This parameter explicitly sets a .PDOS file. Otherwise, the PDOS file
+    	is attempted to read from the fdf file
     tbt_nc: tbtncSileTBtrans, optional
-        This parameter explicitly sets a .TBT.nc file. Otherwise, the PDOS
-        file is attempted to read from the fdf file
+    	This parameter explicitly sets a .TBT.nc file. Otherwise, the PDOS
+    	file is attempted to read from the fdf file
+    wfsx_file: wfsxSileSiesta, optional
+    	The WFSX file to get the eigenstates.             In standard SIESTA
+    	nomenclature, this should probably be the *.fullBZ.WFSX file, as it
+    	is the one             that contains the eigenstates from the full
+    	brillouin zone.
     geometry: Geometry or sile (or path to file) that contains a geometry, optional
-        If this is passed, the geometry that has been read is ignored and
-        this one is used instead.
+    	If this is passed, the geometry that has been read is ignored and
+    	this one is used instead.
     Erange: array-like of shape (2,), optional
-        Energy range where PDOS is displayed.
+    	Energy range where PDOS is displayed.
     distribution: dict, optional
-        The distribution used for the smearing of the PDOS if calculated by
-        sisl.             It accepts the same types of values as the
-        `distribution` argument of `EigenstateElectron.PDOS`.
-        Additionally, it accepts a dictionary containing arguments that are
-        passed directly             to
-        `sisl.physics.distribution.get_distribution`. E.g.: {"method":
-        "gaussian",              "smearing": 0.01, "x0": 0.0}
-        Structure of the dict: {         'method':          'smearing':
-        'x0':  }
+    	The distribution used for the smearing of the PDOS if calculated by
+    	sisl.             It accepts the same types of values as the
+    	`distribution` argument of `EigenstateElectron.PDOS`.
+    	Additionally, it accepts a dictionary containing arguments that are
+    	passed directly             to
+    	`sisl.physics.distribution.get_distribution`. E.g.: {"method":
+    	"gaussian",              "smearing": 0.01, "x0": 0.0}
+    	Structure of the dict: {         'method':          'smearing':
+    	'x0':  }
     nE: int, optional
-        If calculating the PDOS from a hamiltonian, the number of energy
-        points used
+    	If calculating the PDOS from a hamiltonian, the number of energy
+    	points used
     kgrid: array-like, optional
-        The number of kpoints in each reciprocal direction.              A
-        Monkhorst-Pack grid will be generated to calculate the PDOS.
-        If not provided, it will be set to 3 for the periodic directions
-        and 1 for the non-periodic ones.
+    	The number of kpoints in each reciprocal direction.              A
+    	Monkhorst-Pack grid will be generated to calculate the PDOS.
+    	If not provided, it will be set to 3 for the periodic directions
+    	and 1 for the non-periodic ones.
     kgrid_displ: array-like, optional
-        Displacement of the Monkhorst-Pack grid
+    	Displacement of the Monkhorst-Pack grid
     E0: float, optional
-        The energy to which all energies will be referenced (including
-        Erange).
+    	The energy to which all energies will be referenced (including
+    	Erange).
     requests: array-like of dict, optional
-        Here you can ask for the specific PDOS that you need.
-        TIP: Queries can be activated and deactivated.   Each item is a
-        dict.    Structure of the dict: {         'name':          'species':
-        'atoms':    Structure of the dict: {         'index':    Structure of
-        the dict: {         'in':  }         'fx':          'fy':
-        'fz':          'x':          'y':          'z':          'Z':
-        'neighbours':    Structure of the dict: {         'range':
-        'R':          'neigh_tag':  }         'tag':          'seq':  }
-        'orbitals':          'spin':          'normalize':          'color':
-        'linewidth':          'dash':          'split_on':          'scale':
-        The final DOS will be multiplied by this number. }
+    	Here you can ask for the specific PDOS that you need.
+    	TIP: Queries can be activated and deactivated.   Each item is a
+    	dict.    Structure of the dict: {         'name':          'species':
+    	'atoms':    Structure of the dict: {         'index':    Structure of
+    	the dict: {         'in':  }         'fx':          'fy':
+    	'fz':          'x':          'y':          'z':          'Z':
+    	'neighbours':    Structure of the dict: {         'range':
+    	'R':          'neigh_tag':  }         'tag':          'seq':  }
+    	'orbitals':          'spin':          'normalize':          'color':
+    	'linewidth':          'dash':          'split_on':          'scale':
+    	The final DOS will be multiplied by this number. }
     root_fdf: fdfSileSiesta, optional
-        Path to the fdf file that is the 'parent' of the results.
+    	Path to the fdf file that is the 'parent' of the results.
     results_path: str, optional
-        Directory where the files with the simulations results are
-        located. This path has to be relative to the root fdf.
+    	Directory where the files with the simulations results are
+    	located. This path has to be relative to the root fdf.
     entry_points_order: array-like, optional
-        Order with which entry points will be attempted.
+    	Order with which entry points will be attempted.
     backend:  optional
-        Directory where the files with the simulations results are
-        located. This path has to be relative to the root fdf.
+    	Directory where the files with the simulations results are
+    	located. This path has to be relative to the root fdf.
     """
 
     #Define all the class attributes
@@ -120,6 +125,15 @@ class PdosPlot(Plot):
                 "placeholder": "Write the path to your TBT.nc file here...",
             },
             help = """This parameter explicitly sets a .TBT.nc file. Otherwise, the PDOS file is attempted to read from the fdf file """
+        ),
+
+        SileInput(key='wfsx_file', name='Path to WFSX file',
+            dtype=sisl.io.siesta.wfsxSileSiesta,
+            default=None,
+            help="""The WFSX file to get the eigenstates.
+            In standard SIESTA nomenclature, this should probably be the *.fullBZ.WFSX file, as it is the one
+            that contains the eigenstates from the full brillouin zone.
+            """
         ),
 
         GeometryInput(
@@ -300,7 +314,7 @@ class PdosPlot(Plot):
         #Get the info from the .PDOS file
         self.geometry, self.E, self.PDOS = self.get_sile(pdos_file or "pdos_file").read_data()
 
-    @entry_point("TB trans", 1)
+    @entry_point("TB trans", 2)
     def _read_TBtrans(self, root_fdf, tbt_nc):
         """
         Reads the PDOS from a *.TBT.nc file coming from a TBtrans run.
@@ -320,7 +334,43 @@ class PdosPlot(Plot):
         # Read the geometry from the TBT.nc file and get only the device part
         self.geometry = tbt_sile.read_geometry(**read_geometry_kwargs).sub(tbt_sile.a_dev)
 
-    @entry_point('hamiltonian', 2)
+    @entry_point('wfsx file', 3)
+    def _read_from_wfsx(self, root_fdf, wfsx_file, Erange, nE, E0, distribution):
+        """Generates the PDOS values from a file containing eigenstates."""
+        # Read the hamiltonian. We need it because we need the overlap matrix.
+        if not hasattr(self, "H"):
+            self.setup_hamiltonian()
+
+        # Get the wfsx file
+        wfsx_sile = self.get_sile(wfsx_file or "wfsx_file")
+
+        # Read the sizes of the file, which contain the number of spin channels
+        # and the number of orbitals and the number of k points.
+        sizes = wfsx_sile.read_sizes()
+        # Check that spin sizes of hamiltonian and wfsx file match
+        assert self.H.spin.size == sizes['nspin'], \
+            f"Hamiltonian has spin size {self.H.spin.size} while file has spin size {sizes['nspin']}"
+        # Get the size of the spin channel. The size returned might be 8 if it is a spin-orbit
+        # calculation, but we need only 4 spin channels (total, x, y and z), same as with non-colinear
+        nspin = min(4, sizes['nspin'])
+
+        # Get the energies for which we need to calculate the PDOS.
+        self.E = np.linspace(Erange[0], Erange[-1], nE) + E0
+
+        # Initialize the PDOS array
+        self.PDOS = np.zeros((nspin, sizes["nou"], self.E.shape[0]), dtype=np.float64)
+
+        # Loop through eigenstates in the WFSX file and add their contribution to the PDOS.
+        # Note that we pass the hamiltonian as the parent here so that the overlap matrix
+        # for each point can be calculated by eigenstate.PDOS()
+        for eigenstate in wfsx_sile.yield_eigenstate(self.H):
+            spin = eigenstate.info.get("spin", 0)
+            if nspin == 4:
+                spin = slice(None)
+
+            self.PDOS[spin] += eigenstate.PDOS(self.E, distribution=distribution) * eigenstate.info.get("weight", 1)
+
+    @entry_point('hamiltonian', 4)
     def _read_from_H(self, kgrid, kgrid_displ, Erange, nE, E0, distribution):
         """
         Calculates the PDOS from a sisl Hamiltonian.
@@ -338,7 +388,7 @@ class PdosPlot(Plot):
 
         self.E = np.linspace(Erange[0], Erange[-1], nE) + E0
 
-        self.mp = sisl.MonkhorstPack(self.H, kgrid, kgrid_displ)
+        self.bz = sisl.MonkhorstPack(self.H, kgrid, kgrid_displ)
 
         # Define the available spins
         spin_indices = [0]
@@ -348,7 +398,7 @@ class PdosPlot(Plot):
         # Calculate the PDOS for all available spins
         PDOS = []
         for spin in spin_indices:
-            with self.mp.apply(pool=_do_parallel_calc) as parallel:
+            with self.bz.apply(pool=_do_parallel_calc) as parallel:
                 spin_PDOS = parallel.average.eigenstate(
                     spin=spin,
                     wrap=lambda eig: eig.PDOS(self.E, distribution=distribution)

--- a/sisl/viz/plots/tests/test_bands.py
+++ b/sisl/viz/plots/tests/test_bands.py
@@ -76,8 +76,11 @@ class TestBandsPlot(_TestPlot):
             # from two different prespectives
             if name.startswith("sisl_H_path"):
                 # Passing a list of points (as if we were interacting from a GUI)
+                # We want 6 points in total. This is the path that we want to get:
+                # [0,0,0] --2-- [2/3, 1/3, 0] --1-- [1/2, 0, 0]
                 path = [{"active": True, "x": x, "y": y, "z": z, "divisions": 3,
                     "name": tick} for tick, (x, y, z) in zip(["Gamma", "M", "K"], [[0, 0, 0], [2/3, 1/3, 0], [1/2, 0, 0]])]
+                path[-1]['divisions'] = 2
 
                 init_func = partial(H.plot.bands, band_structure=path)
             else:


### PR DESCRIPTION
Addresses https://github.com/zerothi/sisl/issues/147 by making python keep track of the fortran file unit.

Now if one wants to iterate over all eigenstates the whole file is only read once, in contrast to the previous implementation, which read the file from the beginning at each iteration. This quick code snippet shows the difference in performance for iterating over all eigenstates for the file `spin_unpolarized.bands.WFSX`, which contains 95 k points:

```python
import sisl

wfsx = sisl.get_sile("spin_unpolarized.bands.WFSX")
geom = sisl.geom.diamond()

def iterate(which):
    it = {"new": wfsx.yield_eigenstate, "old": wfsx.old_yield_eigenstate}[which]
    
    for state in it(parent=geom):
        pass
    
%timeit iterate("new")
%timeit iterate("old")
```
```
1.87 ms ± 90.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
35.7 ms ± 97.1 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

I have some doubts:
- I think the spin and k indices are not written on the WFSX file as the old implementation assumes (`spin-loop[k-loop]`). I believe it's the opposite (`k-loop[spin-loop]`). You can test this by trying to read a polarized WFSX file, which will fail on the second eigenstate. I attach one so that you can test it. If this is true, I need to make some changes to the old implementation.
- You already mentioned in https://github.com/zerothi/sisl/issues/147 that the reading is unstable. I think I stumble upon this when reading the polarized file attached here. The binary check raises an error at `ik = 68`. Why is this? :sweat_smile: 

Files (too big to attach): https://drive.google.com/drive/folders/1lgqckfkpq0mZo-3ucBxtXvz5fMKlXCQv?usp=sharing