### PR TITLE
bug: fixed bug in cartesian cell check at GridPlot

### DIFF
--- a/sisl/viz/plots/grid.py
+++ b/sisl/viz/plots/grid.py
@@ -497,7 +497,7 @@ class GridPlot(Plot):
         tol: float, optional
             Threshold value to consider a component of the cell nonzero.
         """
-        bigger_than_tol = cell > tol
+        bigger_than_tol = abs(cell) > tol
         return bigger_than_tol.sum() == 3 and bigger_than_tol.any(axis=0).all() and bigger_than_tol.any(axis=1).all()
 
     def _is_1D_cartesian(self, cell, coord_ax, tol=1e-3):

--- a/sisl/viz/plots/tests/conftest.py
+++ b/sisl/viz/plots/tests/conftest.py
@@ -30,6 +30,13 @@ def siesta_test_files(sisl_files):
 
     return _siesta_test_files
 
+@pytest.fixture(scope="session")
+def vasp_test_files(sisl_files):
+
+    def _siesta_test_files(path):
+        return sisl_files(osp.join('sisl', 'io', 'vasp', path))
+
+    return _siesta_test_files
 
 class _TestPlot:
 

--- a/sisl/viz/plots/tests/test_grid.py
+++ b/sisl/viz/plots/tests/test_grid.py
@@ -12,6 +12,7 @@ from typing import ChainMap
 
 import pytest
 import numpy as np
+import os.path as osp
 
 import sisl
 from sisl.viz import GridPlot, Animation
@@ -39,13 +40,16 @@ class TestGridPlot(_TestPlot):
         "grid_shape" # Tuple indicating the grid shape
     ]
 
-    @pytest.fixture(scope="class", params=["siesta_RHO", "complex_grid"])
-    def init_func_and_attrs(self, request, siesta_test_files):
+    @pytest.fixture(scope="class", params=["siesta_RHO", "VASP CHGCAR", "complex_grid"])
+    def init_func_and_attrs(self, request, siesta_test_files, vasp_test_files):
         name = request.param
 
         if name == "siesta_RHO":
             init_func = sisl.get_sile(siesta_test_files("SrTiO3.RHO")).plot
             attrs = {"grid_shape": (48, 48, 48)}
+        if name == "VASP CHGCAR":
+            init_func = sisl.get_sile(vasp_test_files(osp.join("graphene", "CHGCAR"))).plot.grid
+            attrs = {"grid_shape": (24, 24, 100)}
         elif name == "complex_grid":
             complex_grid_shape = (8, 10, 10)
             np.random.seed(1)
@@ -196,12 +200,12 @@ class TestGridPlot(_TestPlot):
             assert len(scanned.frames) == 2
 
             # Provide step in Ang
-            step = plot.grid.cell[0, 0]/2
+            step = plot.grid.cell[2, 2]/2
             scanned = plot.scan(along="z", step=step, mode="as_is")
             assert len(scanned.frames) == 2
 
             # Provide breakpoints
-            breakpoints = [plot.grid.cell[0, 0]*frac for frac in [1/3, 2/3, 3/3]]
+            breakpoints = [plot.grid.cell[2, 2]*frac for frac in [1/3, 2/3, 3/3]]
             scanned = plot.scan(along="z", breakpoints=breakpoints, mode="as_is")
             assert len(scanned.frames) == 2
 


### PR DESCRIPTION
There was a little bug when checking whether the grid needed to be transformed.

`[1,0,0] , [1,1,0], [0,0,1]` was correctly detected as non-cartesian but `[1,0,0] , [-1,1,0], [0,0,1]` wasn't (because of the negative sign).

I discovered it when plotting the graphene `CHGCAR` in the test files so I figured I might as well include it in the tests :)

Before fix:

![newplot - 2022-01-10T202739 132](https://user-images.githubusercontent.com/42074085/148826952-b930736d-a216-4ea7-af43-4cfa65dda5c9.png)

After fix:

![newplot - 2022-01-10T202701 582](https://user-images.githubusercontent.com/42074085/148826986-0592f772-566d-4102-8a47-8b0ed28c942a.png)

