### PR TITLE
Add option to sdata to write DOS to stdout or file

### DIFF
--- a/sisl/io/siesta/eig.py
+++ b/sisl/io/siesta/eig.py
@@ -10,11 +10,11 @@ from sisl._internal import set_module
 from sisl.physics import get_distribution
 from sisl.utils import strmap
 from sisl.utils.cmd import default_ArgumentParser, default_namespace
-from sisl.unit.siesta import units
+from sisl.unit import units
 from .kp import kpSileSiesta
 
 
-__all__ = ['eigSileSiesta']
+__all__ = ["eigSileSiesta"]
 
 
 @set_module("sisl.io.siesta")
@@ -27,26 +27,28 @@ class eigSileSiesta(SileSiesta):
 
     .. code:: bash
 
+        # Plot the eigenspectrum
         sdata siesta.EIG --plot
         # or to save to png file
         sdata siesta.EIG --plot eig_spread.png
-
 
     One may also extract/plot the DOS using the eigenvalues and the k-point weights:
 
     .. code:: bash
 
-        sdata siesta.EIG --dos
-        # or to save to png file
-        sdata siesta.EIG --dos dos.png
-	# or to write DOS to stdout
-        sdata siesta.EIG --dos-write
-	# or to write DOS to file
-        sdata siesta.EIG --dos-write dos.dat
+        # plot the DOS using default values
+        sdata siesta.EIG --dos --plot
+        # change the energy spacing and plot it
+        sdata siesta.EIG --dos dE=1meV --plot
+        # change the energy spacing;
+        # plot two different temperatures
+        sdata siesta.EIG --dos dE=1meV kT=5K --dos kT=25K --plot
+        # store the data in a dos.dat (3 columns, E, kT=5, kT=25K)
+        sdata siesta.EIG --dos dE=1meV kT=5K --dos kT=25K --out dos.dat
 
     This will default to plot the DOS using these parameters:
     dE = 5 meV, kT = 300 K (25 meV), Gaussian distribution and in the full energy-range of the eigenvalue spectrum.
-    By default the k-point weights will be read in the ``siesta.KP`` file, however if the file does not
+    By default the k-point weights will be read in the ``*.KP`` file, however if the file does not
     exist one may use the option ``--kp-file FILE`` to read in the weights from ``FILE``.
 
     To limit the shown energy region, simply use:
@@ -65,6 +67,8 @@ class eigSileSiesta(SileSiesta):
 
     which will calculate the DOS in steps of 10 meV, the temperature smearing is 0.1 eV and
     the used distribution is a Lorentzian.
