### PR TITLE
Too large energies printed in siesta made sisl crash

### DIFF
--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -15,6 +15,7 @@ from sisl import Geometry, Atom, SuperCell
 from sisl.utils import PropertyDict
 from sisl.utils.cmd import *
 from sisl.unit.siesta import unit_convert
+from sisl.messages import warn
 
 __all__ = ['outSileSiesta']
 
@@ -614,11 +615,17 @@ class outSileSiesta(SileSiesta):
             key, val = line.split("=")
             key = key.split(":")[1].strip()
             key = name_conv.get(key, key)
+            try:
+                val = float(val)
+            except ValueError:
+                warn(f"Couldn't convert energy '{key}' ({val}) to a float, asigning np.nan.")
+                val = np.nan
+
             if key.startswith("ion."):
                 # sub-nest
-                out.ion[key[4:]] = float(val)
+                out.ion[key[4:]] = val
             else:
-                out[key] = float(val)
+                out[key] = val
             line = next(itt)
 
         return out


### PR DESCRIPTION
When SIESTA has to print an energy value that it is too large to be formatted, it prints `**********************`. This was making `outSileSiesta.read_energy()` fail in those cases, since it was trying to convert the string to a float. In my case the very large energy was the ion-electron energy, and although I only cared about the total energy it reads all of them and crashes because it can not read a particular one.

With this commit when the energy can not be parsed to float `np.nan` is asigned. We could check for asterisks in the string, but I think that would be a waste of time. Also, I didn't know whether to choose `np.inf` over `np.nan`. The problem is that the sign of the "infinite" value is unknown and it is not really infinite, so I think `np.nan` is better.