### PR TITLE
Use PeriodicTable to convert atomic labels to atomic numbers in xsf file

### DIFF
--- a/sisl/io/xsf.py
+++ b/sisl/io/xsf.py
@@ -9,7 +9,7 @@ import numpy as np
 from .sile import *
 
 from sisl._internal import set_module
-from sisl import Geometry, AtomUnknown, SuperCell
+from sisl import Geometry, AtomUnknown, SuperCell, PeriodicTable
 from sisl.utils import str_spec
 import sisl._array as _a
 
@@ -205,7 +205,7 @@ class xsfSile(Sile):
                 for _ in range(int(line[0])):
                     line = self.readline().split()
                     if not xyz_set[istep]:
-                        iatom.append(int(line[0]))
+                        iatom.append(PeriodicTable().Z(line[0]))
                         ixyz.append([float(x) for x in line[1:4]])
                     if ret_data and len(line) > 4:
                         idata.append([float(x) for x in line[4:]])


### PR DESCRIPTION
The XSF file format allows the use of atomic labels instead of atomic numbers. The xsfSile has been modified to use PeriodicTable().Z() to convert these labels to the corresponding atomic numbers if these labels are used in an xsf file.