### PR TITLE
Fixed reading of n, l, zeta in hsx_read_specie1

### DIFF
--- a/sisl/io/siesta/_src/hsx_read.f90
+++ b/sisl/io/siesta/_src/hsx_read.f90
@@ -1354,7 +1354,7 @@ subroutine read_hsx_specie1(fname, ispecie, no_specie, n_specie, l_specie, zeta_
 
 ! Internal variables and arrays
   integer :: iu, ierr, version
-  integer :: is
+  integer :: is, io
 
   ! Local readables
   integer :: nspecies, lna_u, lno_u, lnspin, nsc(3)
@@ -1388,7 +1388,7 @@ subroutine read_hsx_specie1(fname, ispecie, no_specie, n_specie, l_specie, zeta_
 
   do is = 1, nspecies
     if ( is == ispecie ) then
-      read(iu, iostat=ierr) n_specie, l_specie, zeta_specie
+      read(iu, iostat=ierr) (n_specie(io), l_specie(io), zeta_specie(io), io=1,no_specie)
       call iostat_update(ierr)
     else
       read(iu, iostat=ierr) !nfio(is,io), lfio(is,io), zetafio(is,io)


### PR DESCRIPTION
@juijan and I noticed that the reading of the quantum numbers of the orbitals (n, l, zeta) from the HSX file does not work correctly for HSX file version 1. There is an inconsistency between the ordering of the number during reading and writing. The writing routine (`write_hsx` in `io_hsx.F90`) writes them in the order `n(1), l(1), zeta(1), n(2), l(2), zeta(2), ...`, while the reading routine expects it in the order `n(1), n(2), ..., l(1), l(2), ..., zeta(1), zeta(2), ...`. This PR fixes the reading routine to use the same ordering.
