### PR TITLE
Dependencies not installed on pip install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,13 @@
 [metadata]
 name = sisl
 
+[options]
+install_requires =
+    numpy>=1.13
+    scipy>=0.18
+    netCDF4
+    pyparsing>=1.5.7
+
 [options.entry_points]
 console_scripts =
   sgeom = sisl.geometry:sgeom
@@ -12,6 +19,14 @@ console_scripts =
   sdata = sisl.utils._sisl_cmd:sisl_cmd
   stoolbox = sisl_toolbox.cli:stoolbox_cli
 
+[options.extras_require]
+analysis = xarray>=0.10.0; tqdm
+viz = dill >= 0.3.2; pathos; pandas; xarray >= 0.10.0; scikit-image; plotly; matplotlib; ase
+viz-plotly = dill >= 0.3.2; pathos; pandas; xarray >= 0.10.0; scikit-image; plotly
+viz-matplotlib = dill >= 0.3.2; pathos; pandas; xarray >= 0.10.0; scikit-image; matplotlib
+viz-blender = dill >= 0.3.2; pathos; pandas; xarray >= 0.10.0; scikit-image;
+viz-ase = dill >= 0.3.2; pathos; pandas; xarray >= 0.10.0; scikit-image; ase
+test= pytest; pytest-cov; pytest-env; pytest-faulthandler; coveralls; tqdm; dill >= 0.3.2; pathos; pandas; xarray >= 0.10.0; scikit-image; plotly; matplotlib; ase
 
 [flake8]
 max-complexity = 18


### PR DESCRIPTION
Closes #428.

It was not only optional dependencies that were not working, but even install dependencies. I.e. `pip install sisl` did not install anything more than sisl. I wonder if the `[project]` table in `pyproject.toml` is simply ignored by `pip` / `setuptools`? :thinking: 