+    Several invocations of ``--dos`` will collect the data until either a ``--plot`` or ``--out``
+    is found on the command line.
     """
 
     @sile_fh_open(True)
@@ -120,8 +124,8 @@ class eigSileSiesta(SileSiesta):
     @default_ArgumentParser(description="Manipulate Siesta EIG file.")
     def ArgumentParser(self, p=None, *args, **kwargs):
         """ Returns the arguments that is available for this Sile """
-        #limit_args = kwargs.get('limit_arguments', True)
-        short = kwargs.get('short', False)
+        #limit_args = kwargs.get("limit_arguments", True)
+        short = kwargs.get("short", False)
 
         def opts(*args):
             if short:
@@ -140,7 +144,19 @@ class eigSileSiesta(SileSiesta):
             "_Emap": None,
             "_data": [], 
             "_data_header" : [],
+            "_dos_args": [
+                # default dE 5 meV
+                0.005,
+                # default T = 300 k
+                units("K", "eV") * 300,
+                # distribution type
+                "gaussian"
+            ],
         }
+        try:
+            d["_weights"] = kpSileSiesta(str(self.file).replace("EIG", "KP")).read_data()[1]
+        except:
+            d["_weights"] = None
         namespace = default_namespace(**d)
 
         # Energy grabs
@@ -148,21 +164,157 @@ class eigSileSiesta(SileSiesta):
 
             def __call__(self, parser, ns, value, option_string=None):
                 ns._Emap = strmap(float, value)[0]
-        p.add_argument('--energy', '-E',
+        p.add_argument("--energy", "-E",
                        action=ERange,
-                       help='Denote the sub-section of energies that are plotted: "-1:0,1:2" [eV]')
+                       help="Denote the sub-section of energies that are plotted: '-1:0,1:2' [eV]")
 
         # k-point weights
         class KP(argparse.Action):
             def __call__(self, parser, ns, value, option_string=None):
                 ns._weights = kpSileSiesta(value[0]).read_data()[1]
-        p.add_argument('--kp-file', '-kp', nargs=1, metavar='FILE', action=KP,
-                       help='The k-point file from which to read the band-weights (only applicable to --dos option)')
+        p.add_argument("--kp-file", "-kp", nargs=1, metavar="FILE", action=KP,
+                       help="The k-point file from which to read the band-weights (only applicable to --dos option)")
 
-        class EIGPlot(argparse.Action):
+        # Energy grabs
+        class DOS(argparse.Action):
+            def __call__(dos_self, parser, ns, values, option_string=None): # pylint: disable=E0213
+                if getattr(ns, "_weights", None) is None:
+                    if ns._eigs.shape[1] > 1:
+                        raise ValueError("Can not calculate DOS when k-point weights are unknown, please pass -kp before this command")
 
-            def __call__(self, parser, ns, value, option_string=None):
+                if len(ns._weights) != ns._eigs.shape[1]:
+                    raise SileError(f"{self!s} --dos the number of k-points for the eigenvalues and k-point weights "
+                                    "are different, please use -kp before --dos.")
+
+                # Specify default settings
+                dE = ns._dos_args[0]
+                kT = ns._dos_args[1]
+                distribution = ns._dos_args[2]
+                for i, value in enumerate(values):
+                    if "=" in value:
+                        # it is a direct parseable thing
+                        key, val = value.split("=")
+                        if key.lower() in ("de", "e"):
+                            try:
+                                dE = units(val, "eV")
+                            except Exception:
+                                dE = float(val)
+                        elif key.lower() in ("kt", "t"):
+                            try:
+                                kT = units(val, "eV")
+                            except Exception:
+                                kT = float(val)
+                        elif key.lower().startswith("dist"):
+                            distribution = val
+                        else:
+                            raise ValueError(f"Unknown key: {key}, should be one of [dE, kT, dist]")
+
+                    elif i == 0:
+                        try:
+                            dE = float(value)
+                        except Exception:
+                            # *must* be a str?
+                            distribution = value
+                    elif i == 1:
+                        try:
+                            kT = float(value)
+                        except Exception:
+                            # *must* be a str?
+                            distribution = value
+                    elif i == 2:
+                        try:
+                            distribution = value
+                        except Exception:
+                            raise ValueError(f"Unknown value for distribution: {value}")
+                    else:
+                        raise ValueError(f"Too many values passed? Unknown value {value}?")
+
+                # store for next invocation
+                ns._dos_args[0] = dE
+                ns._dos_args[1] = kT 
+                ns._dos_args[2] = distribution
+
+                # Now create the final distribution
+                distribution = get_distribution(distribution, smearing=kT)
+                
+                if ns._Emap is None:
+                    # We will plot the DOS in the entire energy window
+                    ns._Emap = [ns._eigs.min() - kT * 4, ns._eigs.max() + kT * 4]
+
+                # Now we are ready to process
+                E = np.arange(ns._Emap[0], ns._Emap[1], dE)
+                n_data = len(ns._data_header)
+                same_E = False
+                if n_data > 0:
+                    for i in range(n_data):
+                        header = ns._data_header[-i]
+                        if header == "Energy":
+                            try:
+                                same_E = np.allclose(E, ns._data[-i])
+                            except Exception:
+                                same_E = False
+
+                if not same_E:
+                    ns._data_header.append("Energy")
+                    ns._data.append(E)
+
+                def calc_dos(E, eig, w):
+                    nonlocal distribution
+                    DOS = np.zeros(len(E))
+                    for w_band, e_band in zip(w, eig):
+                        for e in e_band:
+                            DOS += distribution(E - e) * w_band
+                    return DOS
+
+                T = kT * units(f"eV", "K")
+                str_T = f"{T:.2f}K"
+                
+                if ns._eigs.shape[0] == 2:
+                    for eigs, ud in zip(ns._eigs, ("up", "down")):
+                        ns._data_header.append(f"DOS-{ud} T={str_T}")
+                        ns._data.append(calc_dos(E, eigs, ns._weights))
+                else:
+                    ns._data_header.append(f"DOS T={str_T}")
+                    ns._data.append(calc_dos(E, ns._eigs[0, :, :], ns._weights))
+        p.add_argument("--dos", action=DOS, nargs="*", metavar="dE, kT, DIST",
+                       help="Calculate (and internally store) the density of states from the .EIG file, "
+                       "dE = energy separation (5 meV), kT = smearing (300 K), DIST = distribution function (Gaussian). "
+                       "The arguments will be the new defaults for later --dos calls.")
+
+        class Plot(argparse.Action):
+
+            def _plot_data(self, parser, ns, value, option_string=None):
+                """ Plot data as contained in ns._data """
+                from matplotlib import pyplot as plt
+                plt.figure()
+
+                E = None
+                is_DOS = True
+                for header, data in zip(ns._data_header, ns._data):
+                    if header == "Energy":
+                        E = data
+                    elif "DOS" in header:
+                        plt.plot(E, data, label=header)
+                    else:
+                        # currently, we can only do DOS, so we shouldn't worry
+                        is_DOS = False
+
+                Emap = ns._Emap
+                if Emap is not None:
+                    plt.xlim(Emap[0], Emap[1])
+                
+                if is_DOS:
+                    plt.ylabel("DOS [1/eV]")
+                plt.legend()
+
+                if value is None:
+                    plt.show()
+                else:
+                    plt.savefig(value)
+
+            def _plot_eig(self, parser, ns, value, option_string=None):
                 import matplotlib.pyplot as plt
+
                 E = ns._eigs
                 #Emin = np.min(E)
                 #Emax = np.max(E)
@@ -176,117 +328,37 @@ class eigSileSiesta(SileSiesta):
                     ik = np.arange(y.shape[0])
                     for ib in range(y.shape[1]):
                         ax.scatter(ik, y[:, ib], s=s)
-                    ax.set_xlabel('k-index')
+                    ax.set_xlabel("k-index")
                     ax.set_xlim(-0.5, len(y) + 0.5)
                     if not E is None:
                         ax.set_ylim(E[0], E[1])
 
                 if E.shape[0] == 2:
-                    _, ax = plt.subplots(1, 2)
-                    ax[0].set_ylabel('E-Ef [eV]')
+                    _, axs = plt.subplots(1, 2)
+                    axs[0].set_ylabel("E-Ef [eV]")
 
                     # We must plot spin-up/down separately
-                    for i, ud in enumerate(['UP', 'DOWN']):
-                        myplot(ax[i], 'Eigenspectrum SPIN-'+ud, E[i, :, :], ns._Emap, s)
+                    for ax, eig, ud in zip(axs, E, ("UP", "DOWN")):
+                        myplot(ax, f"Eigenspectrum {ud}", eig, ns._Emap, s)
                 else:
                     plt.figure()
                     ax = plt.gca()
-                    ax.set_ylabel('E-Ef [eV]')
-                    myplot(ax, 'Eigenspectrum', E[0, :, :], ns._Emap, s)
+                    ax.set_ylabel("E-Ef [eV]")
+                    myplot(ax, "Eigenspectrum", E[0, :, :], ns._Emap, s)
+
                 if value is None:
                     plt.show()
                 else:
                     plt.savefig(value)
-        p.add_argument(*opts('--plot', '-p'), action=EIGPlot, nargs='?', metavar='FILE',
-                       help='Plot the eigenvalues from the .EIG file, possibly saving plot to a file.')
-
-        # Energy grabs
-        class DOS(argparse.Action):
-            def __call__(dos_self, parser, ns, value, option_string=None): # pylint: disable=E0213
-                if not hasattr(ns, '_weight'):
-                    # Try and read in the k-point-weights
-                    ns._weight = kpSileSiesta(str(self.file).replace('EIG', 'KP')).read_data()[1]
-
-                if ns._Emap is None:
-                    # We will plot the DOS in the entire energy window
-                    ns._Emap = [ns._eigs.min(), ns._eigs.max()]
-
-                if len(ns._weight) != ns._eigs.shape[1]:
-                    raise SileError(str(self) + ' --dos the number of k-points for the eigenvalues and k-point weights '
-                                    'are different, please use --weight correctly.')
-
-                # Specify default settings
-                dE = 0.005 # 5 meV
-                kT = units('K', 'eV') * 300
-                distr = get_distribution('gaussian', smearing=kT)
-                out = None
-                if len(value) > 0:
-                    i = 0
-                    try:
-                        dE = float(value[i])
-                        i += 1
-                    except Exception: pass
-                    try:
-                        kT = float(value[i])
-                        i += 1
-                    except Exception: pass
-                    try:
-                        distr = get_distribution(value[i], smearing=kT)
-                        i += 1
-                    except Exception: pass
-                    try:
-                        out = value[i]
-                    except Exception: pass
-
-                # Now we are ready to process
-                E = np.arange(ns._Emap[0] - kT * 4, ns._Emap[1] + kT * 4, dE)
-                ns._data_header.append('Energy')
-                ns._data.append(E)
-
-                def calc_dos(E, eig, w):
-                    DOS = np.zeros(len(E))
-                    for ib in range(eig.shape[0]):
-                        for e in eig[ib, :]:
-                            DOS += distr(E - e) * w[ib]
-                    return DOS
-
-                if ns._eigs.shape[0] == 2:
-                    for i, ud in enumerate(['up', 'down']):
-                        ns._data_header.append(f'DOS-{ud}')
-                        ns._data.append(calc_dos(E, ns._eigs[i, :, :], ns._weight))
-                else:
-                    ns._data_header.append('DOS')
-                    ns._data.append(calc_dos(E, ns._eigs[0, :, :], ns._weight))
-        p.add_argument('--dos', action=DOS, nargs='*', metavar='dE,kT,DIST,FILE',
-                       help='Plot the density of states from the .EIG file, '
-                       'dE = energy separation, kT = smearing, DIST = distribution function (Gaussian) possibly saving plot to a file.')
-
-        class Plot(argparse.Action):
 
             def __call__(self, parser, ns, value, option_string=None):
-
                 if len(ns._data) == 0:
-                    # do nothing if data has not been collected
-                    print("No data has been collected in the arguments, nothing will be plotted, have you forgotten arguments?")
-                    return
-
-                from matplotlib import pyplot as plt
-                plt.figure()
-                
-                is_DOS = True
-                for i in range(1, len(ns._data)):
-                    plt.plot(ns._data[0], ns._data[i], label=ns._data_header[i])
-                    is_DOS &= 'DOS' in ns._data_header[i]
-
-                if is_DOS:
-                    plt.ylabel('DOS [1/eV]')
-
-                if value is None:
-                    plt.show()
+                    self._plot_eig(parser, ns, value, option_string)
                 else:
-                    plt.savefig(value)
-        p.add_argument('--plot', '-p', action=Plot, nargs='?', metavar='FILE',
-                       help='Plot the currently collected information (at its current invocation).')
+                    self._plot_data(parser, ns, value, option_string)
+
+        p.add_argument("--plot", "-p", action=Plot, nargs="?", metavar="FILE",
+                       help="Plot the currently collected information (at its current invocation), or the eigenspectrum")
 
         class Out(argparse.Action):
             def __call__(self, parser, ns, value, option_string=None):
@@ -295,16 +367,18 @@ class eigSileSiesta(SileSiesta):
 
                 if len(ns._data) == 0:
                     # do nothing if data has not been collected
-                    print("No data has been collected in the arguments, nothing will be written, have you forgotten arguments?")
-                    return
+                    raise ValueError("No data has been collected in the arguments, nothing will be written, have you forgotten arguments?")
+
+                if sum((h == "Energy" for h in ns._data_header)) > 1:
+                    raise ValueError("There are multiple non-commensurate energy-grids, saving data requires a single energy-grid.")
 
                 from sisl.io import tableSile
-                tableSile(out, mode='w').write(*ns._data,
+                tableSile(out, mode="w").write(*ns._data,
                                                header=ns._data_header)
-        p.add_argument('--out', '-o', nargs=1, action=Out,
-                       help='Store currently collected information (at its current invocation) to the out file.')
+        p.add_argument("--out", "-o", nargs=1, action=Out,
+                       help="Store currently collected information (at its current invocation) to the out file.")
 
         return p, namespace
 
 
-add_sile('EIG', eigSileSiesta, gzip=True)
+add_sile("EIG", eigSileSiesta, gzip=True)

--- a/sisl/io/siesta/eig.py
+++ b/sisl/io/siesta/eig.py
@@ -125,12 +125,7 @@ class eigSileSiesta(SileSiesta):
     def ArgumentParser(self, p=None, *args, **kwargs):
         """ Returns the arguments that is available for this Sile """
         #limit_args = kwargs.get("limit_arguments", True)
-        short = kwargs.get("short", False)
-
-        def opts(*args):
-            if short:
-                return args
-            return [args[0]]
+        #short = kwargs.get("short", False)
 
         # We limit the import to occur here
         import argparse
@@ -155,7 +150,7 @@ class eigSileSiesta(SileSiesta):
         }
         try:
             d["_weights"] = kpSileSiesta(str(self.file).replace("EIG", "KP")).read_data()[1]
-        except:
+        except Exception:
             d["_weights"] = None
         namespace = default_namespace(**d)
 
@@ -222,10 +217,7 @@ class eigSileSiesta(SileSiesta):
                             # *must* be a str?
                             distribution = value
                     elif i == 2:
-                        try:
-                            distribution = value
-                        except Exception:
-                            raise ValueError(f"Unknown value for distribution: {value}")
+                        distribution = value
                     else:
                         raise ValueError(f"Too many values passed? Unknown value {value}?")
 

--- a/sisl/io/siesta/tests/test_eig.py
+++ b/sisl/io/siesta/tests/test_eig.py
@@ -9,11 +9,11 @@ from sisl.io.siesta.eig import *
 import numpy as np
 
 pytestmark = [pytest.mark.io, pytest.mark.siesta]
-_dir = osp.join('sisl', 'io', 'siesta')
+_dir = osp.join("sisl", "io", "siesta")
 
 
 def test_si_pdos_kgrid_eig(sisl_files):
-    f = sisl_files(_dir, 'si_pdos_kgrid.EIG')
+    f = sisl_files(_dir, "si_pdos_kgrid.EIG")
     eig = eigSileSiesta(f).read_data()
 
     # nspin, nk, nb
@@ -22,16 +22,45 @@ def test_si_pdos_kgrid_eig(sisl_files):
 
 def test_si_pdos_kgrid_eig_ArgumentParser(sisl_files, sisl_tmp):
     pytest.importorskip("matplotlib", reason="matplotlib not available")
-    png = sisl_tmp('si_pdos_kgrid.EIG.png', _dir)
-    si = sisl.get_sile(sisl_files(_dir, 'si_pdos_kgrid.EIG'))
+    png = sisl_tmp("si_pdos_kgrid.EIG.png", _dir)
+    si = sisl.get_sile(sisl_files(_dir, "si_pdos_kgrid.EIG"))
     p, ns = si.ArgumentParser()
     p.parse_args([], namespace=ns)
-    p.parse_args(['--energy', ' -2:2'], namespace=ns)
-    p.parse_args(['--energy', ' -2:2', '--plot', png], namespace=ns)
+    p.parse_args(["--energy", " -2:2"], namespace=ns)
+    p.parse_args(["--energy", " -2:2", "--plot", png], namespace=ns)
+
+
+def test_si_pdos_kgrid_eig_ArgumentParser_de(sisl_files, sisl_tmp):
+    dat = sisl_tmp("si_pdos_kgrid.EIG.dat", _dir)
+    kp = sisl_files(_dir, "si_pdos_kgrid.KP")
+    si = sisl.get_sile(sisl_files(_dir, "si_pdos_kgrid.EIG"))
+    p, ns = si.ArgumentParser()
+    assert ns._dos_args[0] == pytest.approx(0.005)
+    assert ns._dos_args[2] == "gaussian"
+    assert ns._weights is not None
+    ns._weights = None
+    p.parse_args(["-kp" , str(kp)], namespace=ns)
+    assert ns._weights is not None
+    p.parse_args(["--dos", "dE=1meV", "kT=20meV"], namespace=ns)
+    assert ns._weights is not None
+    assert ns._dos_args[0] == pytest.approx(1e-3)
+    assert ns._dos_args[1] == pytest.approx(20e-3)
+    assert ns._dos_args[2] == "gaussian"
+    p.parse_args(["--dos", "kT=10meV", "dist=lorentzian"], namespace=ns)
+    assert ns._dos_args[0] == pytest.approx(1e-3)
+    assert ns._dos_args[1] == pytest.approx(10e-3)
+    assert ns._dos_args[2] == "lorentzian"
+    assert len(ns._data) == 3
+    p.parse_args(["--dos", "1meV", "5meV", "gaussian"], namespace=ns)
+    assert ns._dos_args[0] == pytest.approx(1e-3)
+    assert ns._dos_args[1] == pytest.approx(5e-3)
+    assert ns._dos_args[2] == "gaussian"
+    assert len(ns._data) == 4
+    p.parse_args(["--out", dat], namespace=ns)
 
 
 def test_soc_pt2_xx_eig(sisl_files):
-    f = sisl_files(_dir, 'SOC_Pt2_xx.EIG')
+    f = sisl_files(_dir, "SOC_Pt2_xx.EIG")
     eig = eigSileSiesta(f).read_data()
 
     # nspin, nk, nb
@@ -41,13 +70,13 @@ def test_soc_pt2_xx_eig(sisl_files):
 
 
 def test_soc_pt2_xx_eig_fermi_level(sisl_files):
-    f = sisl_files(_dir, 'SOC_Pt2_xx.EIG')
+    f = sisl_files(_dir, "SOC_Pt2_xx.EIG")
     ef = eigSileSiesta(f).read_fermi_level()
-    fdf = sisl_files(_dir, 'SOC_Pt2_xx.fdf')
-    ef1 = fdfSileSiesta(fdf).read_fermi_level(order='EIG')
+    fdf = sisl_files(_dir, "SOC_Pt2_xx.fdf")
+    ef1 = fdfSileSiesta(fdf).read_fermi_level(order="EIG")
     assert ef == pytest.approx(ef1)
     # This should prefer the TSHS
-    ef2 = fdfSileSiesta(fdf).read_fermi_level(order='TSHS')
+    ef2 = fdfSileSiesta(fdf).read_fermi_level(order="TSHS")
     # since we are using a different conversion in sisl
     # vs. siesta we have to make this.
     # once https://gitlab.com/siesta-project/siesta/-/merge_requests/30


### PR DESCRIPTION
As the title suggests: adds a new option to `sdata` (`--dos-write`) , which calculates the density of states and either writes it to standard output or to a file (if provided). Additional arguments are the same as for `--dos`. 

Not sure if you want to add it, but I found it useful. 🤷 