### PR TITLE
Quick bug fix. Plot was not callable.

### DIFF
--- a/sisl/viz/_plotables.py
+++ b/sisl/viz/_plotables.py
@@ -24,7 +24,7 @@ class ObjectPlotHandler(ObjectDispatcher):
     def __call__(self, *args, **kwargs):
         """If the plot handler is called, we will run the default plotting function
         unless the keyword method has been passed."""
-        return getattr(self, kwargs.pop("method", self._default))(*args, **kwargs)
+        return getattr(self, kwargs.pop("method", self._default) or self._default)(*args, **kwargs)
 
 
 class PlotDispatch(AbstractDispatch):

--- a/sisl/viz/tests/test_plot.py
+++ b/sisl/viz/tests/test_plot.py
@@ -8,7 +8,7 @@ This file tests general Plot behavior.
 """
 from copy import deepcopy
 import os
-from sisl.messages import SislWarning
+from sisl.messages import SislInfo, SislWarning
 
 import pytest
 import numpy as np
@@ -224,3 +224,10 @@ class TestSubPlots(TestMultiplePlot):
 class _TestAnimation(TestMultiplePlot):
 
     PlotClass = Animation
+
+def test_calling_Plot():
+    # Just check that it doesn't raise any error
+    with pytest.warns(SislInfo):
+        plot = Plot("nonexistent.LDOS")
+
+    assert isinstance(plot, GridPlot)


### PR DESCRIPTION
Since I always use the `.plot()` method, I didn't realise that 

```python
from sisl.viz import Plot
Plot("file.ext")
```

was broken. Now it works again thanks to the report of @lindasheila :)
