### PR TITLE
enh: enabled zak phase calculations to automatically shift for mirror…

### DIFF
--- a/sisl/physics/state.py
+++ b/sisl/physics/state.py
@@ -858,7 +858,7 @@ class State(ParentContainer):
             idx = np.unravel_index(_argmax(_abs(s)), s.shape)
             s *= phi * _conj(s[idx] / _abs(s[idx]))
 
-    def change_gauge(self, gauge):
+    def change_gauge(self, gauge, offset=(0, 0, 0)):
         r""" In-place change of the gauge of the state coefficients
 
         The two gauges are related through:
@@ -873,6 +873,8 @@ class State(ParentContainer):
         ----------
         gauge : {'R', 'r'}
             specify the new gauge for the mode coefficients
+        offset : array_like, optional
+            whether the coordinates should be offset by another phase-factor
         """
         # These calls will fail if the gauge is not specified.
         # In that case it will not do anything
@@ -889,7 +891,8 @@ class State(ParentContainer):
             return
 
         g = self.parent.geometry
-        phase = g.xyz[g.o2a(_a.arangei(g.no)), :] @ (k @ g.rcell)
+        xyz = g.xyz + offset
+        phase = xyz[g.o2a(_a.arangei(g.no)), :] @ (k @ g.rcell)
 
         try:
             if not self.parent.spin.is_diagonal:

--- a/sisl/physics/tests/test_hamiltonian.py
+++ b/sisl/physics/tests/test_hamiltonian.py
@@ -783,7 +783,7 @@ class TestHamiltonian:
         bz2 = BandStructure.param_circle(H, 20, 0.01, [0, 0, 1], [1/3] * 3, loop=True)
         assert np.allclose(berry_phase(bz1), berry_phase(bz2))
 
-    def test_berry_phase_zak(self):
+    def test_berry_phase_zak_x(self):
         # SSH model, topological cell
         g = Geometry([[-.6, 0, 0], [0.6, 0, 0]], Atom(1, 1.001), sc=[2, 10, 10])
         g.set_nsc([3, 1, 1])
@@ -797,6 +797,37 @@ class TestHamiltonian:
         assert np.allclose(np.abs(berry_phase(bz, sub=0, method='zak')), np.pi)
         # Just to do the other branch
         berry_phase(bz, method='zak')
+
+    def test_berry_phase_zak_y(self):
+        # SSH model, topological cell
+        g = Geometry([[0, -.6, 0], [0, 0.6, 0]], Atom(1, 1.001), sc=[10, 2, 10])
+        g.set_nsc([1, 3, 1])
+        H = Hamiltonian(g)
+        H.construct([(0.1, 1.0, 1.5), (0, 1., 0.5)])
+        # Contour
+        k = np.linspace(0.0, 1.0, 101)
+        K = np.zeros([k.size, 3])
+        K[:, 1] = k
+        bz = BrillouinZone(H, K)
+        assert np.allclose(np.abs(berry_phase(bz, sub=0, method='zak')), np.pi)
+        # Just to do the other branch
+        berry_phase(bz, method='zak')
+
+    def test_berry_phase_zak_offset(self):
+        # SSH model, topological cell
+        g = Geometry([[0., 0, 0], [1.2, 0, 0]], Atom(1, 1.001), sc=[2, 10, 10])
+        g.set_nsc([3, 1, 1])
+        H = Hamiltonian(g)
+        H.construct([(0.1, 1.0, 1.5), (0, 1., 0.5)])
+        # Contour
+        k = np.linspace(0.0, 1.0, 101)
+        K = np.zeros([k.size, 3])
+        K[:, 0] = k
+        bz = BrillouinZone(H, K)
+        zak = berry_phase(bz, sub=0, method='zak')
+        assert np.allclose(np.abs(zak), np.pi)
+        zak_origin = berry_phase(bz, sub=0, method='zak:origin')
+        assert not np.allclose(np.abs(zak), np.abs(zak_origin))
 
     def test_berry_phase_method_fail(self):
         # wrong method keyword


### PR DESCRIPTION
… sym

When the geometry is not created with mirror symmetry the Zak-phase
is not correct. The coordinates must be located in origin around the
mirror symmetric point which is not natural for end-users.

@tfrederiksen please have a look here, comments and suggestions are most welcome.

I don't know if it should rather be an offset that is defaulting to the average position, or? Ideas?

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #410 
 - [x] Tests added
 - [x] Documentation for functionality

