### PR TITLE
Generalization of StateC.outer function

### DIFF
--- a/sisl/physics/state.py
+++ b/sisl/physics/state.py
@@ -1066,11 +1066,13 @@ class StateC(State):
         s.info = self.info
         return s
 
-    def outer(self, idx=None):
+    def outer(self, coefficients=None, idx=None):
         r""" Return the outer product for the indices `idx` (or all if ``None``) by :math:`\sum_i|\psi_i\rangle c_i\langle\psi_i|`
 
         Parameters
         ----------
+        coefficients : array_like, optional
+           alternative coefficients to be used in the outer product
         idx : int or array_like, optional
            only perform an outer product of the specified indices, otherwise all states are used
 
@@ -1079,10 +1081,14 @@ class StateC(State):
         numpy.ndarray
             a matrix with the sum of outer state products
         """
+        if coefficients is None:
+            c = self.c
+        else:
+            c = _a.asarrayd(coefficients)
         if idx is None:
-            return einsum('k,ki,kj->ij', self.c, self.state, _conj(self.state))
+            return einsum('k,ki,kj->ij', c, self.state, _conj(self.state))
         idx = self._sanitize_index(idx).ravel()
-        return einsum('k,ki,kj->ij', self.c[idx], self.state[idx], _conj(self.state[idx]))
+        return einsum('k,ki,kj->ij', c[idx], self.state[idx], _conj(self.state[idx]))
 
     def sort(self, ascending=True):
         """ Sort and return a new `StateC` by sorting the coefficients (default to ascending)

--- a/sisl/physics/tests/test_state.py
+++ b/sisl/physics/tests/test_state.py
@@ -348,9 +348,11 @@ def test_cstate_outer():
     o1.fill(0)
     for i, sub in enumerate(state):
         o += couter(sub.c[0], sub.state[0, :])
-        o1 += state.outer(i)
+        o1 += state.outer(idx=i)
 
     assert np.allclose(out, o)
     assert np.allclose(out, o1)
-    o = state.outer(np.arange(len(state)))
+    o = state.outer(idx=np.arange(len(state)))
     assert np.allclose(out, o)
+
+    state.outer(coefficients=np.ones(10))


### PR DESCRIPTION
We have been thinking about using the `EigenstateElectron.outer` function to define some projector operators, but to do this one needs to be able to set the coefficients. In principle it could be achieved by overwriting the state coefficients, but I think this is not generally desirable. This branch instead enables an optional `coefficients` parameter.

Here is a simple script that illustrates the idea of constructing projectors in the eigenstate space of a Hamiltonian:
```python
import sisl
import numpy as np

g = sisl.geom.graphene()
H = sisl.Hamiltonian(g)
H.construct([[0.1, 1.5], [0, -2.7]])
H = H.tile(2, 0).tile(2, 1)
es = H.eigenstate()

# create projectors onto occupied and empty subspaces
occ = es.occupation()
Pocc = es.outer(coefficients=occ)
Pemp = es.outer(coefficients=1-occ)

# construct a simple bonding state
vb = np.ones(H.shape[0])
vb /= vb.dot(vb) # normalize
print('\nBonding state vb\n', vb)
print('Pocc.vb\n', Pocc.dot(vb))
print('Pemp.vb\n', Pemp.dot(vb))

# construct a simple anti-bonding state
vab = vb.copy()
vab[::2] *= -1
print('\nAntibonding state vab\n', vab)
print('Pocc.vab\n', Pocc.dot(vab))
print('Pemp.vab\n', Pemp.dot(vab))
```
which produces
```
Bonding state vb
 [0.125 0.125 0.125 0.125 0.125 0.125 0.125 0.125]
Pocc.vb
 [0.125 0.125 0.125 0.125 0.125 0.125 0.125 0.125]
Pemp.vb
 [-2.35922393e-16  1.38777878e-17  1.59594560e-16  1.38777878e-17
  9.71445147e-17  6.24500451e-17  9.71445147e-17 -3.12250226e-16]

Antibonding state vab
 [-0.125  0.125 -0.125  0.125 -0.125  0.125 -0.125  0.125]
Pocc.vab
 [1.38777878e-17 1.38777878e-17 6.93889390e-18 2.08166817e-17
 2.77555756e-17 4.16333634e-17 2.08166817e-17 1.38777878e-17]
Pemp.vab
 [-0.125  0.125 -0.125  0.125 -0.125  0.125 -0.125  0.125]
```
This shows that operating with the projectors on the bonding (antibonding) state one gets the state itself and zero (zero and itself) for the occupied and empty subspaces, respectively.