### PR TITLE
mnt: changed spin_squared name to other name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ we hit release version 1.0.0.
 - `stdoutSileSiesta.read_*` now defaults to read the *next* entry, and not the last
 - `stdoutSileSiesta.read_*` changed MD output functionality, see #586 for details
 - `AtomNeighbours` changed name to `AtomNeighbor` to follow #393
+- changed method name `spin_squared` to `spin_contamination`
 - removed `Lattice.translate|move`, they did not make sense, and so their
   usage should be deferred to `Lattice.add` instead.
 - `vacuum` is now an optional parameter for all ribbon structures

--- a/docs/api/physics.electron.rst
+++ b/docs/api/physics.electron.rst
@@ -24,7 +24,7 @@ One may also plot real-space wavefunctions.
    conductivity
    wavefunction
    spin_moment
-   spin_squared
+   spin_contamination
 
 
 Supporting classes

--- a/src/sisl/physics/electron.py
+++ b/src/sisl/physics/electron.py
@@ -20,7 +20,7 @@ One may also plot real-space wavefunctions.
    conductivity
    wavefunction
    spin_moment
-   spin_squared
+   spin_contamination
 
 
 Supporting classes
@@ -86,7 +86,7 @@ from .spin import Spin
 from .state import Coefficient, State, StateC, _FakeMatrix, degenerate_decouple
 
 __all__ = ["DOS", "PDOS", "COP"]
-__all__ += ["spin_moment", "spin_squared"]
+__all__ += ["spin_moment", "spin_contamination"]
 __all__ += ["berry_phase", "berry_curvature"]
 __all__ += ["conductivity"]
 __all__ += ["wavefunction"]
@@ -526,12 +526,12 @@ def spin_moment(state, S=None, project=False):
 
 
 @set_module("sisl.physics.electron")
-def spin_squared(state_alpha, state_beta, S=None):
-    r""" Calculate the spin squared expectation value between two spin states
+def spin_contamination(state_alpha, state_beta, S=None):
+    r""" Calculate the spin contamination value between two spin states
 
     This calculation only makes sense for spin-polarized calculations.
 
-    The expectation value is calculated using the following formula:
+    The contamination value is calculated using the following formula:
 
     .. math::
        S^2_{\alpha,i} &= \sum_j |\langle \psi_j^\beta | \mathbf S | \psi_i^\alpha \rangle|^2
@@ -564,18 +564,14 @@ def spin_squared(state_alpha, state_beta, S=None):
     """
     if state_alpha.ndim == 1:
         if state_beta.ndim == 1:
-            Sa, Sb = spin_squared(
-                state_alpha.reshape(1, -1), state_beta.reshape(1, -1), S
-            )
+            Sa, Sb = spin_contamination(state_alpha.reshape(1, -1), state_beta.reshape(1, -1), S)
             return oplist((Sa[0], Sb[0]))
-        return spin_squared(state_alpha.reshape(1, -1), state_beta, S)
+        return spin_contamination(state_alpha.reshape(1, -1), state_beta, S)
     elif state_beta.ndim == 1:
-        return spin_squared(state_alpha, state_beta.reshape(1, -1), S)
+        return spin_contamination(state_alpha, state_beta.reshape(1, -1), S)
 
     if state_alpha.shape[1] != state_beta.shape[1]:
-        raise ValueError(
-            "spin_squared requires alpha and beta states to have same number of orbitals"
-        )
+        raise ValueError("spin_contamination requires alpha and beta states to have same number of orbitals")
 
     if S is None:
 

--- a/src/sisl/physics/electron.py
+++ b/src/sisl/physics/electron.py
@@ -564,14 +564,18 @@ def spin_contamination(state_alpha, state_beta, S=None):
     """
     if state_alpha.ndim == 1:
         if state_beta.ndim == 1:
-            Sa, Sb = spin_contamination(state_alpha.reshape(1, -1), state_beta.reshape(1, -1), S)
+            Sa, Sb = spin_contamination(
+                state_alpha.reshape(1, -1), state_beta.reshape(1, -1), S
+            )
             return oplist((Sa[0], Sb[0]))
         return spin_contamination(state_alpha.reshape(1, -1), state_beta, S)
     elif state_beta.ndim == 1:
         return spin_contamination(state_alpha, state_beta.reshape(1, -1), S)
 
     if state_alpha.shape[1] != state_beta.shape[1]:
-        raise ValueError("spin_contamination requires alpha and beta states to have same number of orbitals")
+        raise ValueError(
+            "spin_contamination requires alpha and beta states to have same number of orbitals"
+        )
 
     if S is None:
 

--- a/src/sisl/physics/hamiltonian.py
+++ b/src/sisl/physics/hamiltonian.py
@@ -5,10 +5,10 @@ import numpy as np
 
 import sisl._array as _a
 from sisl._internal import set_module
-from .distribution import get_distribution
-from .electron import EigenvalueElectron, EigenstateElectron
-from .sparse import SparseOrbitalBZSpin
 
+from .distribution import get_distribution
+from .electron import EigenstateElectron, EigenvalueElectron
+from .sparse import SparseOrbitalBZSpin
 
 __all__ = ["Hamiltonian"]
 

--- a/src/sisl/physics/hamiltonian.py
+++ b/src/sisl/physics/hamiltonian.py
@@ -5,10 +5,10 @@ import numpy as np
 
 import sisl._array as _a
 from sisl._internal import set_module
-
 from .distribution import get_distribution
-from .electron import EigenstateElectron, EigenvalueElectron, spin_squared
+from .electron import EigenvalueElectron, EigenstateElectron
 from .sparse import SparseOrbitalBZSpin
+
 
 __all__ = ["Hamiltonian"]
 

--- a/src/sisl/physics/tests/test_hamiltonian.py
+++ b/src/sisl/physics/tests/test_hamiltonian.py
@@ -9,11 +9,22 @@ import pytest
 from scipy.linalg import block_diag
 from scipy.sparse import SparseEfficiencyWarning, issparse
 
