### PR TITLE
mnt: fixed #477 and #478, changed *_current to *_transmission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once
 we hit release version 1.0.0.
 
-## [UNRELEASED] - YYYY-MM-DD
+## [0.13.0] - YYYY-MM-DD
 
 ### Added
 - enabled unit specification for lengths in cube-files
@@ -17,6 +17,19 @@ we hit release version 1.0.0.
 ### Fixed
 - orbital quantum numbers from HSX file was wrong in v1, #462
 - RealSpaceSI for right semi-infinite directions, #475
+
+### Changed
+- tbtncSileTBtrans and its derivates has changed, drastically.
+	This will accommodate changes related to #477 and #478.
+	Now `*_transmission` refers to energy resolved transmissions
+  and `*_current` reflects bias-window integrated quantities.
+	The defaults and argument order has changed drastically, so
+  users should adapt their scripts depending on `sisl` version.
+	A check can be made, `if sisl.__version_tuple__[:3] >= (0, 13, 0):`
+- To streamline argument order the `*_ACO[OH]P` routines have changed
+	`elec` and `E` argument order. This makes them compatible with
+	`orbital_transmission` etc.
+
 
 ## [0.12.2] - 2022-5-2
 

--- a/sisl/io/tbtrans/tbt.py
+++ b/sisl/io/tbtrans/tbt.py
@@ -2436,17 +2436,21 @@ class tbtncSileTBtrans(_devncSileTBtrans):
 
         Parameters
         ----------
-        geom: bool, optional
+        geometry: bool, optional
            return the geometry
+        vector_transmission: bool, optional
+           return the bond transmissions as vectors
+        vector_current: bool, optional
+           return the bond currents as vectors
+        atom_transmission: bool, optional
+           return the atomic transmission flowing through an atom (the *activity* current)
         atom_current: bool, optional
            return the atomic current flowing through an atom (the *activity* current)
-        vector_current: bool, optional
-           return the orbital currents as vectors
         """
         val = []
         for kw in kwargs:
 
-            if kw in ['geom', 'geometry']:
+            if kw in ("geom", "geometry"):
                 if kwargs[kw]:
                     val.append(self.geometry)
 

--- a/sisl/io/tbtrans/tbt.py
+++ b/sisl/io/tbtrans/tbt.py
@@ -1197,6 +1197,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
 
         return Dab
 
+    @wrap_filterwarnings("ignore", category=SparseEfficiencyWarning)
     def sparse_atom_to_vector(self, Dab) -> ndarray:
         """ Reduce an atomic sparse matrix to a vector contribution of each atom
 

--- a/sisl/io/tbtrans/tests/test_tbt.py
+++ b/sisl/io/tbtrans/tests/test_tbt.py
@@ -365,10 +365,13 @@ def test_1_graphene_all_fail_kavg(sisl_files, sisl_tmp):
         tbt.transmission(kavg=[0, 1])
 
 
-@pytest.mark.only
 def test_1_graphene_sparse_current(sisl_files, sisl_tmp):
     tbt = sisl.get_sile(sisl_files(_dir, '1_graphene_all.TBT.nc'))
     J = tbt.orbital_current()
+    assert np.allclose(J.data, 0)
+    J = tbt.orbital_current(only="+")
+    assert np.allclose(J.data, 0)
+    J = tbt.orbital_current(only="-")
     assert np.allclose(J.data, 0)
     J = tbt.bond_current()
     assert np.allclose(J.data, 0)


### PR DESCRIPTION
The orbital_current was confusing for end-users as it
signalled it was a bias-window integrated quantity.

Now the routines have changed names and additional ones
have been added.

*_transmission: are the orbital/atom/... resolved
  transmissions (they have `E` as argument)
*_current: are the orbital/atom/... bias window
  integrated quantities that reflects the total
  current (they don't have `E` as argument)

This will break old users scripts as the interfaces
has also changed.
Now all electrode arguments defaults to the 1st electrode
and energy arguments are generally the first ones (except DOS).

This *should* be more what users want as for 2 electrode systems
they'll generally only calculate one orbital_current for the first
electrode.

For old users one can accommodate these settings by using this
small snippet:
```python 
if sisl.__version_tuple__[:3] >= (0, 13, 0):
   tbt.orbital_transmission(0.1, "Left")
else:
   tbt.orbital_current("Left", 0.1)
```
Same goes for the other equivalent routines.

I am not sure whether the interface changes are a good idea, I would be grateful for any comments! @tfrederiksen @sofiasanz (others!)

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [X] Closes #477 and #478
 - [X] Tests added
 - [X] Documentation for functionality
 - [X] User visible changes (including notable bug fixes) are documented in `CHANGELOG`
