### PR TITLE
Enabled reading raw coordinates from xyzSile

### DIFF
--- a/sisl/io/xyz.py
+++ b/sisl/io/xyz.py
@@ -88,7 +88,7 @@ class xyzSile(Sile):
         return Geometry(xyz, atoms=sp, sc=sc)
 
     @sile_fh_open()
-    def read_geometry(self, atoms=None, sc=None):
+    def read_geometry(self, atoms=None, sc=None, ret_xyz=False):
         """ Returns Geometry object from the XYZ file
 
         Parameters
@@ -97,13 +97,17 @@ class xyzSile(Sile):
             the atoms to be associated with the Geometry
         sc : SuperCell, optional
             the supercell to be associated with the geometry
+        ret_xyz : bool, optional
+            if True, the raw xyz coordinates are returned in a numpy array,
+            instead of a Geometry object.
         """
         # Read number of atoms
         na = int(self.readline())
 
         # Read header, and try and convert to dictionary
         header = self.readline()
-        kv = header_to_dict(header)
+        if not ret_xyz:
+            kv = header_to_dict(header)
 
         # Read atoms and coordinates
         sp = [None] * na
@@ -113,6 +117,9 @@ class xyzSile(Sile):
             l = line().split(maxsplit=5)
             sp[ia] = l[0]
             xyz[ia, :] = l[1:4]
+
+        if ret_xyz:
+            return xyz
 
         if atoms is not None:
             sp = atoms


### PR DESCRIPTION
Some time ago you made me notice that I could read successive geometries in a xyz file by keeping the file handle open:

```python
import sisl

xyz_sile = sisl.get_sile("trajectory.xyz")
traj = []
with xyz_sile as s:
    while True:
        try:
            geom = s.read_geometry()
            traj.append(geom.xyz)
        except:
            # No more geometries to read
            break
```

However, this is unfeasible for reasonably sized trajectories due to the overhead of initializing `Geometry` objects. As stated in https://github.com/zerothi/sisl/pull/167, it would be great to have some generalized way of manipulating time series/trajectory data, specially for geometries. While there is no such thing, I think `sisl` users could benefit from being able to at least read trajectories from `.xyz` files, even if there is no way of treating them in SIESTA. I introduced the `ret_xyz` keyword argument to skip geometry instantiation, which makes it feasible (and very quick) to read trajectories.

```python
import sisl

xyz_sile = sisl.get_sile("trajectory.xyz")
traj = []
with xyz_sile as s:
    while True:
        try:
            xyz = s.read_geometry(ret_xyz=True)
            traj.append(xyz)
        except:
            # No more geometries to read
            break
```

If you agree this is OK (I think it's the least intrusive way to allow users to do this without new functionality), I would add a test for it.