-from sisl import Geometry, Atom, Lattice, Hamiltonian, Spin, BandStructure, MonkhorstPack, BrillouinZone
-from sisl import get_distribution
-from sisl import oplist
-from sisl import Grid, SphericalOrbital, SislError
-from sisl.physics.electron import berry_phase, spin_contamination, conductivity
+from sisl import (
+    Atom,
+    BandStructure,
+    BrillouinZone,
+    Geometry,
+    Grid,
+    Hamiltonian,
+    Lattice,
+    MonkhorstPack,
+    SislError,
+    SphericalOrbital,
+    Spin,
+    get_distribution,
+    oplist,
+)
+from sisl.physics.electron import berry_phase, conductivity, spin_contamination
 
 pytestmark = [
     pytest.mark.physics,
@@ -1428,7 +1439,11 @@ class TestHamiltonian:
 
     @pytest.mark.parametrize("k", [[0, 0, 0], [0.1, 0, 0]])
     def test_spin_contamination(self, setup, k):
-        g = Geometry([[i, 0, 0] for i in range(10)], Atom(6, R=1.01), lattice=Lattice(1, nsc=[3, 1, 1]))
+        g = Geometry(
+            [[i, 0, 0] for i in range(10)],
+            Atom(6, R=1.01),
+            lattice=Lattice(1, nsc=[3, 1, 1]),
+        )
         H = Hamiltonian(g, spin=Spin.POLARIZED)
         H.construct(([0.1, 1.1], [[0, 0.1], [1, 1.1]]))
         H[0, 0] = (0.1, 0.0)
@@ -1446,23 +1461,31 @@ class TestHamiltonian:
         assert len(sup) == 2
         assert len(sdn) == es_beta.shape[0]
 
-        sup, sdn = spin_contamination(es_alpha.sub(range(3)).state, es_beta.sub(range(2)).state)
+        sup, sdn = spin_contamination(
+            es_alpha.sub(range(3)).state, es_beta.sub(range(2)).state
+        )
         assert sup.sum() == pytest.approx(sdn.sum())
         assert len(sup) == 3
         assert len(sdn) == 2
 
-        sup, sdn = spin_contamination(es_alpha.sub(0).state.ravel(), es_beta.sub(range(2)).state)
+        sup, sdn = spin_contamination(
+            es_alpha.sub(0).state.ravel(), es_beta.sub(range(2)).state
+        )
         assert sup.sum() == pytest.approx(sdn.sum())
         assert sup.ndim == 1
         assert len(sup) == 1
         assert len(sdn) == 2
 
-        sup, sdn = spin_contamination(es_alpha.sub(0).state.ravel(), es_beta.sub(0).state.ravel())
+        sup, sdn = spin_contamination(
+            es_alpha.sub(0).state.ravel(), es_beta.sub(0).state.ravel()
+        )
         assert sup.sum() == pytest.approx(sdn.sum())
         assert sup.ndim == 0
         assert sdn.ndim == 0
 
-        sup, sdn = spin_contamination(es_alpha.sub(range(2)).state, es_beta.sub(0).state.ravel())
+        sup, sdn = spin_contamination(
+            es_alpha.sub(range(2)).state, es_beta.sub(0).state.ravel()
+        )
         assert sup.sum() == pytest.approx(sdn.sum())
         assert len(sup) == 2
         assert len(sdn) == 1

--- a/src/sisl/physics/tests/test_hamiltonian.py
+++ b/src/sisl/physics/tests/test_hamiltonian.py
@@ -1451,25 +1451,29 @@ class TestHamiltonian:
         es_alpha = H.eigenstate(k, spin=0)
         es_beta = H.eigenstate(k, spin=1)
 
-        sup, sdn = spin_contamination(es_alpha.state, es_beta.state)
+        sup, sdn = spin_contamination(es_alpha.state, es_beta.state, sum=False)
         assert sup.sum() == pytest.approx(sdn.sum())
         assert len(sup) == es_alpha.shape[0]
         assert len(sdn) == es_beta.shape[0]
+        s = spin_contamination(es_alpha.state, es_beta.state)
+        assert sup.sum() == pytest.approx(s)
 
-        sup, sdn = spin_contamination(es_alpha.sub(range(2)).state, es_beta.state)
+        sup, sdn = spin_contamination(
+            es_alpha.sub(range(2)).state, es_beta.state, sum=False
+        )
         assert sup.sum() == pytest.approx(sdn.sum())
         assert len(sup) == 2
         assert len(sdn) == es_beta.shape[0]
 
         sup, sdn = spin_contamination(
-            es_alpha.sub(range(3)).state, es_beta.sub(range(2)).state
+            es_alpha.sub(range(3)).state, es_beta.sub(range(2)).state, sum=False
         )
         assert sup.sum() == pytest.approx(sdn.sum())
         assert len(sup) == 3
         assert len(sdn) == 2
 
         sup, sdn = spin_contamination(
-            es_alpha.sub(0).state.ravel(), es_beta.sub(range(2)).state
+            es_alpha.sub(0).state.ravel(), es_beta.sub(range(2)).state, sum=False
         )
         assert sup.sum() == pytest.approx(sdn.sum())
         assert sup.ndim == 1
@@ -1477,14 +1481,14 @@ class TestHamiltonian:
         assert len(sdn) == 2
 
         sup, sdn = spin_contamination(
-            es_alpha.sub(0).state.ravel(), es_beta.sub(0).state.ravel()
+            es_alpha.sub(0).state.ravel(), es_beta.sub(0).state.ravel(), sum=False
         )
         assert sup.sum() == pytest.approx(sdn.sum())
         assert sup.ndim == 0
         assert sdn.ndim == 0
 
         sup, sdn = spin_contamination(
-            es_alpha.sub(range(2)).state, es_beta.sub(0).state.ravel()
+            es_alpha.sub(range(2)).state, es_beta.sub(0).state.ravel(), sum=False
         )
         assert sup.sum() == pytest.approx(sdn.sum())
         assert len(sup) == 2


### PR DESCRIPTION
The correct name is a contamination of the spin states. This change adheres so that it is more correct.

@tfrederiksen @sofiasanz could you please review this name change?
I think this is more correct, no? You have it used in hubbard, but just wanted to clear it out.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Documentation for functionality
 - [x] User visible changes (including notable bug fixes) are documented in `CHANGELOG`
