### PR TITLE
Allow bond styling in GeometryPlot

### DIFF
--- a/docs/visualization/viz_module/showcase/GeometryPlot.ipynb
+++ b/docs/visualization/viz_module/showcase/GeometryPlot.ipynb
@@ -635,6 +635,46 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Custom styles for bonds\n",
+    "\n",
+    "Just as `atoms_style`, there is a setting that allows you to tweak the **styling of the bonds**: `bonds_style`. Unlike `atoms_style`, for now only one style specification can be provided. That is, `bonds_style` only accepts a dictionary, not a list of dictionaries. The dictionary can contain the following keys: `color`, `width` and `opacity`, but you don't need to provide all of them.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot.update_settings(axes=\"yx\", bonds_style={\"color\": \"orange\", \"width\": 5, \"opacity\": 0.5})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "    \n",
+    "Coloring individual bonds\n",
+    "    \n",
+    "It is **not possible to style bonds individually** yet, e.g. using a colorscale. However, it is one of the goals to improve ``GeometryPlot`` and some thought has already been put into how to design the interface to make it as usable as possible. Rest assured that when the right interface is found, coloring individual bonds will be allowed, as well as drawing bicolor bonds, as most rendering softwares do.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = plot.update_settings(axes=\"xyz\", bonds_style={})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Drawing arrows\n",
     "\n",
     "It is very common that you want to display arrows on the atoms, **to show some vector property** such as a force or an electric field.\n",
@@ -816,7 +856,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/sisl/viz/backends/blender/_plots/geometry.py
+++ b/sisl/viz/backends/blender/_plots/geometry.py
@@ -35,13 +35,13 @@ def add_atoms_frame(ani_objects, child_objects, frame):
         ani_obj.scale = child_obj.scale
         ani_obj.keyframe_insert(data_path="scale", frame=frame)
 
-        # Set the atom color
-        ani_obj.data.materials[0].node_tree.nodes["Principled BSDF"].inputs[0].default_value = child_obj.data.materials[0].node_tree.nodes["Principled BSDF"].inputs[0].default_value
-        ani_obj.data.materials[0].node_tree.nodes["Principled BSDF"].inputs[0].keyframe_insert(data_path="default_value", frame=frame)
+        # Set the atom color and opacity
+        ani_mat_inputs = ani_obj.data.materials[0].node_tree.nodes["Principled BSDF"].inputs
+        child_mat_inputs = child_obj.data.materials[0].node_tree.nodes["Principled BSDF"].inputs
 
-        # And opacity
-        ani_obj.data.materials[0].node_tree.nodes["Principled BSDF"].inputs[19].default_value = child_obj.data.materials[0].node_tree.nodes["Principled BSDF"].inputs[19].default_value
-        ani_obj.data.materials[0].node_tree.nodes["Principled BSDF"].inputs[19].keyframe_insert(data_path="default_value", frame=frame)
+        for input_key in ("Base Color", "Alpha"):
+            ani_mat_inputs[input_key].default_value = child_mat_inputs[input_key].default_value
+            ani_mat_inputs[input_key].keyframe_insert(data_path="default_value", frame=frame)
 
 
 class BlenderGeometryBackend(BlenderBackend, GeometryBackend):
@@ -82,9 +82,9 @@ class BlenderGeometryBackend(BlenderBackend, GeometryBackend):
         self._color_obj(atom, color, opacity=opacity)
 
     def _draw_bonds_3D(self, *args, line=None, **kwargs):
-        # Set the width of the bonds to 0.2, otherwise they look gigantic.
+        # Multiply the width of the bonds to 0.2, otherwise they look gigantic.
         line = line or {}
-        line["width"] = 0.2
+        line["width"] = 0.2 * line.get("width", 1)
         # And call the method to draw bonds (which will use self.draw_line3D)
         collection = self.get_collection("Bonds")
         super()._draw_bonds_3D(*args, line=line, collection=collection, **kwargs)

--- a/sisl/viz/backends/blender/backend.py
+++ b/sisl/viz/backends/blender/backend.py
@@ -36,11 +36,12 @@ def add_line_frame(ani_objects, child_objects, frame):
 
         # Loop through all the materials that the object might have associated
         for ani_material, child_material in zip(ani_obj.data.materials, child_obj.data.materials):
-            ani_material.node_tree.nodes["Principled BSDF"].inputs[0].default_value = child_material.node_tree.nodes["Principled BSDF"].inputs[0].default_value
-            ani_material.node_tree.nodes["Principled BSDF"].inputs[0].keyframe_insert(data_path="default_value", frame=frame)
+            ani_mat_inputs = ani_material.node_tree.nodes["Principled BSDF"].inputs
+            child_mat_inputs = child_material.node_tree.nodes["Principled BSDF"].inputs
 
