### PR TITLE
Fixed conditional numpy versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ requires = [
     # should fix #310
     "oldest-supported-numpy; sys_platform != 'win32'",
     # TODO work-arounds for windows installations
-    "numpy==1.19.5 ; sys_platform == 'win32' ; python_version <= '3.9'",
-    "numpy==1.21.5 ; sys_platform == 'win32' ; python_version >= '3.10'",
+    "numpy==1.19.5 ; sys_platform == 'win32' and python_version <= '3.9'",
+    "numpy==1.21.5 ; sys_platform == 'win32' and python_version >= '3.10'",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -30,8 +30,8 @@ requires-python = ">=3.7"
 
 dependencies = [
     # TODO work-arounds for windows installations
-    "numpy==1.19.5 ; sys_platform == 'win32' ; python_version <= '3.9'",
-    "numpy==1.21.5 ; sys_platform == 'win32' ; python_version >= '3.10'",
+    "numpy>=1.19.5 ; sys_platform == 'win32' and python_version <= '3.9'",
+    "numpy>=1.21.5 ; sys_platform == 'win32' and python_version >= '3.10'",
     "numpy>=1.13 ; sys_platform != 'win32'",
     "scipy>=0.18",
     "netCDF4",

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,23 +11,10 @@ readme = file: README.md
 [options]
 zip_safe = False
 
-# TODO update this together with pyproject.toml
-setup_requires =
-   wheel
-   setuptools>=46.0
-   setuptools_scm>=6.2
-   Cython>=0.28
-   # see https://github.com/scipy/oldest-supported-numpy/
-   # should fix #310
-   oldest-supported-numpy; platform_system != 'Windows'
-   # workarounds for windows installations
-   numpy==1.19.5 ; platform_system == 'Windows' ; python_version <= '3.9'
-   numpy==1.21.5 ; platform_system == 'Windows' ; python_version >= '3.10'
-
 install_requires =
     # these two requirements are work-arounds for windows installations
-    numpy==1.19.5 ; platform_system == 'Windows' ; python_version <= '3.9'
-    numpy==1.21.5 ; platform_system == 'Windows' ; python_version >= '3.10'
+    numpy>=1.19.5 ; platform_system == 'Windows' and python_version <= '3.9'
+    numpy>=1.21.5 ; platform_system == 'Windows' and python_version >= '3.10'
     numpy>=1.13 ; platform_system != 'Windows'
     scipy>=0.18
     netCDF4


### PR DESCRIPTION
The builds were failing with the recently added conditions.
- Two conditions must be joined with `and` or `or`, they were joined with a semicolon and therefore raised a parsing error.
- I removed `setup_requires` in `setup.cfg`, since it only adds confusion and is deprecated by `setuptools`. See the note under https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#package-requirement.
- Updated installation numpy to be `>=` than the build numpy version, not equal.