### PR TITLE
Enabled reading zipped *.fdf.gz files

### DIFF
--- a/sisl/io/siesta/fdf.py
+++ b/sisl/io/siesta/fdf.py
@@ -7,6 +7,7 @@ import numpy as np
 import scipy as sp
 from os.path import isfile
 import itertools as itools
+import gzip
 
 from ..sile import add_sile, get_sile_class, sile_fh_open, sile_raise_write, SileError
 from .sile import SileSiesta
@@ -107,6 +108,9 @@ class fdfSileSiesta(SileSiesta):
         if self.dir_file(f).is_file():
             self._parent_fh.append(self.fh)
             self.fh = self.dir_file(f).open(self._mode)
+        elif self.dir_file(f + '.gz').is_file():
+            self._parent_fh.append(self.fh)
+            self.fh = gzip.open(self.dir_file(f + '.gz'), mode='rt')
         else:
             warn(str(self) + f' is trying to include file: {f} but the file seems not to exist? Will disregard file!')
 

--- a/sisl/io/sile.py
+++ b/sisl/io/sile.py
@@ -555,7 +555,7 @@ class Sile(BaseSile):
 
     def _open(self):
         if self.file.suffix == ".gz":
-            self.fh = gzip.open(str(self.file))
+            self.fh = gzip.open(str(self.file), mode='rt')
         else:
             self.fh = self.file.open(self._mode)
         self._line = 0


### PR DESCRIPTION
I was trying to use sisl to read some zipped SIESTA fdf files and found that this was not working for two reasons:
* reading files *via* `gzip` should be using `mode=rt` (text mode) to handle comparisons like `line.startswith('#')` (with `mode=r` the strings are of `binary` type),
* include-files like `%include OTHER.fdf` means that sisl should also check for `OTHER.fdf.gz`. 

This branch should fix the above.
