### PR TITLE
Docs for displaying "volumes"

### DIFF
--- a/docs/visualization/viz_module/showcase/GridPlot.ipynb
+++ b/docs/visualization/viz_module/showcase/GridPlot.ipynb
@@ -37,6 +37,7 @@
    "source": [
     "import sisl\n",
     "import sisl.viz\n",
+    "import numpy as np\n",
     "# This is just for convenience to retreive files\n",
     "siesta_files = sisl._environ.get_environ_variable(\"SISL_FILES_TESTS\") / \"sisl\" / \"io\" / \"siesta\""
    ]
@@ -339,6 +340,53 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Volumetric display\n",
+    "----\n",
+    "\n",
+    "Using isosurfaces in the 3D representation, one can achieve a sense of volumetric data. We can do so by asking for **multiple isosurfaces an setting the opacity** of each one properly.\n",
+    "\n",
+    "You can play with it and do the exact thing that you wish. For example, we can represent isosurfaces at increasing values, with the higher values being more opaque:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot.update_settings(\n",
+    "    axes=\"xyz\", isos=[{\"frac\":frac, \"opacity\": frac/2, \"color\": \"green\"} for frac in np.linspace(0.1, 0.8, 20)],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The more surfaces you add, the more sense of depth you'll acheive. But of course, it will be more expensive to render.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "    \n",
+    "Note\n",
+    "    \n",
+    "Playing with colors (e.g. setting a colorscale) and not just opacities might give you even a better sense of depth. A way of automatically handling this for you might be introduced in the future.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = plot.update_settings(axes=\"xy\", isos=[])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Colorscales\n",
     "\n",
     "You might have already seen that 2d representations use a colorscale. You can change it with the `colorscale` setting."
@@ -350,7 +398,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot.update_settings(isos=[], colorscale=\"temps\")"
+    "plot.update_settings(colorscale=\"temps\")"
    ]
   },
   {
@@ -604,7 +652,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/sisl/viz/backends/blender/_plots/grid.py
+++ b/sisl/viz/backends/blender/_plots/grid.py
@@ -21,21 +21,23 @@ class BlenderGridBackend(BlenderBackend, GridBackend):
             obj = bpy.data.objects.new(mesh.name, mesh)
 
             col.objects.link(obj)
-            bpy.context.view_layer.objects.active = obj
+            #bpy.context.view_layer.objects.active = obj
 
             edges = []
             mesh.from_pydata(isosurf["vertices"], edges, isosurf["faces"].tolist())
 
-            mat = bpy.data.materials.new("material")
-            mat.use_nodes = True
+            self._color_obj(obj, isosurf["color"], isosurf['opacity'])
 
-            color = self._to_rgb_color(isosurf["color"])
+            # mat = bpy.data.materials.new("material")
+            # mat.use_nodes = True
 
-            if color is not None:
-                mat.node_tree.nodes["Principled BSDF"].inputs[0].default_value = (*color, 1)
+            # color = self._to_rgb_color(isosurf["color"])
 
-            mat.node_tree.nodes["Principled BSDF"].inputs[19].default_value = isosurf["opacity"]
+            # if color is not None:
+            #     mat.node_tree.nodes["Principled BSDF"].inputs[0].default_value = (*color, 1)
 
-            mesh.materials.append(mat)
+            # mat.node_tree.nodes["Principled BSDF"].inputs[19].default_value = isosurf["opacity"]
+
+            # mesh.materials.append(mat)
 
 GridPlot.backends.register("blender", BlenderGridBackend)


### PR DESCRIPTION
This is not really a new feature, but I thought I could add documentation on how to achieve "volumetric" displays just in case it is useful for someone. You can get them by asking for multiple isosurfaces and playing with opacities and colors. And it is surprisingly cheap to compute and render.

With this code:

```python
grid.plot(
    axes="xyz", z_range=[0, 10], isos=[{"frac":frac, "opacity": frac*0.7, "color": "green"} for frac in np.linspace(0.3, 0.8, 10)],
    plot_geom=True, geom_kwargs={"show_cell": False, "atoms_scale": 0.3}
)
```
you can get something like this:
(in plotly)
![newplot - 2022-02-08T034746 507](https://user-images.githubusercontent.com/42074085/152914226-75b86bfe-80fb-492a-afe7-d5616babacc4.png)

(in blender)
![vol_blender3](https://user-images.githubusercontent.com/42074085/152916136-fcc7f61d-603d-40ea-8c3c-119c423c625c.png)

I also added some fixes to make grids work in `blender >= 3.0` (any lower version is not supported).