-            ani_material.node_tree.nodes["Principled BSDF"].inputs[19].default_value = child_material.node_tree.nodes["Principled BSDF"].inputs[19].default_value
-            ani_material.node_tree.nodes["Principled BSDF"].inputs[19].keyframe_insert(data_path="default_value", frame=frame)
+            for input_key in ("Base Color", "Alpha"):
+                ani_mat_inputs[input_key].default_value = child_mat_inputs[input_key].default_value
+                ani_mat_inputs[input_key].keyframe_insert(data_path="default_value", frame=frame)
 
 
 class BlenderBackend(Backend):
@@ -188,8 +189,10 @@ class BlenderBackend(Backend):
             mat = bpy.data.materials.new("material")
             mat.use_nodes = True
 
-            mat.node_tree.nodes["Principled BSDF"].inputs[0].default_value = (*color, 1)
-            mat.node_tree.nodes["Principled BSDF"].inputs[19].default_value = opacity
+            BSDF_inputs = mat.node_tree.nodes["Principled BSDF"].inputs
+
+            BSDF_inputs["Base Color"].default_value = (*color, 1)
+            BSDF_inputs["Alpha"].default_value = opacity
 
             obj.active_material = mat
 

--- a/sisl/viz/plots/bond_length.py
+++ b/sisl/viz/plots/bond_length.py
@@ -55,6 +55,11 @@ class BondLengthMap(GeometryPlot):
         A file name that can read a geometry
     show_bonds: bool, optional
         Show bonds between atoms.
+    bonds_style: dict, optional
+        Customize the style of the bonds by passing style specifications.
+        Currently, you can only pass one style specification. Styling bonds
+        individually is not supported yet, but it will be in the future.
+        Structure of the dict: {          }
     axes:  optional
         The axis along which you want to see the geometry.              You
         can provide as many axes as dimensions you want for your plot.
@@ -292,7 +297,7 @@ class BondLengthMap(GeometryPlot):
 
         self.get_param("atoms").update_options(self.geometry)
 
-    def _wrap_bond3D(self, bond, show_strain=False):
+    def _wrap_bond3D(self, bond, bonds_styles, show_strain=False):
         """
         Receives a bond and sets its color to the bond length for the 3D case
         """
@@ -306,12 +311,12 @@ class BondLengthMap(GeometryPlot):
         self.colors.append(color)
 
         return {
-            **self._default_wrap_bond3D(bond),
+            **self._default_wrap_bond3D(bond, bonds_styles=bonds_styles),
             "color": color,
             "name": name
         }
 
-    def _wrap_bond2D(self, bond, xys, show_strain=False):
+    def _wrap_bond2D(self, bond, xys, bonds_styles, show_strain=False):
         """
         Receives a bond and sets its color to the bond length for the 2D case
         """
@@ -324,7 +329,10 @@ class BondLengthMap(GeometryPlot):
 
         self.colors.append(color)
 
-        return {"xys": xys, "color": color, "name": name}
+        return {
+            **self._default_wrap_bond2D(bond, xys, bonds_styles=bonds_styles),
+            "color": color, "name": name
+        }
 
     @staticmethod
     def _bond_length(geom, bond):

--- a/sisl/viz/plots/tests/test_geometry.py
+++ b/sisl/viz/plots/tests/test_geometry.py
@@ -181,6 +181,21 @@ class TestGeometry(_TestPlot):
                             np.tile(atoms_style[key][sorted_atoms], nsc[0]*nsc[1]*nsc[2])
                         ).sum() == (plot.geometry.na - 1) * nsc[0]*nsc[1]*nsc[2]
 
+    def test_bonds_style(self, plot, axes, ndim, nsc):
+        if ndim == 1:
+            return
+
+        bonds_style = {"width": 2, "opacity": 0.6}
+
+        plot.update_settings(atoms=None, axes=axes, nsc=nsc, bonds_style=bonds_style)
+
+        bonds_props = plot._for_backend["bonds_props"]
+
+        assert bonds_props[0]["width"] == 2
+        assert bonds_props[0]["opacity"] == 0.6
+
+        plot.update_settings(bonds_style={})
+
     def test_arrows(self, plot, axes, ndim, nsc):
         # Check that arrows accepts both a dictionary and a list and the data is properly transferred
         for arrows in ({"data": [0, 0, 2]}, [{"data": [0, 0, 2]}]):


### PR DESCRIPTION
@tfrederiksen wanted to give a different styling to the bonds, but that was not yet supported. I thought I'd sneak this in before the release just in case someone else might need it.

To style bonds, you need to use the `bonds_style` setting, just as you do with `atoms_style`. However, for now only one styling can be provided for all bonds. I will add per-bond styling in the future but I want to think about the interface carefully so I didn't want to rush it. When it is added it will use `bonds_style` as well, so there will be no problems with backward compatibility.

Here's an example:

```python
import sisl
import sisl.viz

sisl.geom.graphene_nanoribbon(7).plot(
    axes="yx", atoms_scale=1.5, bonds_style={"color": "orange", "width": 8, "opacity": 0.7},
)
```

![newplot - 2022-01-15T001337 681](https://user-images.githubusercontent.com/42074085/149597164-1c79d4be-6b5d-4cc2-aae0-7190f3447f32.png)


