### PR TITLE
Support for discontinous bands plots

### DIFF
--- a/sisl/viz/backends/templates/_plots/bands.py
+++ b/sisl/viz/backends/templates/_plots/bands.py
@@ -56,6 +56,7 @@ class BandsBackend(Backend):
 
         if "spin" not in filtered_bands.coords:
             filtered_bands = filtered_bands.expand_dims("spin")
+
         # Now loop through all bands to draw them
         for ispin, spin_bands in enumerate(filtered_bands.transpose('spin', 'band', 'k')):
             line_style = line


### PR DESCRIPTION
Adds support for the recently added feature in `BandStructure`.

Discontinous band structures are also supported for spin texture
and fatbands plots.

As an example of discontinous fatbands:

```python
import sisl

gr = sisl.geom.graphene()
H = sisl.Hamiltonian(gr)
H.construct([(0.1, 1.44), (0, -2.7)])
H[0,0] = -2

bz = sisl.BandStructure(H, [[0, 0, 0], [2/3, 1/3, 0], None, [2/3, 1/3, 0], [1/2, 0, 0]], 30, ["Gamma", "M","M", "K"])

bands_plot = bz.plot.fatbands()
bands_plot.split_groups(on="atoms", name="Atom $atoms")
```

![newplot - 2021-12-14T015844 155](https://user-images.githubusercontent.com/42074085/145913253-9a67de81-3f92-4ffd-9c6b-45fc254937c1.png)

