### PR TITLE
mnt: bumped Python requirement

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,7 +22,7 @@ the actual installation begins.
 
 For running sisl you are required these versions:
 
-- `Python`_ 3.6 or above
+- `Python`_ 3.7 or above
 - `numpy`_ (1.13 or later)
 - `scipy`_ (0.18 or later)
 - `netCDF4-python <netcdf4-py_>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ build-backend = "setuptools.build_meta"
 
 # Top most items are probably changed the most
 [project]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 
 dependencies = [
     "numpy>=1.13",


### PR DESCRIPTION
This allows namedtuples with defaults and also
aligns with numpy requirements.