### PR TITLE
Enable dtype change in sisl.Grid.copy

### DIFF
--- a/sisl/grid.py
+++ b/sisl/grid.py
@@ -397,7 +397,7 @@ class Grid(SuperCellChild):
             d['dtype'] = dtype
         grid = self.__class__([1] * 3, bc=np.copy(self.bc), **d)
         # This also ensures the shape is copied!
-        grid.grid = self.grid.copy()
+        grid.grid = self.grid.astype(dtype=d['dtype'])
         return grid
 
     def swapaxes(self, a, b):

--- a/sisl/tests/test_grid.py
+++ b/sisl/tests/test_grid.py
@@ -72,6 +72,8 @@ class TestGrid:
     def test_copy(self, setup):
         assert setup.g.copy() == setup.g
         assert not setup.g.copy() != setup.g
+        gc = setup.g.copy(dtype=np.complex128)
+        assert gc.dtype == np.complex128
 
     def test_add1(self, setup):
         g = setup.g + setup.g


### PR DESCRIPTION
The `sisl.Grid.copy` function did not actually allow for a change of the array dtype (as suggested in the documentation). This branch fixes this.