### PR TITLE
Function to translate atoms in geometry into the unit cell

### DIFF
--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -2352,7 +2352,7 @@ class Geometry(SuperCellChild):
         return g
     translate = move
 
-    def translate2uc(self, atoms=None, axes=(0, 1, 2), tol=1e-5):
+    def translate2uc(self, atoms=None, axes=(0, 1, 2)):
         """Translates atoms in the geometry into the unit cell
 
         One can translate a subset of the atoms by supplying `atoms`
@@ -2364,12 +2364,10 @@ class Geometry(SuperCellChild):
              atoms will be translated
         axes : int or array_like, optional
              only translate certain lattice directions, defaults to all
-        tol : float, optional
-             tolerance controlling a temporary shift of coordinates
         """
         # extract fractional coordinates
         fxyz = self.fxyz
-        fxyz[:, axes] = (fxyz[:, axes] + tol) % 1 - tol
+        fxyz[:, axes] = fxyz[:, axes] % 1
         # remove negative rounding errors
         fxyz[:, axes] = np.where(fxyz[:, axes] > 0, fxyz[:, axes], 0)
         g = self.copy()

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -2352,7 +2352,7 @@ class Geometry(SuperCellChild):
         return g
     translate = move
 
-    def translate2uc(self, atoms=None, tol=1e-5):
+    def translate2uc(self, atoms=None, axes=(0, 1, 2), tol=1e-5):
         """Translates atoms in the geometry into the unit cell
 
         One can translate a subset of the atoms by supplying `atoms`
@@ -2362,14 +2362,16 @@ class Geometry(SuperCellChild):
         atoms : int or array_like, optional
              only translate the given atomic indices, if not specified, all
              atoms will be translated
+        axes : int or array_like, optional
+             only translate certain lattice directions, defaults to all
         tol : float, optional
              tolerance controlling a temporary shift of coordinates
         """
-        shift = np.ones(3) * tol
-        fxyz = (self.fxyz + shift) % 1
-        fxyz -= shift
+        # extract fractional coordinates
+        fxyz = self.fxyz
+        fxyz[:, axes] = (fxyz[:, axes] + tol) % 1 - tol
         # remove negative rounding errors
-        fxyz = np.where(fxyz > 0, fxyz, 0)
+        fxyz[:, axes] = np.where(fxyz[:, axes] > 0, fxyz[:, axes], 0)
         g = self.copy()
         if atoms is None:
             g.xyz = fxyz.dot(self.cell)

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -2352,6 +2352,32 @@ class Geometry(SuperCellChild):
         return g
     translate = move
 
+    def translate2uc(self, atoms=None, tol=1e-5):
+        """Translates atoms in the geometry into the unit cell
+
+        One can translate a subset of the atoms by supplying `atoms`
+
+        Parameters
+        ----------
+        atoms : int or array_like, optional
+             only translate the given atomic indices, if not specified, all
+             atoms will be translated
+        tol : float, optional
+             tolerance controlling a temporary shift of coordinates
+        """
+        shift = np.ones(3) * tol
+        fxyz = (self.fxyz + shift) % 1
+        fxyz -= shift
+        # remove negative rounding errors
+        fxyz = np.where(fxyz > 0, fxyz, 0)
+        g = self.copy()
+        if atoms is None:
+            g.xyz = fxyz.dot(self.cell)
+        else:
+            idx = self._sanitize_atoms(atoms).ravel()
+            g.xyz[idx] = fxyz[idx].dot(self.cell)
+        return g
+
     def swap(self, atoms_a, atoms_b):
         """ Swap a set of atoms in the geometry and return a new one
 

--- a/sisl/tests/test_geometry.py
+++ b/sisl/tests/test_geometry.py
@@ -1582,3 +1582,15 @@ def test_translate2uc():
     gr = gr.move([5, 5, 5])
     gr2 = gr.translate2uc()
     assert not np.allclose(gr.xyz, gr2.xyz)
+
+
+def test_translate2uc_axes():
+    gr = sisl_geom.graphene() * (2, 3, 1)
+    gr = gr.move([5, 5, 5])
+    gr_once = gr.translate2uc()
+    gr_individual = gr.translate2uc(axes=0)
+    assert not np.allclose(gr_once.xyz, gr_individual.xyz)
+    gr_individual = gr_individual.translate2uc(axes=1)
+    assert np.allclose(gr_once.xyz, gr_individual.xyz)
+    gr_individual = gr_individual.translate2uc(axes=2)
+    assert np.allclose(gr_once.xyz, gr_individual.xyz)

--- a/sisl/tests/test_geometry.py
+++ b/sisl/tests/test_geometry.py
@@ -1575,3 +1575,10 @@ def test_geometry_new_xyz(sisl_tmp):
     gr2 = gr.new(out)
     assert np.allclose(gr.xyz, gr2.xyz)
     assert gr == gr2
+
+
+def test_translate2uc():
+    gr = sisl_geom.graphene() * (2, 3, 1)
+    gr = gr.move([5, 5, 5])
+    gr2 = gr.translate2uc()
+    assert not np.allclose(gr.xyz, gr2.xyz)


### PR DESCRIPTION
Through my work with the surface slabs I think it would be convenient with a function that translates atoms (if outside) into the unit cell. I think similar algorithms are already in use internally. This PR offers this as a new function `translate2uc`.