### PR TITLE
enh: scaling lattice vectors by different factors

### DIFF
--- a/sisl/supercell.py
+++ b/sisl/supercell.py
@@ -670,8 +670,8 @@ class SuperCell:
 
         return idx
 
-    def cell_vertices(self):
-        """Vertices of the cell.
+    def vertices(self):
+        """Vertices of the cell
         
         Returns
         --------
@@ -679,12 +679,11 @@ class SuperCell:
             The coordinates of the vertices of the cell. The first three dimensions
             correspond to each cell axis, and the last one contains the xyz coordinates.
         """
-        verts_fxyz = np.zeros((8,3))
-        verts_fxyz[4:, 0] = 1
-        verts_fxyz[[2, 3, 6, 7], 1] = 1
-        verts_fxyz[1::2, 2] = 1
-
-        return (verts_fxyz @ self.cell).reshape(2, 2, 2, 3)
+        verts = np.zeros([2, 2, 2, 3])
+        verts[1, :, :, 0] = 1
+        verts[:, 1, :, 1] = 1
+        verts[:, :, 1, 2] = 1
+        return (verts.reshape(-1, 3) @ self.cell).reshape(2, 2, 2, 3)
 
     def scale(self, scale, what="abc"):
         """ Scale lattice vectors
@@ -693,21 +692,18 @@ class SuperCell:
 
         Parameters
         ----------
-        scale : ``float`` or array-like of floats with shape (3,)
+        scale : float or (3,)
            the scale factor for the new lattice vectors.
         what: {"abc", "xyz"}
            If three different scale factors are provided, whether each scaling factor
            is to be applied on the corresponding lattice vector ("abc") or on the
            corresponding cartesian coordinate ("xyz").
         """
-        if isinstance(scale, Iterable):
-            if what == "abc":
-                # The scale is a vector, reshape it so that in the multiplication each item
-                # is the scale factor of the corresponding lattice vector
-                scale = np.reshape(scale, (-1, 1))
-            elif what != "xyz":
-                raise ValueError(f"'what' argument must be either 'abc' or 'xyz'. '{what}' was provided.")
-        return self.copy(self.cell * scale)
+        if what == "abc":
+            return self.copy((self.cell.T * scale).T)
+        if what == "xyz":
+            return self.copy(self.cell * scale)
+        raise ValueError(f"{self.__class__.__name__}.scale argument what='{what}' is not in ['abc', 'xyz'].")
 
     def tile(self, reps, axis):
         """ Extend the unit-cell `reps` times along the `axis` lattice vector

--- a/sisl/supercell.py
+++ b/sisl/supercell.py
@@ -677,13 +677,13 @@ class SuperCell:
         --------
         array of shape (2, 2, 2, 3):
             The coordinates of the vertices of the cell. The first three dimensions
-            correspond to each cell axis, and the last one contains the xyz coordinates.
+            correspond to each cell axis (off, on), and the last one contains the xyz coordinates.
         """
         verts = np.zeros([2, 2, 2, 3])
         verts[1, :, :, 0] = 1
         verts[:, 1, :, 1] = 1
         verts[:, :, 1, 2] = 1
-        return (verts.reshape(-1, 3) @ self.cell).reshape(2, 2, 2, 3)
+        return verts @ self.cell
 
     def scale(self, scale, what="abc"):
         """ Scale lattice vectors

--- a/sisl/tests/test_geometry.py
+++ b/sisl/tests/test_geometry.py
@@ -692,6 +692,24 @@ class TestGeometry:
         assert len(two) == len(setup.g)
         assert np.allclose(two.xyz[:, :] / 2., setup.g.xyz)
 
+    def test_scale_vector_abc(self, setup):
+        two = setup.g.scale([2, 1, 1], what="abc")
+        assert len(two) == len(setup.g)
+        # Check that cell has been scaled accordingly
+        assert np.allclose(two.cell[0] / 2., setup.g.cell[0])
+        assert np.allclose(two.cell[1:], setup.g.cell[1:])
+        # Now check that fractional coordinates are still the same
+        assert np.allclose(two.fxyz, setup.g.fxyz)
+    
+    def test_scale_vector_xyz(self, setup):
+        two = setup.g.scale([2, 1, 1], what="xyz")
+        assert len(two) == len(setup.g)
+        # Check that cell has been scaled accordingly
+        assert np.allclose(two.cell[:, 0] / 2., setup.g.cell[:, 0])
+        assert np.allclose(two.cell[:, 1:], setup.g.cell[:, 1:])
+        # Now check that fractional coordinates are still the same
+        assert np.allclose(two.fxyz, setup.g.fxyz)
+
     def test_close1(self, setup):
         three = range(3)
         for ia in setup.mol:

--- a/sisl/tests/test_supercell.py
+++ b/sisl/tests/test_supercell.py
@@ -166,6 +166,14 @@ class TestSuperCell:
         with pytest.raises(Exception):
             setup.sc.sc_index([100, 100, 100])
 
+    def test_cell_vertices(self, setup):
+        verts = setup.sc.cell_vertices()
+
+        assert verts.shape == (2, 2, 2, 3)
+        assert np.allclose(verts[0, 0, 0], [0, 0, 0])
+        assert np.allclose(verts[1, 0, 0], setup.sc.cell[0])
+        assert np.allclose(verts[1, 1, 1], setup.sc.cell.sum(axis=0))
+
     def test_cut1(self, setup):
         cut = setup.sc.cut(2, 0)
         assert np.allclose(cut.cell[0, :] * 2, setup.sc.cell[0, :])

--- a/sisl/tests/test_supercell.py
+++ b/sisl/tests/test_supercell.py
@@ -166,8 +166,8 @@ class TestSuperCell:
         with pytest.raises(Exception):
             setup.sc.sc_index([100, 100, 100])
 
-    def test_cell_vertices(self, setup):
-        verts = setup.sc.cell_vertices()
+    def test_vertices(self, setup):
+        verts = setup.sc.vertices()
 
         assert verts.shape == (2, 2, 2, 3)
         assert np.allclose(verts[0, 0, 0], [0, 0, 0])


### PR DESCRIPTION
This allows passing a vector with three scale factors to `Geometry.scale` and `Supercell.scale`, which are understood as the scale factor for each lattice vector.

I needed this because I need to change the surface parameters of a slab to make it fit with another lattice, while keeping the perpendicular (bulk) direction untouched.

For example:

```python
sisl.geom.graphene().scale([1.2, 1.2, 1])
```

makes the honeycomb lattice a bit bigger while keeping the same vacuum.

PS: Maybe we might as well accept a full transformation matrix? (although that should probably be a different `transform` method).