### PR TITLE
Reading output from ORCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ we hit release version 1.0.0.
 ## [0.13.0] - YYYY-MM-DD
 
 ### Added
+- implemented reading of output files from ORCA, #500
 - HydrogenicOrbital is added for simple handling of 1-valence electron
 	orbitals, #499
 - Bohr radius to constants

--- a/sisl/io/__init__.py
+++ b/sisl/io/__init__.py
@@ -53,6 +53,12 @@ OpenMX
    omxSileOpenMX - input file
 
 
+ORCA
+====
+
+   txtSileORCA - property txt file
+
+
 ScaleUp
 =======
 
@@ -157,6 +163,7 @@ from .gulp import *
 from .ham import *
 from .molden import *
 from .openmx import *
+from .orca import *
 from .pdb import *
 from .scaleup import *
 from .siesta import *

--- a/sisl/io/__init__.py
+++ b/sisl/io/__init__.py
@@ -56,6 +56,7 @@ OpenMX
 ORCA
 ====
 
+   outputSileORCA - standard output file
    txtSileORCA - property txt file
 
 

--- a/sisl/io/__init__.py
+++ b/sisl/io/__init__.py
@@ -57,7 +57,7 @@ ORCA
 ====
 
    outputSileORCA - standard output file
-   txtSileORCA - property txt file
+   txtSileORCA - property.txt file
 
 
 ScaleUp

--- a/sisl/io/orca/__init__.py
+++ b/sisl/io/orca/__init__.py
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+ORCA
+====
+
+   txtSileORCA - ORCA property txt file
+"""
+from .sile import *
+from .txt import *

--- a/sisl/io/orca/__init__.py
+++ b/sisl/io/orca/__init__.py
@@ -5,7 +5,9 @@
 ORCA
 ====
 
-   txtSileORCA - ORCA property txt file
+   outputSileORCA - ORCA output file
+   txtSileORCA - ORCA property.txt file
 """
 from .sile import *
 from .txt import *
+from .output import *

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -65,7 +65,7 @@ class outputSileORCA(SileORCA):
     def no(self):
         """ Number of orbitals (basis functions) """
         if self._no is None:
-            f = self.step_to("Number of atoms")
+            f = self.step_to("Number of basis functions")
             if f[0]:
                 self._no = int(f[1].split()[-1])
             else:

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -80,6 +80,10 @@ class outputSileORCA(SileORCA):
         ----------
         all : bool, optional
             return electron numbers from all steps (instead of last)
+
+        Returns
+        -------
+        ndarray or list of ndarrays : alpha and beta electrons
         """
 
         def readE(itt, reopen=False):
@@ -126,7 +130,7 @@ class outputSileORCA(SileORCA):
 
         Returns
         -------
-        PropertyDicts or ndarray : atom/orbital-resolved charge (or spin) data
+        PropertyDicts or ndarray or lists : atom/orbital-resolved charge (or spin) data
         """
 
         if name.lower() in ['mulliken', 'm']:
@@ -276,16 +280,18 @@ class outputSileORCA(SileORCA):
 
     @sile_fh_open()
     def read_energy(self, all=False, convert=True):
-        """ Reads the energy specification from ORCA output file
+        """ Reads the energy blocks
 
         Parameters
         ----------
-        all: bool, optional
-            return a list of dictionaries from each step
+        all : bool, optional
+            return a list of dictionaries from each step (instead of the last)
+        convert : bool, optional
+            whether to convert the energies to eV (Ha-values are read)
 
         Returns
         -------
-        PropertyDict : all data from the "TOTAL SCF ENERGY" segment
+        PropertyDict or list of PropertyDict : all energy data from the "TOTAL SCF ENERGY" and "DFT DISPERSION CORRECTION" blocks
         """
         def readE(itt, vdw, reopen=False):
             if convert:

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -96,8 +96,8 @@ class outputSileORCA(SileORCA):
             elif name.lower() in ['loewdin', 'lowdin', 'löwdin']:
                 step_to = "LOEWDIN ATOMIC CHARGES AND SPIN POPULATIONS"
 
-            def read_block(itt, step_to):
-                f = self.step_to(step_to, reread=False)[0]
+            def read_block(itt, step_to, reread=True):
+                f = self.step_to(step_to, reread=reread)[0]
                 if not f:
                     return None
                 next(itt) # skip ---
@@ -132,13 +132,13 @@ class outputSileORCA(SileORCA):
                     v = next(itt).split()
                 return D
 
-            def read_block(itt, step_to):
-                f = self.step_to(step_to, reread=False)[0]
+            def read_block(itt, step_to, reread=True):
+                f = self.step_to(step_to, reread=reread)[0]
                 if not f:
                     return None
-                self.step_to("CHARGE", reread=False)
+                self.step_to("CHARGE", reread=reread)
                 charge = read_reduced_orbital_block(itt)
-                self.step_to("SPIN", reread=False)
+                self.step_to("SPIN", reread=reread)
                 spin = read_reduced_orbital_block(itt)
                 if orbital is None:
                     return charge, spin
@@ -160,8 +160,8 @@ class outputSileORCA(SileORCA):
             elif name.lower() in ['loewdin', 'lowdin', 'löwdin']:
                 step_to = "LOEWDIN ORBITAL CHARGES AND SPIN POPULATIONS"
 
-            def read_block(itt, step_to):
-                f = self.step_to(step_to, reread=False)[0]
+            def read_block(itt, step_to, reread=True):
+                f = self.step_to(step_to, reread=reread)[0]
                 if not f:
                     return None
                 next(itt) # skip ---
@@ -192,7 +192,7 @@ class outputSileORCA(SileORCA):
         block = read_block(itt, step_to)
         while block is not None:
             blocks.append(block)
-            block = read_block(itt, step_to)
+            block = read_block(itt, step_to, reread=False)
 
         if all:
             return blocks

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import numpy as np
+from functools import lru_cache
 from .sile import SileORCA
 from ..sile import add_sile, sile_fh_open
 
@@ -18,11 +19,12 @@ class outputSileORCA(SileORCA):
 
     @sile_fh_open()
     def completed(self):
-        """ True if the full file has been read and "ORCA TERMINATED NORMALLY"" was found. """
+        """ True if the full file has been read and "ORCA TERMINATED NORMALLY" was found. """
         return self.step_to("ORCA TERMINATED NORMALLY")[0]
 
 
     @property
+    @lru_cache(1)
     def _natoms(self):
         f, line = self.step_to("Number of atoms")
         v = line.split()
@@ -106,7 +108,7 @@ class outputSileORCA(SileORCA):
 
         Returns
         -------
-        ndarrays or PropertyDicts : charge and spin data
+        ndarray or PropertyDicts : charge and spin data
         """
 
         f = self.step_to("MULLIKEN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS", reread=False)[0]
@@ -121,14 +123,13 @@ class outputSileORCA(SileORCA):
 
         if orbital is not None:
             natoms = self._natoms
-            c = np.zeros(natoms, np.float64)
-            s = np.zeros(natoms, np.float64)
+            cs = np.zeros((natoms, 2), np.float64)
             for key in charge:
                 ia, orb = key
                 if orb == orbital:
-                    c[ia] = charge[key]
-                    s[ia] = spin[key]
-            return c, s
+                    cs[ia, 0] = charge[key]
+                    cs[ia, 1] = spin[key]
+            return cs
 
         return charge, spin
 
@@ -145,7 +146,7 @@ class outputSileORCA(SileORCA):
 
         Returns
         -------
-        ndarrays or PropertyDicts : charge and spin data
+        ndarray or PropertyDicts : charge and spin data
         """
 
         f = self.step_to("LOEWDIN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS", reread=False)[0]
@@ -160,14 +161,13 @@ class outputSileORCA(SileORCA):
 
         if orbital is not None:
             natoms = self._natoms
-            c = np.zeros(natoms, np.float64)
-            s = np.zeros(natoms, np.float64)
+            cs = np.zeros((natoms, 2), np.float64)
             for key in charge:
                 ia, orb = key
                 if orb == orbital:
-                    c[ia] = charge[key]
-                    s[ia] = spin[key]
-            return c, s
+                    cs[ia, 0] = charge[key]
+                    cs[ia, 1] = spin[key]
+            return cs
 
         return charge, spin
 

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -217,10 +217,9 @@ class outputSileORCA(SileORCA):
                     return D
                 else:
                     Da = np.zeros(self.na, np.float64)
-                    for key in D:
-                        ia, orb = key
+                    for (ia, orb), d in D.items():
                         if orb == orb_key:
-                            Da[ia] = D[key]
+                            Da[ia] = d
                     return Da
 
         elif projection == 'orbital' and not reduced:

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -43,6 +43,32 @@ class outputSileORCA(SileORCA):
         return np.array(M)
 
 
+    @sile_fh_open()
+    def read_loewdin_atomic(self):
+        """ Reads the atom-resolved Loewdin charge and spin population analysis
+
+        Returns
+        -------
+        ndarray : atom-resolved charge and spin populations
+        """
+
+        f = self.step_to("LOEWDIN ATOMIC CHARGES AND SPIN POPULATIONS", reread=False)[0]
+        if not f:
+            return None
+
+        itt = iter(self)
+
+        next(itt) # ---
+        L = []
+        v = next(itt).split()
+        while len(v) > 0:
+            ia = int(v[0])
+            L.append([float(v[-2]), float(v[-1])])
+            v = next(itt).split()
+
+        return np.array(L)
+
+
     def _read_orbital_block(self):
         itt = iter(self)
         D = PropertyDict()
@@ -76,10 +102,33 @@ class outputSileORCA(SileORCA):
 
         f = self.step_to("CHARGE", reread=False)[0]
         charge = self._read_orbital_block()
-        
+
         f = self.step_to("SPIN", reread=False)[0]
         spin = self._read_orbital_block()
 
         return charge, spin
+
+
+    @sile_fh_open()
+    def read_loewdin_orbitals(self):
+        """ Reads the orbital-resolved Loewdin charge and spin population analysis
+
+        Returns
+        -------
+        PropertyDicts : charge and spin dictionaries
+        """
+
+        f = self.step_to("LOEWDIN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS", reread=False)[0]
+        if not f:
+            return None
+
+        f = self.step_to("CHARGE", reread=False)[0]
+        charge = self._read_orbital_block()
+
+        f = self.step_to("SPIN", reread=False)[0]
+        spin = self._read_orbital_block()
+
+        return charge, spin
+
 
 add_sile('output', outputSileORCA, gzip=True)

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -288,7 +288,7 @@ class outputSileORCA(SileORCA):
         PropertyDict : all data from the "TOTAL SCF ENERGY" segment
         """
 
-        Hartree2eV = 27.211386245988
+        Hartree2eV = 27.2113834
 
         def readE(itt, vdw, reread=True):
             if convert:

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -250,6 +250,8 @@ class outputSileORCA(SileORCA):
                     ia = int(ia)
                     if spin_block and spin:
                         Do[io] = float(v[4])
+                    elif not spin_block and spin:
+                        return None
                     else:
                         Do[io] = float(v[3])
                     if orbital == v[2]:

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -42,8 +42,27 @@ class outputSileORCA(SileORCA):
 
         return np.array(M)
 
+
+    def _read_orbital_block(self):
+        itt = iter(self)
+        D = PropertyDict()
+        v = next(itt).split()
+        while len(v) > 0:
+            if len(v) == 8:
+                ia = int(v[0])
+                D[(ia, v[2])] = float(v[4])
+                D[(ia, v[5])] = float(v[7])
+            elif len(v) == 6:
+                D[(ia, v[0])] = float(v[2])
+                D[(ia, v[3])] = float(v[5])
+            else:
+                D[(ia, v[0])] = float(v[2])
+            v = next(itt).split()
+        return D
+
+
     @sile_fh_open()
-    def read_mulliken_orbitals(self, all=False):
+    def read_mulliken_orbitals(self):
         """ Reads the orbital-resolved Mulliken charge and spin population analysis
 
         Returns
@@ -55,38 +74,11 @@ class outputSileORCA(SileORCA):
         if not f:
             return None
 
-        itt = iter(self)
-
         f = self.step_to("CHARGE", reread=False)[0]
-        charge = PropertyDict()
-        v = next(itt).split()
-        while len(v) > 0:
-            if len(v) == 8:
-                ia = int(v[0])
-                #sa = v[1]
-                charge[(ia, v[2])] = float(v[4])
-                charge[(ia, v[5])] = float(v[7])
-            elif len(v) == 6:
-                charge[(ia, v[0])] = float(v[2])
-                charge[(ia, v[3])] = float(v[5])
-            else:
-                charge[(ia, v[0])] = float(v[2])
-            v = next(itt).split()
+        charge = self._read_orbital_block()
         
         f = self.step_to("SPIN", reread=False)[0]
-        spin = PropertyDict()
-        v = next(itt).split()
-        while len(v) > 0:
-            if len(v) == 8:
-                ia = int(v[0])
-                spin[(ia, v[2])] = float(v[4])
-                spin[(ia, v[5])] = float(v[7])
-            elif len(v) == 6:
-                spin[(ia, v[0])] = float(v[2])
-                spin[(ia, v[3])] = float(v[5])
-            else:
-                spin[(ia, v[0])] = float(v[2])
-            v = next(itt).split()
+        spin = self._read_orbital_block()
 
         return charge, spin
 

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -16,6 +16,11 @@ __all__ = ['outputSileORCA']
 class outputSileORCA(SileORCA):
     """ Output file from ORCA """
 
+    @sile_fh_open()
+    def completed(self):
+        return self.step_to("ORCA TERMINATED NORMALLY")[0]
+
+
     @property
     def _natoms(self):
         f, line = self.step_to("Number of atoms")
@@ -94,7 +99,7 @@ class outputSileORCA(SileORCA):
 
         Parameters
         ----------
-        orbital : str or list of str, optional
+        orbital : str, optional
             if an orbital string is specified a ndarray is returned with the corresponding
             values per atom, otherwise the whole orbital block is returned as dictionary
 

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -89,11 +89,24 @@ class outputSileORCA(SileORCA):
         PropertyDicts or ndarray : atom/orbital-resolved charge and spin data
         """
 
-        if projection.lower() == 'atom':
+        if name.lower() in ['mulliken', 'm']:
+            name = 'mulliken'
+        elif name.lower() in ['loewdin', 'lowdin', 'löwdin', 'l']:
+            name = 'loewdin'
+        else:
+            raise NotImplementedError(f"name={name} is not implemented")
 
-            if name.lower() == 'mulliken':
+        if projection.lower() in ['atom', 'atoms', 'a']:
+            projection = 'atom'
+        elif projection.lower() in ['orbital', 'orbitals', 'orb', 'o']:
+            projection = 'orbital'
+        else:
+            raise ValueError(f"Projection must be atom or orbital")
+
+        if projection == 'atom':
+            if name == 'mulliken':
                 step_to = "MULLIKEN ATOMIC CHARGES AND SPIN POPULATIONS"
-            elif name.lower() in ['loewdin', 'lowdin', 'löwdin']:
+            elif name == 'loewdin':
                 step_to = "LOEWDIN ATOMIC CHARGES AND SPIN POPULATIONS"
 
             def read_block(itt, step_to, reread=True):
@@ -108,12 +121,10 @@ class outputSileORCA(SileORCA):
                     A[ia] = float(v[-2]), float(v[-1])
                 return A
 
-        elif projection.lower() == 'orbital' and reduced:
-
-            # Reduced basis
-            if name.lower() == 'mulliken':
+        elif projection == 'orbital' and reduced:
+            if name == 'mulliken':
                 step_to = "MULLIKEN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS"
-            elif name.lower() in ['loewdin', 'lowdin', 'löwdin']:
+            elif name == 'loewdin':
                 step_to = "LOEWDIN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS"
 
             def read_reduced_orbital_block(itt):
@@ -152,12 +163,10 @@ class outputSileORCA(SileORCA):
                             csa[ia, 1] = spin[key]
                     return csa
 
-        elif projection.lower() == 'orbital' and not reduced:
-
-            # Full basis
-            if name.lower() == 'mulliken':
+        elif projection == 'orbital' and not reduced:
+            if name == 'mulliken':
                 step_to = "MULLIKEN ORBITAL CHARGES AND SPIN POPULAITONS"
-            elif name.lower() in ['loewdin', 'lowdin', 'löwdin']:
+            elif name == 'loewdin':
                 step_to = "LOEWDIN ORBITAL CHARGES AND SPIN POPULATIONS"
 
             def read_block(itt, step_to, reread=True):

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -53,8 +53,11 @@ class outputSileORCA(SileORCA):
     def na(self):
         """ Number of atoms """
         if self._na is None:
-            v = self.step_to("Number of atoms")[1].split()
-            self._na = int(v[-1])
+            f = self.step_to("Number of atoms")
+            if f[0]:
+                self._na = int(f[1].split()[-1])
+            else:
+                return None
         return self._na
 
     @property
@@ -62,8 +65,11 @@ class outputSileORCA(SileORCA):
     def no(self):
         """ Number of orbitals (basis functions) """
         if self._no is None:
-            v = self.step_to("Number of basis functions")[1].split()
-            self._no = int(v[-1])
+            f = self.step_to("Number of atoms")
+            if f[0]:
+                self._no = int(f[1].split()[-1])
+            else:
+                return None
         return self._no
 
     @sile_fh_open()

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -74,7 +74,13 @@ class outputSileORCA(SileORCA):
 
     @sile_fh_open()
     def read_electrons(self, all=False):
-        """ Number of electrons (alpha, beta) """
+        """ Read number of electrons (alpha, beta)
+
+        Parameters
+        ----------
+        all : bool, optional
+            return electron numbers from all steps (instead of last)
+        """
 
         def readE(itt, reread=True):
             f = self.step_to("N(Alpha)", reread=reread)

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -136,9 +136,9 @@ class outputSileORCA(SileORCA):
                 f = self.step_to(step_to, reread=reread)[0]
                 if not f:
                     return None
-                self.step_to("CHARGE", reread=reread)
+                self.step_to("CHARGE", reread=False)
                 charge = read_reduced_orbital_block(itt)
-                self.step_to("SPIN", reread=reread)
+                self.step_to("SPIN", reread=False)
                 spin = read_reduced_orbital_block(itt)
                 if orbital is None:
                     return charge, spin

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -109,7 +109,7 @@ class outputSileORCA(SileORCA):
         return None
 
     @sile_fh_open()
-    def read_charge(self, name='mulliken', projection='orbital', orbital=None,
+    def read_charge(self, name='mulliken', projection='orbital', orb_key=None,
                     reduced=True, spin=False, all=False):
         """ Reads from charge (or spin) population analysis
 
@@ -119,8 +119,8 @@ class outputSileORCA(SileORCA):
             name of the charge scheme to be read
         projection : {'orbital', 'atom'}
             whether to get orbital- or atom-resolved quantities
-        orbital : str, optional
-            allows to extract the atom-resolved orbital values matching this keyword
+        orb_key : str, optional
+            allows to extract the atom-resolved orbitals matching this keyword
         reduced : bool, optional
             whether to search for full or reduced orbital projections
         spin : bool, optional
@@ -213,13 +213,13 @@ class outputSileORCA(SileORCA):
                 else:
                     return None
                 D = read_reduced_orbital_block(itt)
-                if orbital is None:
+                if orb_key is None:
                     return D
                 else:
                     Da = np.zeros(self.na, np.float64)
                     for key in D:
                         ia, orb = key
-                        if orb == orbital:
+                        if orb == orb_key:
                             Da[ia] = D[key]
                     return Da
 
@@ -258,9 +258,9 @@ class outputSileORCA(SileORCA):
                         return None
                     else:
                         Do[io] = float(v[3])
-                    if orbital == v[2]:
+                    if v[2] == orb_key:
                         Da[ia] += Do[io]
-                if orbital is None:
+                if orb_key is None:
                     return Do
                 else:
                     return Da

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -66,16 +66,6 @@ class outputSileORCA(SileORCA):
             self._no = int(v[-1])
         return self._no
 
-    def _read_atomic_block(self):
-        itt = iter(self)
-        next(itt) # skip ---
-        A = np.empty((self.na, 2), np.float64)
-        for ia in range(self.na):
-            line = next(itt)
-            v = line.split()
-            A[ia] = float(v[-2]), float(v[-1])
-        return A
-
     def _read_reduced_orbital_block(self):
         itt = iter(self)
         D = PropertyDict()
@@ -94,7 +84,8 @@ class outputSileORCA(SileORCA):
         return D
 
     @sile_fh_open()
-    def read_charge(self, name='mulliken', projection='orbital', orbital=None, reduced=True):
+    def read_charge(self, name='mulliken', projection='orbital', orbital=None,
+                    reduced=True, all=False):
         """ Reads from charge and spin population analysis
 
         Parameters
@@ -107,6 +98,8 @@ class outputSileORCA(SileORCA):
             allows to extract the atom-resolved orbital values matching this keyword
         reduced : bool, optional
             whether to search for full or reduced orbital projections
+        all: bool, optional
+            return a list of all population analysis blocks instead of the last one
 
         Returns
         -------
@@ -116,76 +109,97 @@ class outputSileORCA(SileORCA):
         if projection.lower() == 'atom':
 
             if name.lower() == 'mulliken':
-                f = self.step_to("MULLIKEN ATOMIC CHARGES AND SPIN POPULATIONS")[0]
+                step_to = "MULLIKEN ATOMIC CHARGES AND SPIN POPULATIONS"
             elif name.lower() in ['loewdin', 'lowdin', 'löwdin']:
-                f = self.step_to("LOEWDIN ATOMIC CHARGES AND SPIN POPULATIONS")[0]
-            if not f:
-                return None
+                step_to = "LOEWDIN ATOMIC CHARGES AND SPIN POPULATIONS"
 
-            return self._read_atomic_block()
+            def read_block(itt, step_to):
+                f = self.step_to(step_to, reread=False)[0]
+                if not f:
+                    return None
+                print(next(itt)) # skip ---
+                A = np.empty((self.na, 2), np.float64)
+                for ia in range(self.na):
+                    line = next(itt)
+                    v = line.split()
+                    A[ia] = float(v[-2]), float(v[-1])
+                return A
 
         elif projection.lower() == 'orbital' and reduced:
 
             # Reduced basis
             if name.lower() == 'mulliken':
-                f = self.step_to("MULLIKEN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS")[0]
+                step_to = "MULLIKEN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS"
             elif name.lower() in ['loewdin', 'lowdin', 'löwdin']:
-                f = self.step_to("LOEWDIN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS")[0]
-            if not f:
-                return None
+                step_to = "LOEWDIN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS"
 
-            self.step_to("CHARGE", reread=False)
-            charge = self._read_reduced_orbital_block()
-
-            self.step_to("SPIN", reread=False)
-            spin = self._read_reduced_orbital_block()
-
-            if orbital is None:
-                return charge, spin
-
-            else:
-                # atom-resolved (charge, spin) from dictionary
-                csa = np.zeros((self.na, 2), np.float64)
-                for key in charge:
-                    ia, orb = key
-                    if orb == orbital:
-                        csa[ia, 0] = charge[key]
-                        csa[ia, 1] = spin[key]
-                return csa
+            def read_block(itt, step_to):
+                f = self.step_to(step_to, reread=False)[0]
+                if not f:
+                    return None
+                self.step_to("CHARGE", reread=False)
+                charge = self._read_reduced_orbital_block()
+                self.step_to("SPIN", reread=False)
+                spin = self._read_reduced_orbital_block()
+                if orbital is None:
+                    return charge, spin
+                else:
+                    # atom-resolved (charge, spin) from dictionary
+                    csa = np.zeros((self.na, 2), np.float64)
+                    for key in charge:
+                        ia, orb = key
+                        if orb == orbital:
+                            csa[ia, 0] = charge[key]
+                            csa[ia, 1] = spin[key]
+                    return csa
 
         elif projection.lower() == 'orbital' and not reduced:
 
             # Full basis
-            itt = iter(self)
             if name.lower() == 'mulliken':
-                f = self.step_to("MULLIKEN ORBITAL CHARGES AND SPIN POPULAITONS")[0]
-                next(itt) # skip one more line in this case
+                step_to = "MULLIKEN ORBITAL CHARGES AND SPIN POPULAITONS"
             elif name.lower() in ['loewdin', 'lowdin', 'löwdin']:
-                f = self.step_to("LOEWDIN ORBITAL CHARGES AND SPIN POPULATIONS")[0]
-            if not f:
-                return None
+                step_to = "LOEWDIN ORBITAL CHARGES AND SPIN POPULATIONS"
 
-            next(itt) # skip ---
-            cso = np.empty((self.no, 2), np.float64) # orbital-resolved (charge, spin)
-            csa = np.zeros((self.na, 2), np.float64) # atom-resolved (charge, spin)
-            for io in range(self.no):
-                v = next(itt).split() # io, ia+element, orb, chg, spin
-                # split atom number and element from v[1]
-                ia, element = '', ''
-                for s in v[1]:
-                    if s.isdigit():
-                        ia += s
-                    else:
-                        element += s
-                ia = int(ia)
-                cso[io] = v[3:5]
-                if orbital == v[2]:
-                    csa[ia] += cso[io]
+            def read_block(itt, step_to):
+                f = self.step_to(step_to, reread=False)[0]
+                if not f:
+                    return None
+                next(itt) # skip ---
+                if "MULLIKEN" in step_to:
+                    next(itt) # skip another line
+                cso = np.empty((self.no, 2), np.float64) # orbital-resolved (charge, spin)
+                csa = np.zeros((self.na, 2), np.float64) # atom-resolved (charge, spin)
+                for io in range(self.no):
+                    v = next(itt).split() # io, ia+element, orb, chg, spin
+                    # split atom number and element from v[1]
+                    ia, element = '', ''
+                    for s in v[1]:
+                        if s.isdigit():
+                            ia += s
+                        else:
+                            element += s
+                    ia = int(ia)
+                    cso[io] = v[3:5]
+                    if orbital == v[2]:
+                        csa[ia] += cso[io]
+                if orbital is None:
+                    return cso
+                else:
+                    return csa
 
-            if orbital is None:
-                return cso
-            else:
-                return csa
+        itt = iter(self)
+        blocks = []
+        block = read_block(itt, step_to)
+        while block is not None:
+            blocks.append(block)
+            block = read_block(itt, step_to)
+
+        if all:
+            return blocks
+        if len(blocks) > 0:
+            return blocks[-1]
+        return None
 
 
 add_sile('output', outputSileORCA, gzip=True)

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -7,7 +7,7 @@ from ..sile import add_sile, sile_fh_open
 
 from sisl.utils import PropertyDict
 from sisl._internal import set_module
-from sisl import Geometry
+from sisl.unit import units
 
 __all__ = ['outputSileORCA']
 
@@ -287,12 +287,9 @@ class outputSileORCA(SileORCA):
         -------
         PropertyDict : all data from the "TOTAL SCF ENERGY" segment
         """
-
-        Hartree2eV = 27.2113834
-
         def readE(itt, vdw, reopen=False):
             if convert:
-                sc = Hartree2eV
+                sc = units('Ha', 'eV')
             else:
                 sc = 1
             f = self.step_to("TOTAL SCF ENERGY", reopen=reopen, allow_reread=False)[0]

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -107,10 +107,10 @@ class outputSileORCA(SileORCA):
         if not f:
             return None
 
-        f = self.step_to("CHARGE", reread=False)[0]
+        self.step_to("CHARGE", reread=False)
         charge = self._read_orbital_block()
 
-        f = self.step_to("SPIN", reread=False)[0]
+        self.step_to("SPIN", reread=False)
         spin = self._read_orbital_block()
 
         if orbital is not None:
@@ -146,10 +146,10 @@ class outputSileORCA(SileORCA):
         if not f:
             return None
 
-        f = self.step_to("CHARGE", reread=False)[0]
+        self.step_to("CHARGE", reread=False)
         charge = self._read_orbital_block()
 
-        f = self.step_to("SPIN", reread=False)[0]
+        self.step_to("SPIN", reread=False)
         spin = self._read_orbital_block()
 
         if orbital is not None:

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -111,19 +111,19 @@ class outputSileORCA(SileORCA):
         PropertyDicts or ndarray : atom/orbital-resolved charge and spin data
         """
 
-        if projection.lower()[0] == 'a':
-            if name.lower()[0] == 'm':
+        if projection.lower() == 'atom':
+            if name.lower() == 'mulliken':
                 f = self.step_to("MULLIKEN ATOMIC CHARGES AND SPIN POPULATIONS")[0]
-            elif name.lower()[0] == 'l':
+            elif name.lower() in ['loewdin', 'lowdin', 'löwdin']:
                 f = self.step_to("LOEWDIN ATOMIC CHARGES AND SPIN POPULATIONS")[0]
             if not f:
                 return None
             return self._read_atomic_block()
 
-        elif projection.lower()[0] == 'o':
-            if name.lower()[0] == 'm':
+        elif projection.lower() == 'orbital':
+            if name.lower() == 'mulliken':
                 f = self.step_to("MULLIKEN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS", reread=False)[0]
-            elif name.lower()[0] == 'l':
+            elif name.lower() in ['loewdin', 'lowdin', 'löwdin']:
                 f = self.step_to("LOEWDIN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS", reread=False)[0]
             if not f:
                 return None

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -18,6 +18,7 @@ class outputSileORCA(SileORCA):
 
     @sile_fh_open()
     def completed(self):
+        """ True if the full file has been read and "ORCA TERMINATED NORMALLY"" was found. """
         return self.step_to("ORCA TERMINATED NORMALLY")[0]
 
 

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -27,6 +27,8 @@ class outputSileORCA(SileORCA):
     @lru_cache(1)
     def _natoms(self):
         f, line = self.step_to("Number of atoms")
+        if not f:
+            return None
         v = line.split()
         return int(v[-1])
 

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -279,25 +279,19 @@ class outputSileORCA(SileORCA):
         return None
 
     @sile_fh_open()
-    def read_energy(self, all=False, convert=True):
+    def read_energy(self, all=False):
         """ Reads the energy blocks
 
         Parameters
         ----------
         all : bool, optional
             return a list of dictionaries from each step (instead of the last)
-        convert : bool, optional
-            whether to convert the energies to eV (Ha-values are read)
 
         Returns
         -------
-        PropertyDict or list of PropertyDict : all energy data from the "TOTAL SCF ENERGY" and "DFT DISPERSION CORRECTION" blocks
+        PropertyDict or list of PropertyDict : all energy data (in eV) from the "TOTAL SCF ENERGY" and "DFT DISPERSION CORRECTION" blocks
         """
         def readE(itt, vdw, reopen=False):
-            if convert:
-                sc = units('Ha', 'eV')
-            else:
-                sc = 1
             f = self.step_to("TOTAL SCF ENERGY", reopen=reopen, allow_reread=False)[0]
             if not f:
                 return None
@@ -309,20 +303,20 @@ class outputSileORCA(SileORCA):
             while "----" not in line:
                 v = line.split()
                 if "Total Energy" in line:
-                    E["total"] = float(v[-4]) * sc
+                    E["total"] = float(v[-4]) * units('Ha', 'eV')
                 elif "E(X)" in line:
-                    E["exchange"] = float(v[-2]) * sc
+                    E["exchange"] = float(v[-2]) * units('Ha', 'eV')
                 elif "E(C)" in line:
-                    E["correlation"] = float(v[-2]) * sc
+                    E["correlation"] = float(v[-2]) * units('Ha', 'eV')
                 elif "E(XC)" in line:
-                    E["xc"] = float(v[-2]) * sc
+                    E["xc"] = float(v[-2]) * units('Ha', 'eV')
                 elif "DFET-embed. en." in line:
-                    E["embedding"] = float(v[-2]) * sc
+                    E["embedding"] = float(v[-2]) * units('Ha', 'eV')
                 line = next(itt)
             if vdw:
                 self.step_to("DFT DISPERSION CORRECTION")[1]
                 v = self.step_to("Dispersion correction")[1].split()
-                E["vdw"] = float(v[-1]) * sc
+                E["vdw"] = float(v[-1]) * units('Ha', 'eV')
             return E
 
         # check if vdw block is present

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -1,0 +1,93 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import numpy as np
+from .sile import SileORCA
+from ..sile import add_sile, sile_fh_open
+
+from sisl.utils import PropertyDict
+from sisl._internal import set_module
+from sisl import Geometry
+
+__all__ = ['outputSileORCA']
+
+
+@set_module("sisl.io.orca")
+class outputSileORCA(SileORCA):
+    """ Output file from ORCA """
+
+    @sile_fh_open()
+    def read_mulliken_atomic(self):
+        """ Reads the atom-resolved Mulliken charge and spin population analysis
+
+        Returns
+        -------
+        ndarray : atom-resolved charge and spin populations
+        """
+
+        f = self.step_to("MULLIKEN ATOMIC CHARGES AND SPIN POPULATIONS", reread=False)[0]
+        if not f:
+            return None
+
+        itt = iter(self)
+
+        next(itt) # ---
+        M = []
+        line = next(itt)
+        while "Sum of atomic" not in line:
+            v = line.split()
+            ia = int(v[0])
+            M.append([float(v[-2]), float(v[-1])])
+            line = next(itt)
+
+        return np.array(M)
+
+    @sile_fh_open()
+    def read_mulliken_orbitals(self, all=False):
+        """ Reads the orbital-resolved Mulliken charge and spin population analysis
+
+        Returns
+        -------
+        PropertyDicts : charge and spin dictionaries
+        """
+
+        f = self.step_to("MULLIKEN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS", reread=False)[0]
+        if not f:
+            return None
+
+        itt = iter(self)
+
+        f = self.step_to("CHARGE", reread=False)[0]
+        charge = PropertyDict()
+        v = next(itt).split()
+        while len(v) > 0:
+            if len(v) == 8:
+                ia = int(v[0])
+                #sa = v[1]
+                charge[(ia, v[2])] = float(v[4])
+                charge[(ia, v[5])] = float(v[7])
+            elif len(v) == 6:
+                charge[(ia, v[0])] = float(v[2])
+                charge[(ia, v[3])] = float(v[5])
+            else:
+                charge[(ia, v[0])] = float(v[2])
+            v = next(itt).split()
+        
+        f = self.step_to("SPIN", reread=False)[0]
+        spin = PropertyDict()
+        v = next(itt).split()
+        while len(v) > 0:
+            if len(v) == 8:
+                ia = int(v[0])
+                spin[(ia, v[2])] = float(v[4])
+                spin[(ia, v[5])] = float(v[7])
+            elif len(v) == 6:
+                spin[(ia, v[0])] = float(v[2])
+                spin[(ia, v[3])] = float(v[5])
+            else:
+                spin[(ia, v[0])] = float(v[2])
+            v = next(itt).split()
+
+        return charge, spin
+
+add_sile('output', outputSileORCA, gzip=True)

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -73,6 +73,32 @@ class outputSileORCA(SileORCA):
         return self._no
 
     @sile_fh_open()
+    def read_electrons(self, all=False):
+        """ Number of electrons (alpha, beta) """
+
+        def readE(itt, reread=True):
+            f = self.step_to("N(Alpha)", reread=reread)
+            if f[0]:
+                alpha = float(f[1].split()[-2])
+                beta = float(next(itt).split()[-2])
+            else:
+                return None
+            return alpha, beta
+
+        itt = iter(self)
+        E = []
+        e = readE(itt)
+        while e is not None:
+            E.append(e)
+            e = readE(itt, reread=False)
+
+        if all:
+            return np.array(E)
+        if len(E) > 0:
+            return np.array(E[-1])
+        return None
+
+    @sile_fh_open()
     def read_charge(self, name='mulliken', projection='orbital', orbital=None,
                     reduced=True, all=False):
         """ Reads from charge and spin population analysis

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -109,7 +109,7 @@ class outputSileORCA(SileORCA):
         return None
 
     @sile_fh_open(True)
-    def read_charge(self, name='mulliken', projection='orbital', orb_key=None,
+    def read_charge(self, name='mulliken', projection='orbital', orbitals=None,
                     reduced=True, spin=False, all=False):
         """ Reads from charge (or spin) population analysis
 
@@ -119,7 +119,7 @@ class outputSileORCA(SileORCA):
             name of the charge scheme to be read
         projection : {'orbital', 'atom'}
             whether to get orbital- or atom-resolved quantities
-        orb_key : str, optional
+        orbitals : str, optional
             allows to extract the atom-resolved orbitals matching this keyword
         reduced : bool, optional
             whether to search for full or reduced orbital projections
@@ -213,12 +213,12 @@ class outputSileORCA(SileORCA):
                 else:
                     return None
                 D = read_reduced_orbital_block(itt)
-                if orb_key is None:
+                if orbitals is None:
                     return D
                 else:
                     Da = np.zeros(self.na, np.float64)
                     for (ia, orb), d in D.items():
-                        if orb == orb_key:
+                        if orb == orbitals:
                             Da[ia] = d
                     return Da
 
@@ -257,9 +257,9 @@ class outputSileORCA(SileORCA):
                         return None
                     else:
                         Do[io] = float(v[3])
-                    if v[2] == orb_key:
+                    if v[2] == orbitals:
                         Da[ia] += Do[io]
-                if orb_key is None:
+                if orbitals is None:
                     return Do
                 else:
                     return Da

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -72,7 +72,7 @@ class outputSileORCA(SileORCA):
                 return None
         return self._no
 
-    @sile_fh_open()
+    @sile_fh_open(True)
     def read_electrons(self, all=False):
         """ Read number of electrons (alpha, beta)
 
@@ -86,8 +86,8 @@ class outputSileORCA(SileORCA):
         ndarray or list of ndarrays : alpha and beta electrons
         """
 
-        def readE(itt, reopen=False):
-            f = self.step_to("N(Alpha)", reopen=reopen, allow_reread=False)
+        def readE(itt):
+            f = self.step_to("N(Alpha)", allow_reread=False)
             if f[0]:
                 alpha = float(f[1].split()[-2])
                 beta = float(next(itt).split()[-2])
@@ -97,7 +97,7 @@ class outputSileORCA(SileORCA):
 
         itt = iter(self)
         E = []
-        e = readE(itt, reopen=True)
+        e = readE(itt)
         while e is not None:
             E.append(e)
             e = readE(itt)
@@ -108,7 +108,7 @@ class outputSileORCA(SileORCA):
             return np.array(E[-1])
         return None
 
-    @sile_fh_open()
+    @sile_fh_open(True)
     def read_charge(self, name='mulliken', projection='orbital', orb_key=None,
                     reduced=True, spin=False, all=False):
         """ Reads from charge (or spin) population analysis
@@ -153,8 +153,8 @@ class outputSileORCA(SileORCA):
             elif name == 'loewdin':
                 step_to = "LOEWDIN ATOMIC CHARGES"
 
-            def read_block(itt, step_to, reopen=False):
-                f, line = self.step_to(step_to, reopen=reopen, allow_reread=False)
+            def read_block(itt, step_to):
+                f, line = self.step_to(step_to, allow_reread=False)
                 if not f:
                     return None
                 next(itt) # skip ---
@@ -196,8 +196,8 @@ class outputSileORCA(SileORCA):
                     v = next(itt).split()
                 return D
 
-            def read_block(itt, step_to, reopen=False):
-                f, line = self.step_to(step_to, reopen=reopen, allow_reread=False)
+            def read_block(itt, step_to):
+                f, line = self.step_to(step_to, allow_reread=False)
                 if not f:
                     return None
                 if "SPIN" in line:
@@ -228,8 +228,8 @@ class outputSileORCA(SileORCA):
             elif name == 'loewdin':
                 step_to = "LOEWDIN ORBITAL CHARGES"
 
-            def read_block(itt, step_to, reopen=False):
-                f, line = self.step_to(step_to, reopen=reopen, allow_reread=False)
+            def read_block(itt, step_to):
+                f, line = self.step_to(step_to, allow_reread=False)
                 if "SPIN" in line:
                     spin_block = True
                 else:
@@ -266,7 +266,7 @@ class outputSileORCA(SileORCA):
 
         itt = iter(self)
         blocks = []
-        block = read_block(itt, step_to, reopen=True)
+        block = read_block(itt, step_to)
         while block is not None:
             blocks.append(block)
             block = read_block(itt, step_to)
@@ -277,7 +277,7 @@ class outputSileORCA(SileORCA):
             return blocks[-1]
         return None
 
-    @sile_fh_open()
+    @sile_fh_open(True)
     def read_energy(self, all=False):
         """ Reads the energy blocks
 
@@ -297,7 +297,6 @@ class outputSileORCA(SileORCA):
             next(itt) # skip ---
             next(itt) # skip blank line
             line = next(itt)
-            print(line)
             E = PropertyDict()
             while "----" not in line:
                 v = line.split()
@@ -334,7 +333,7 @@ class outputSileORCA(SileORCA):
             return E[-1]
         return None
 
-    @sile_fh_open()
+    @sile_fh_open(True)
     def read_orbital_energies(self, all=False):
         """ Reads the "ORBITAL ENERGIES" blocks
 
@@ -347,8 +346,8 @@ class outputSileORCA(SileORCA):
         -------
         ndarray or list : orbital energies (in eV) from the "ORBITAL ENERGIES" blocks
         """
-        def readE(itt, reopen=False):
-            f = self.step_to("ORBITAL ENERGIES", reopen=reopen, allow_reread=False)[0]
+        def readE(itt):
+            f = self.step_to("ORBITAL ENERGIES", allow_reread=False)[0]
             if not f:
                 return None
             next(itt) # skip ---
@@ -378,7 +377,7 @@ class outputSileORCA(SileORCA):
 
         itt = iter(self)
         E = []
-        e = readE(itt, reopen=True)
+        e = readE(itt)
         while e is not None:
             E.append(e)
             e = readE(itt)

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -45,7 +45,7 @@ class outputSileORCA(SileORCA):
 
         natoms = self._natoms
 
-        f = self.step_to("MULLIKEN ATOMIC CHARGES AND SPIN POPULATIONS", reread=False)[0]
+        f = self.step_to("MULLIKEN ATOMIC CHARGES AND SPIN POPULATIONS")[0]
         if not f:
             return None
 
@@ -63,7 +63,7 @@ class outputSileORCA(SileORCA):
 
         natoms = self._natoms
 
-        f = self.step_to("LOEWDIN ATOMIC CHARGES AND SPIN POPULATIONS", reread=False)[0]
+        f = self.step_to("LOEWDIN ATOMIC CHARGES AND SPIN POPULATIONS")[0]
         if not f:
             return None
 
@@ -89,12 +89,18 @@ class outputSileORCA(SileORCA):
 
 
     @sile_fh_open()
-    def read_mulliken_orbitals(self):
+    def read_mulliken_orbitals(self, orbital=None):
         """ Reads the orbital-resolved Mulliken charge and spin population analysis
+
+        Parameters
+        ----------
+        orbital : str or list of str, optional
+            if an orbital string is specified a ndarray is returned with the corresponding
+            values per atom, otherwise the whole orbital block is returned as dictionary
 
         Returns
         -------
-        PropertyDicts : charge and spin dictionaries
+        ndarrays or PropertyDicts : charge and spin data
         """
 
         f = self.step_to("MULLIKEN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS", reread=False)[0]
@@ -107,16 +113,33 @@ class outputSileORCA(SileORCA):
         f = self.step_to("SPIN", reread=False)[0]
         spin = self._read_orbital_block()
 
+        if orbital is not None:
+            natoms = self._natoms
+            c = np.zeros(natoms, np.float64)
+            s = np.zeros(natoms, np.float64)
+            for key in charge:
+                ia, orb = key
+                if orb == orbital:
+                    c[ia] = charge[key]
+                    s[ia] = spin[key]
+            return c, s
+
         return charge, spin
 
 
     @sile_fh_open()
-    def read_loewdin_orbitals(self):
+    def read_loewdin_orbitals(self, orbital=None):
         """ Reads the orbital-resolved Loewdin charge and spin population analysis
+
+        Parameters
+        ----------
+        orbital : str, optional
+            if an orbital string is specified a ndarray is returned with the corresponding
+            values per atom, otherwise the whole orbital block is returned as dictionary
 
         Returns
         -------
-        PropertyDicts : charge and spin dictionaries
+        ndarrays or PropertyDicts : charge and spin data
         """
 
         f = self.step_to("LOEWDIN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS", reread=False)[0]
@@ -128,6 +151,17 @@ class outputSileORCA(SileORCA):
 
         f = self.step_to("SPIN", reread=False)[0]
         spin = self._read_orbital_block()
+
+        if orbital is not None:
+            natoms = self._natoms
+            c = np.zeros(natoms, np.float64)
+            s = np.zeros(natoms, np.float64)
+            for key in charge:
+                ia, orb = key
+                if orb == orbital:
+                    c[ia] = charge[key]
+                    s[ia] = spin[key]
+            return c, s
 
         return charge, spin
 

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -200,12 +200,14 @@ class outputSileORCA(SileORCA):
                     spin_block = True
                 else:
                     spin_block = False
-                if spin:
+                if spin_block and spin:
                     self.step_to("SPIN", reread=False)
                 elif spin_block:
                     self.step_to("CHARGE", reread=False)
-                else:
+                elif not spin:
                     next(itt) # skip ---
+                else:
+                    return None
                 D = read_reduced_orbital_block(itt)
                 if orbital is None:
                     return D
@@ -233,7 +235,7 @@ class outputSileORCA(SileORCA):
                     return None
                 next(itt) # skip ---
                 if "MULLIKEN" in step_to:
-                    next(itt) # skip another line
+                    next(itt) # skip line "The uncorrected..."
                 Do = np.empty(self.no, np.float64) # orbital-resolved
                 Da = np.zeros(self.na, np.float64) # atom-resolved
                 for io in range(self.no):
@@ -246,7 +248,7 @@ class outputSileORCA(SileORCA):
                         else:
                             element += s
                     ia = int(ia)
-                    if spin:
+                    if spin_block and spin:
                         Do[io] = float(v[4])
                     else:
                         Do[io] = float(v[3])

--- a/sisl/io/orca/output.py
+++ b/sisl/io/orca/output.py
@@ -123,7 +123,6 @@ class outputSileORCA(SileORCA):
                 return charge, spin
 
             else:
-                natoms = self._natoms
                 cs = np.zeros((natoms, 2), np.float64)
                 for key in charge:
                     ia, orb = key

--- a/sisl/io/orca/sile.py
+++ b/sisl/io/orca/sile.py
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from sisl._internal import set_module
+from ..sile import Sile, SileBin
+
+__all__ = ['SileORCA', 'SileBinORCA']
+
+
+@set_module("sisl.io.orca")
+class SileORCA(Sile):
+    pass
+
+
+@set_module("sisl.io.orca")
+class SileBinORCA(SileBin):
+    pass

--- a/sisl/io/orca/tests/__init__.py
+++ b/sisl/io/orca/tests/__init__.py
@@ -1,0 +1,4 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+""" tests for sisl/io/orca """

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -39,124 +39,135 @@ def test_charge_name(sisl_files):
 def test_charge_mulliken_atom(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)
-    A = out.read_charge(name='mulliken', projection='atom', all=True)
-    assert len(A) == 2
-    assert A[0][0, 0] == 0.029160
-    assert A[0][0, 1] == 0.687779
-    assert A[0][1, 0] == -0.029160
-    assert A[0][1, 1] == 0.312221
-    assert A[1][0, 0] == 0.029158
-    assert A[1][0, 1] == 0.687793
-    assert A[1][1, 0] == -0.029158
-    assert A[1][1, 1] == 0.312207
-    A = out.read_charge(name='mulliken', projection='atom', all=False)
-    assert A[0, 0] == 0.029158
-    assert A[0, 1] == 0.687793
-    assert A[1, 0] == -0.029158
-    assert A[1, 1] == 0.312207
+    C = out.read_charge(name='mulliken', projection='atom', all=True)
+    S = out.read_charge(name='mulliken', projection='atom', spin=True, all=True)
+    assert len(C) == 2
+    assert C[0][0] == 0.029160
+    assert S[0][0] == 0.687779
+    assert C[0][1] == -0.029160
+    assert S[0][1] == 0.312221
+    assert C[1][0] == 0.029158
+    assert S[1][0] == 0.687793
+    assert C[1][1] == -0.029158
+    assert S[1][1] == 0.312207
+    C = out.read_charge(name='mulliken', projection='atom', all=False)
+    S = out.read_charge(name='mulliken', projection='atom', spin=True, all=False)
+    assert C[0] == 0.029158
+    assert S[0] == 0.687793
+    assert C[1] == -0.029158
+    assert S[1] == 0.312207
 
 def test_lowedin_atom(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)
-    A = out.read_charge(name='loewdin', projection='atom', all=True)
-    assert len(A) == 2
-    assert A[0][0, 0] == -0.111221
-    assert A[0][0, 1] == 0.660316
-    assert A[0][1, 0] == 0.111221
-    assert A[0][1, 1] == 0.339684
-    assert A[1][0, 0] == -0.111223
-    assert A[1][0, 1] == 0.660327
-    assert A[1][1, 0] == 0.111223
-    assert A[1][1, 1] == 0.339673
-    A = out.read_charge(name='loewdin', projection='atom', all=False)
-    assert A[0, 0] == -0.111223
-    assert A[0, 1] == 0.660327
-    assert A[1, 0] == 0.111223
-    assert A[1, 1] == 0.339673
+    C = out.read_charge(name='loewdin', projection='atom', all=True)
+    S = out.read_charge(name='loewdin', projection='atom', spin=True, all=True)
+    assert len(C) == 2
+    assert C[0][0] == -0.111221
+    assert S[0][0] == 0.660316
+    assert C[0][1] == 0.111221
+    assert S[0][1] == 0.339684
+    assert C[1][0] == -0.111223
+    assert S[1][0] == 0.660327
+    assert C[1][1] == 0.111223
+    assert S[1][1] == 0.339673
+    C = out.read_charge(name='loewdin', projection='atom', all=False)
+    S = out.read_charge(name='loewdin', projection='atom', spin=True, all=False)
+    assert C[0] == -0.111223
+    assert S[0] == 0.660327
+    assert C[1] == 0.111223
+    assert S[1] == 0.339673
 
 def test_charge_mulliken_reduced(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)
-    A = out.read_charge(name='mulliken', projection='orbital', all=True)
-    assert len(A) == 2
+    C = out.read_charge(name='mulliken', projection='orbital', all=True)
+    S = out.read_charge(name='mulliken', projection='orbital', spin=True, all=True)
+    assert len(C) == 2
     # first charge block
-    assert A[0][0][(0, 's')] == 3.915850
-    assert A[0][0][(0, 'pz')] == 0.710261
-    assert A[0][0][(1, 'dz2')] == 0.004147
-    assert A[0][0][(1, 'p')] == 4.116068
+    assert C[0][(0, 's')] == 3.915850
+    assert C[0][(0, 'pz')] == 0.710261
+    assert C[0][(1, 'dz2')] == 0.004147
+    assert C[0][(1, 'p')] == 4.116068
     # first spin block
-    assert A[0][1][(0, 'dx2y2')] == 0.001163
-    assert A[0][1][(1, 'f+2')] == -0.000122
+    assert S[0][(0, 'dx2y2')] == 0.001163
+    assert S[0][(1, 'f+2')] == -0.000122
     # last charge block
-    assert A[1][0][(0, 'pz')] == 0.710263
-    assert A[1][0][(0, 'f0')] == 0.000681
-    assert A[1][0][(1, 's')] == 3.860487
+    assert C[1][(0, 'pz')] == 0.710263
+    assert C[1][(0, 'f0')] == 0.000681
+    assert C[1][(1, 's')] == 3.860487
     # last spin block
-    assert A[1][1][(0, 'p')] == 0.685743
-    assert A[1][1][(1, 'dz2')] == -0.000163
-    A = out.read_charge(name='mulliken', projection='orbital', all=False)
+    assert S[1][(0, 'p')] == 0.685743
+    assert S[1][(1, 'dz2')] == -0.000163
+    C = out.read_charge(name='mulliken', projection='orbital', all=False)
+    S = out.read_charge(name='mulliken', projection='orbital', spin=True, all=False)
     # last charge block
-    assert A[0][(0, 'pz')] == 0.710263
-    assert A[0][(0, 'f0')] == 0.000681
-    assert A[0][(1, 's')] == 3.860487
+    assert C[(0, 'pz')] == 0.710263
+    assert C[(0, 'f0')] == 0.000681
+    assert C[(1, 's')] == 3.860487
     # last spin block
-    assert A[1][(0, 'p')] == 0.685743
-    assert A[1][(1, 'dz2')] == -0.000163
-    A = out.read_charge(name='mulliken', projection='orbital', orbital='pz', all=True)
-    assert A[0][0, 0] == 0.710261
-    A = out.read_charge(name='mulliken', projection='orbital', orbital='f+2', all=True)
-    assert A[0][1, 1] == -0.000122
-    A = out.read_charge(name='mulliken', projection='orbital', orbital='p', all=False)
-    assert A[0, 1] == 0.685743
+    assert S[(0, 'p')] == 0.685743
+    assert S[(1, 'dz2')] == -0.000163
+    C = out.read_charge(name='mulliken', projection='orbital', orbital='pz', all=True)
+    assert C[0][0] == 0.710261
+    S = out.read_charge(name='mulliken', projection='orbital', orbital='f+2', spin=True, all=True)
+    assert S[0][1] == -0.000122
+    S = out.read_charge(name='mulliken', projection='orbital', orbital='p', spin=True, all=False)
+    assert S[0] == 0.685743
 
 def test_charge_loewdin_reduced(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)
-    A = out.read_charge(name='loewdin', projection='orbital', all=True)
-    assert len(A) == 2
-    assert A[0][0][(0, 's')] == 3.553405
-    assert A[0][0][(0, 'pz')] == 0.723111
-    assert A[1][0][(0, 'pz')] == 0.723113
-    assert A[1][1][(1, 'pz')] == -0.010829
-    A = out.read_charge(name='loewdin', projection='orbital', all=False)
-    assert A[0][(0, 'f-3')] == 0.017486
-    assert A[1][(1, 'pz')] == -0.010829
-    assert A[0][(0, 'pz')] == 0.723113
-    assert A[1][(1, 'pz')] == -0.010829
-    A = out.read_charge(name='loewdin', projection='orbital', orbital='s', all=True)
-    assert A[0][0, 0] == 3.553405
-    A = out.read_charge(name='loewdin', projection='orbital', orbital='f-3', all=False)
-    assert A[0, 0] == 0.017486
-    A = out.read_charge(name='loewdin', projection='orbital', orbital='pz', all=False)
-    assert A[0, 0] == 0.723113
+    C = out.read_charge(name='loewdin', projection='orbital', all=True)
+    S = out.read_charge(name='loewdin', projection='orbital', spin=True, all=True)
+    assert len(S) == 2
+    assert C[0][(0, 's')] == 3.553405
+    assert C[0][(0, 'pz')] == 0.723111
+    assert C[1][(0, 'pz')] == 0.723113
+    assert S[1][(1, 'pz')] == -0.010829
+    C = out.read_charge(name='loewdin', projection='orbital', all=False)
+    S = out.read_charge(name='loewdin', projection='orbital', spin=True, all=False)
+    assert C[(0, 'f-3')] == 0.017486
+    assert S[(1, 'pz')] == -0.010829
+    assert C[(0, 'pz')] == 0.723113
+    assert S[(1, 'pz')] == -0.010829
+    C = out.read_charge(name='loewdin', projection='orbital', orbital='s', all=True)
+    assert C[0][0] == 3.553405
+    C = out.read_charge(name='loewdin', projection='orbital', orbital='f-3', all=False)
+    assert C[0] == 0.017486
+    C = out.read_charge(name='loewdin', projection='orbital', orbital='pz', all=False)
+    assert C[0] == 0.723113
 
 def test_charge_mulliken_full(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)
-    A = out.read_charge(name='mulliken', projection='orbital', reduced=False, all=True)
-    assert len(A) == 2
-    assert A[0][0, 0] == 0.821857
-    assert A[0][0, 1] == -0.000020
-    assert A[0][32, 0] == 1.174653
-    assert A[0][32, 1] == -0.000200
-    assert A[1][8, 0] == 0.313072
-    assert A[1][8, 1] == 0.006429
-    A = out.read_charge(name='mulliken', projection='orbital', reduced=False, all=False)
-    assert A[8, 0] == 0.313072
-    assert A[8, 1] == 0.006429
+    C = out.read_charge(name='mulliken', projection='orbital', reduced=False, all=True)
+    S = out.read_charge(name='mulliken', projection='orbital', reduced=False, spin=True, all=True)
+    assert len(C) == 2
+    assert C[0][0] == 0.821857
+    assert S[0][0] == -0.000020
+    assert C[0][32] == 1.174653
+    assert S[0][32] == -0.000200
+    assert C[1][8] == 0.313072
+    assert S[1][8] == 0.006429
+    C = out.read_charge(name='mulliken', projection='orbital', reduced=False, all=False)
+    S = out.read_charge(name='mulliken', projection='orbital', reduced=False, spin=True, all=False)
+    assert C[8] == 0.313072
+    assert S[8] == 0.006429
 
 def test_charge_loewdin_full(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)
-    A = out.read_charge(name='loewdin', projection='orbital', reduced=False, all=True)
-    assert len(A) == 2
-    assert A[0][0, 0] == 0.894846
-    assert A[0][0, 1] == 0.000337
-    assert A[0][61, 0] == 0.006054
-    assert A[0][61, 1] == 0.004362
-    assert A[1][8, 0] == 0.312172
-    assert A[1][8, 1] == 0.005159
-    A = out.read_charge(name='loewdin', projection='orbital', reduced=False, all=False)
-    assert A[8, 0] == 0.312172
-    assert A[8, 1] == 0.005159
-
+    C = out.read_charge(name='loewdin', projection='orbital', reduced=False, all=True)
+    S = out.read_charge(name='loewdin', projection='orbital', reduced=False, spin=True, all=True)
+    assert len(S) == 2
+    assert C[0][0] == 0.894846
+    assert S[0][0] == 0.000337
+    assert C[0][61] == 0.006054
+    assert S[0][61] == 0.004362
+    assert C[1][8] == 0.312172
+    assert S[1][8] == 0.005159
+    C = out.read_charge(name='loewdin', projection='orbital', reduced=False, all=False)
+    S = out.read_charge(name='loewdin', projection='orbital', reduced=False, spin=True, all=False)
+    assert C[8] == 0.312172
+    assert S[8] == 0.005159

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -267,3 +267,17 @@ def test_read_orbital_energies_unpol(sisl_files):
     assert E.shape == (out.no,)
     assert E[0] == -513.0976
     assert E[61] == 1171.5967
+
+def test_multiple_calls(sisl_files):
+    f = sisl_files(_dir, 'molecule2.output')
+    out = outputSileORCA(f)
+    N = out.read_electrons(all=True)
+    assert len(N) == 2
+    E = out.read_orbital_energies(all=True)
+    assert len(E) == 2
+    E = out.read_energy(all=True)
+    assert len(E) == 2
+    C = out.read_charge(name='mulliken', projection='atom', all=True)
+    assert len(C) == 2
+    N = out.read_electrons(all=True)
+    assert len(N) == 2

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -222,3 +222,23 @@ def test_charge_orbital_full_unpol(sisl_files):
     S = out.read_charge(name='mulliken', projection='orbital', reduced=False, spin=True)
     assert C is None
     assert S is None
+
+def test_read_energy(sisl_files):
+    f = sisl_files(_dir, 'molecule.output')
+    out = outputSileORCA(f)
+    E = out.read_energy(all=True, convert=False)
+    assert E[0].xc == -15.222438585593
+    assert E[1].xc == -15.222439217603
+    E = out.read_energy()
+    assert E.xc != -15.222439217603
+
+def test_read_energy_vdw(sisl_files):
+    f = sisl_files(_dir, 'molecule2.output')
+    out = outputSileORCA(f)
+    E = out.read_energy(all=True, convert=False)
+    assert E[0].exchange == -13.310141538373
+    assert E[1].exchange == -13.310144803077
+    assert E[1].vdw == -0.000410877
+    E = out.read_energy()
+    assert E.exchange != -13.310144803077
+    assert E.vdw != -0.000410877

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -226,25 +226,18 @@ def test_charge_orbital_full_unpol(sisl_files):
 def test_read_energy(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)
-    E = out.read_energy(all=True, convert=False)
-    assert E[0].xc == -15.222438585593
-    assert E[1].xc == -15.222439217603
+    E = out.read_energy(all=True)
+    assert len(E) == 2
+    assert E[0].total != 0
     E = out.read_energy()
-    assert E.xc != -15.222439217603
     assert abs(E.total + 3532.4797529941284) < 1e-8
 
 def test_read_energy_vdw(sisl_files):
     f = sisl_files(_dir, 'molecule2.output')
     out = outputSileORCA(f)
-    E = out.read_energy(all=True, convert=False)
-    assert E[0].exchange == -13.310141538373
-    assert E[1].exchange == -13.310144803077
-    assert E[1].vdw == -0.000410877
     E = out.read_energy()
-    assert E.exchange != -13.310144803077
-    assert E.vdw != -0.000410877
+    assert E.vdw != 0
     assert abs(E.total + 3081.265152222452) < 1e-8
-
 
 def test_read_orbital_energies(sisl_files):
     f = sisl_files(_dir, 'molecule.output')

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -1,0 +1,40 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import sys
+import pytest
+import os.path as osp
+import sisl
+from sisl.io.orca.output import *
+import numpy as np
+
+
+pytestmark = [pytest.mark.io, pytest.mark.orca]
+_dir = osp.join('sisl', 'io', 'orca')
+
+
+def test_completed(sisl_files):
+    f = sisl_files(_dir, 'molecule.output')
+    out = outputSileORCA(f)
+    assert out.completed()
+    assert out.na == 2
+    assert out.no == 62
+    
+def test_mulliken_atom(sisl_files):
+    f = sisl_files(_dir, 'molecule.output')
+    out = outputSileORCA(f)
+    n = 'mulliken'
+    A = out.read_charge(name=n, projection='atom', all=True)
+    assert A[0][0, 0] == 0.029160
+    assert A[0][0, 1] == 0.687779
+    assert A[0][1, 0] == -0.029160
+    assert A[0][1, 1] == 0.312221
+    assert A[1][0, 0] == 0.029158
+    assert A[1][0, 1] == 0.687793
+    assert A[1][1, 0] == -0.029158
+    assert A[1][1, 1] == 0.312207
+    A = out.read_charge(name=n, projection='atom', all=False)
+    assert A[0, 0] == 0.029158
+    assert A[0, 1] == 0.687793
+    assert A[1, 0] == -0.029158
+    assert A[1, 1] == 0.312207

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -231,7 +231,7 @@ def test_read_energy(sisl_files):
     assert E[1].xc == -15.222439217603
     E = out.read_energy()
     assert E.xc != -15.222439217603
-    assert abs(E.total + 3532.47810) < 1e-6
+    assert abs(E.total + 3532.4797529941284) < 1e-8
 
 def test_read_energy_vdw(sisl_files):
     f = sisl_files(_dir, 'molecule2.output')
@@ -243,4 +243,4 @@ def test_read_energy_vdw(sisl_files):
     E = out.read_energy()
     assert E.exchange != -13.310144803077
     assert E.vdw != -0.000410877
-    assert (E.total + 3081.26371) < 1e-6
+    assert abs(E.total + 3081.265152222452) < 1e-8

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -231,6 +231,7 @@ def test_read_energy(sisl_files):
     assert E[1].xc == -15.222439217603
     E = out.read_energy()
     assert E.xc != -15.222439217603
+    assert abs(E.total + 3532.47810) < 1e-6
 
 def test_read_energy_vdw(sisl_files):
     f = sisl_files(_dir, 'molecule2.output')
@@ -242,3 +243,4 @@ def test_read_energy_vdw(sisl_files):
     E = out.read_energy()
     assert E.exchange != -13.310144803077
     assert E.vdw != -0.000410877
+    assert (E.total + 3081.26371) < 1e-6

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -13,14 +13,20 @@ pytestmark = [pytest.mark.io, pytest.mark.orca]
 _dir = osp.join('sisl', 'io', 'orca')
 
 
-def test_completed(sisl_files):
+def test_tags(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)
     assert out.completed()
     assert out.na == 2
     assert out.no == 62
-    
-def test_mulliken_atom(sisl_files):
+
+def test_charge_name(sisl_files):
+    f = sisl_files(_dir, 'molecule.output')
+    out = outputSileORCA(f)
+    for name in ['mulliken', 'MULLIKEN', 'loewdin', 'Lowdin', 'LÖWDIN']:
+        assert out.read_charge(name=name) is not None
+
+def test_charge_mulliken_atom(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)
     A = out.read_charge(name='mulliken', projection='atom', all=True)
@@ -58,7 +64,7 @@ def test_lowedin_atom(sisl_files):
     assert A[1, 0] == 0.111223
     assert A[1, 1] == 0.339673
 
-def test_mulliken_reduced(sisl_files):
+def test_charge_mulliken_reduced(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)
     A = out.read_charge(name='mulliken', projection='orbital', all=True)
@@ -86,8 +92,14 @@ def test_mulliken_reduced(sisl_files):
     # last spin block
     assert A[1][(0, 'p')] == 0.685743
     assert A[1][(1, 'dz2')] == -0.000163
+    A = out.read_charge(name='mulliken', projection='orbital', orbital='pz', all=True)
+    assert A[0][0, 0] == 0.710261
+    A = out.read_charge(name='mulliken', projection='orbital', orbital='f+2', all=True)
+    assert A[0][1, 1] == -0.000122
+    A = out.read_charge(name='mulliken', projection='orbital', orbital='p', all=False)
+    assert A[0, 1] == 0.685743
 
-def test_loewdin_reduced(sisl_files):
+def test_charge_loewdin_reduced(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)
     A = out.read_charge(name='loewdin', projection='orbital', all=True)
@@ -101,3 +113,40 @@ def test_loewdin_reduced(sisl_files):
     assert A[1][(1, 'pz')] == -0.010829
     assert A[0][(0, 'pz')] == 0.723113
     assert A[1][(1, 'pz')] == -0.010829
+    A = out.read_charge(name='loewdin', projection='orbital', orbital='s', all=True)
+    assert A[0][0, 0] == 3.553405
+    A = out.read_charge(name='loewdin', projection='orbital', orbital='f-3', all=False)
+    assert A[0, 0] == 0.017486
+    A = out.read_charge(name='loewdin', projection='orbital', orbital='pz', all=False)
+    assert A[0, 0] == 0.723113
+
+def test_charge_mulliken_full(sisl_files):
+    f = sisl_files(_dir, 'molecule.output')
+    out = outputSileORCA(f)
+    A = out.read_charge(name='mulliken', projection='orbital', reduced=False, all=True)
+    assert len(A) == 2
+    assert A[0][0, 0] == 0.821857
+    assert A[0][0, 1] == -0.000020
+    assert A[0][32, 0] == 1.174653
+    assert A[0][32, 1] == -0.000200
+    assert A[1][8, 0] == 0.313072
+    assert A[1][8, 1] == 0.006429
+    A = out.read_charge(name='mulliken', projection='orbital', reduced=False, all=False)
+    assert A[8, 0] == 0.313072
+    assert A[8, 1] == 0.006429
+
+def test_charge_loewdin_full(sisl_files):
+    f = sisl_files(_dir, 'molecule.output')
+    out = outputSileORCA(f)
+    A = out.read_charge(name='loewdin', projection='orbital', reduced=False, all=True)
+    assert len(A) == 2
+    assert A[0][0, 0] == 0.894846
+    assert A[0][0, 1] == 0.000337
+    assert A[0][61, 0] == 0.006054
+    assert A[0][61, 1] == 0.004362
+    assert A[1][8, 0] == 0.312172
+    assert A[1][8, 1] == 0.005159
+    A = out.read_charge(name='loewdin', projection='orbital', reduced=False, all=False)
+    assert A[8, 0] == 0.312172
+    assert A[8, 1] == 0.005159
+

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -108,11 +108,11 @@ def test_charge_mulliken_reduced(sisl_files):
     # last spin block
     assert S[(0, 'p')] == 0.685743
     assert S[(1, 'dz2')] == -0.000163
-    C = out.read_charge(name='mulliken', projection='orbital', orbital='pz', all=True)
+    C = out.read_charge(name='mulliken', projection='orbital', orb_key='pz', all=True)
     assert C[0][0] == 0.710261
-    S = out.read_charge(name='mulliken', projection='orbital', orbital='f+2', spin=True, all=True)
+    S = out.read_charge(name='mulliken', projection='orbital', orb_key='f+2', spin=True, all=True)
     assert S[0][1] == -0.000122
-    S = out.read_charge(name='mulliken', projection='orbital', orbital='p', spin=True, all=False)
+    S = out.read_charge(name='mulliken', projection='orbital', orb_key='p', spin=True, all=False)
     assert S[0] == 0.685743
 
 def test_charge_loewdin_reduced(sisl_files):
@@ -131,11 +131,11 @@ def test_charge_loewdin_reduced(sisl_files):
     assert S[(1, 'pz')] == -0.010829
     assert C[(0, 'pz')] == 0.723113
     assert S[(1, 'pz')] == -0.010829
-    C = out.read_charge(name='loewdin', projection='orbital', orbital='s', all=True)
+    C = out.read_charge(name='loewdin', projection='orbital', orb_key='s', all=True)
     assert C[0][0] == 3.553405
-    C = out.read_charge(name='loewdin', projection='orbital', orbital='f-3', all=False)
+    C = out.read_charge(name='loewdin', projection='orbital', orb_key='f-3', all=False)
     assert C[0] == 0.017486
-    C = out.read_charge(name='loewdin', projection='orbital', orbital='pz', all=False)
+    C = out.read_charge(name='loewdin', projection='orbital', orb_key='pz', all=False)
     assert C[0] == 0.723113
 
 def test_charge_mulliken_full(sisl_files):
@@ -202,16 +202,16 @@ def test_charge_orbital_reduced_unpol(sisl_files):
     S = out.read_charge(name='mulliken', projection='orbital', spin=True, all=False)
     assert C[(0, "px")] == 0.954436
     assert S is None
-    C = out.read_charge(name='mulliken', projection='orbital', orbital='px', all=False)
-    S = out.read_charge(name='mulliken', projection='orbital', orbital='px', spin=True, all=False)
+    C = out.read_charge(name='mulliken', projection='orbital', orb_key='px', all=False)
+    S = out.read_charge(name='mulliken', projection='orbital', orb_key='px', spin=True, all=False)
     assert C[0] == 0.954436
     assert S is None
     C = out.read_charge(name='loewdin', projection='orbital', all=False)
     S = out.read_charge(name='loewdin', projection='orbital', spin=True, all=False)
     assert C[(0, "d")] == 0.315910
     assert S is None
-    C = out.read_charge(name='loewdin', projection='orbital', orbital='d', all=False)
-    S = out.read_charge(name='loewdin', projection='orbital', orbital='d', spin=True, all=False)
+    C = out.read_charge(name='loewdin', projection='orbital', orb_key='d', all=False)
+    S = out.read_charge(name='loewdin', projection='orbital', orb_key='d', spin=True, all=False)
     assert C[0] == 0.315910
     assert S is None
 

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -171,3 +171,54 @@ def test_charge_loewdin_full(sisl_files):
     S = out.read_charge(name='loewdin', projection='orbital', reduced=False, spin=True, all=False)
     assert C[8] == 0.312172
     assert S[8] == 0.005159
+
+def test_charge_atom_unpol(sisl_files):
+    f = sisl_files(_dir, 'molecule2.output')
+    out = outputSileORCA(f)
+    C = out.read_charge(name='mulliken', projection='atom', all=True)
+    S = out.read_charge(name='mulliken', projection='atom', spin=True, all=True)
+    assert len(C) == 2
+    assert len(S) == 0
+    assert C[0][0] == -0.037652
+    C = out.read_charge(name='mulliken', projection='atom', all=False)
+    S = out.read_charge(name='mulliken', projection='atom', spin=True, all=False)
+    assert C[0] == -0.037652
+    assert S is None
+    C = out.read_charge(name='loewdin', projection='atom', all=False)
+    S = out.read_charge(name='loewdin', projection='atom', spin=True, all=False)
+    assert C[0] == -0.259865
+    assert S is None
+
+def test_charge_orbital_reduced_unpol(sisl_files):
+    f = sisl_files(_dir, 'molecule2.output')
+    out = outputSileORCA(f)
+    C = out.read_charge(name='mulliken', projection='orbital', all=True)
+    S = out.read_charge(name='mulliken', projection='orbital', spin=True, all=True)
+    assert len(C) == 2
+    assert len(S) == 0
+    assert C[0][(0, "py")] == 0.534313
+    assert C[1][(1, "px")] == 1.346363
+    C = out.read_charge(name='mulliken', projection='orbital', all=False)
+    S = out.read_charge(name='mulliken', projection='orbital', spin=True, all=False)
+    assert C[(0, "px")] == 0.954436
+    assert S is None
+    C = out.read_charge(name='mulliken', projection='orbital', orbital='px', all=False)
+    S = out.read_charge(name='mulliken', projection='orbital', orbital='px', spin=True, all=False)
+    assert C[0] == 0.954436
+    assert S is None
+    C = out.read_charge(name='loewdin', projection='orbital', all=False)
+    S = out.read_charge(name='loewdin', projection='orbital', spin=True, all=False)
+    assert C[(0, "d")] == 0.315910
+    assert S is None
+    C = out.read_charge(name='loewdin', projection='orbital', orbital='d', all=False)
+    S = out.read_charge(name='loewdin', projection='orbital', orbital='d', spin=True, all=False)
+    assert C[0] == 0.315910
+    assert S is None
+
+def test_charge_orbital_full_unpol(sisl_files):
+    f = sisl_files(_dir, 'molecule2.output')
+    out = outputSileORCA(f)
+    C = out.read_charge(name='mulliken', projection='orbital', reduced=False)
+    S = out.read_charge(name='mulliken', projection='orbital', reduced=False, spin=True)
+    assert C is None
+    assert S is None

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -244,3 +244,33 @@ def test_read_energy_vdw(sisl_files):
     assert E.exchange != -13.310144803077
     assert E.vdw != -0.000410877
     assert abs(E.total + 3081.265152222452) < 1e-8
+
+
+def test_read_orbital_energies(sisl_files):
+    f = sisl_files(_dir, 'molecule.output')
+    out = outputSileORCA(f)
+    E = out.read_orbital_energies(all=True)
+    assert E[0][0, 0] == -513.8983
+    assert E[0][0, 1] == -513.6538
+    assert E[0][61, 0] == 1173.4258
+    assert E[0][61, 1] == 1173.6985
+    assert E[1][0, 0] == -513.8983
+    assert E[1][0, 1] == -513.6538
+    assert E[1][61, 0] == 1173.4259
+    assert E[1][61, 1] == 1173.6985
+    E = out.read_orbital_energies(all=False)
+    assert E.shape == (out.no, 2)
+    assert E[61, 0] == 1173.4259
+
+def test_read_orbital_energies_unpol(sisl_files):
+    f = sisl_files(_dir, 'molecule2.output')
+    out = outputSileORCA(f)
+    E = out.read_orbital_energies(all=True)
+    assert E[0][0] == -513.0978
+    assert E[0][61] == 1171.5965
+    assert E[1][0] == -513.0976
+    assert E[1][61] == 1171.5967
+    E = out.read_orbital_energies(all=False)
+    assert E.shape == (out.no,)
+    assert E[0] == -513.0976
+    assert E[61] == 1171.5967

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -20,6 +20,16 @@ def test_tags(sisl_files):
     assert out.na == 2
     assert out.no == 62
 
+def test_read_electrons(sisl_files):
+    f = sisl_files(_dir, 'molecule.output')
+    out = outputSileORCA(f)
+    N = out.read_electrons(all=True)
+    assert N[0, 0] == 7.999998537730
+    assert N[0, 1] == 6.999998987205
+    N = out.read_electrons(all=False)
+    assert N[0] == 7.999998537734
+    assert N[1] == 6.999998987209
+
 def test_charge_name(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -108,11 +108,11 @@ def test_charge_mulliken_reduced(sisl_files):
     # last spin block
     assert S[(0, 'p')] == 0.685743
     assert S[(1, 'dz2')] == -0.000163
-    C = out.read_charge(name='mulliken', projection='orbital', orb_key='pz', all=True)
+    C = out.read_charge(name='mulliken', projection='orbital', orbitals='pz', all=True)
     assert C[0][0] == 0.710261
-    S = out.read_charge(name='mulliken', projection='orbital', orb_key='f+2', spin=True, all=True)
+    S = out.read_charge(name='mulliken', projection='orbital', orbitals='f+2', spin=True, all=True)
     assert S[0][1] == -0.000122
-    S = out.read_charge(name='mulliken', projection='orbital', orb_key='p', spin=True, all=False)
+    S = out.read_charge(name='mulliken', projection='orbital', orbitals='p', spin=True, all=False)
     assert S[0] == 0.685743
 
 def test_charge_loewdin_reduced(sisl_files):
@@ -131,11 +131,11 @@ def test_charge_loewdin_reduced(sisl_files):
     assert S[(1, 'pz')] == -0.010829
     assert C[(0, 'pz')] == 0.723113
     assert S[(1, 'pz')] == -0.010829
-    C = out.read_charge(name='loewdin', projection='orbital', orb_key='s', all=True)
+    C = out.read_charge(name='loewdin', projection='orbital', orbitals='s', all=True)
     assert C[0][0] == 3.553405
-    C = out.read_charge(name='loewdin', projection='orbital', orb_key='f-3', all=False)
+    C = out.read_charge(name='loewdin', projection='orbital', orbitals='f-3', all=False)
     assert C[0] == 0.017486
-    C = out.read_charge(name='loewdin', projection='orbital', orb_key='pz', all=False)
+    C = out.read_charge(name='loewdin', projection='orbital', orbitals='pz', all=False)
     assert C[0] == 0.723113
 
 def test_charge_mulliken_full(sisl_files):
@@ -202,16 +202,16 @@ def test_charge_orbital_reduced_unpol(sisl_files):
     S = out.read_charge(name='mulliken', projection='orbital', spin=True, all=False)
     assert C[(0, "px")] == 0.954436
     assert S is None
-    C = out.read_charge(name='mulliken', projection='orbital', orb_key='px', all=False)
-    S = out.read_charge(name='mulliken', projection='orbital', orb_key='px', spin=True, all=False)
+    C = out.read_charge(name='mulliken', projection='orbital', orbitals='px', all=False)
+    S = out.read_charge(name='mulliken', projection='orbital', orbitals='px', spin=True, all=False)
     assert C[0] == 0.954436
     assert S is None
     C = out.read_charge(name='loewdin', projection='orbital', all=False)
     S = out.read_charge(name='loewdin', projection='orbital', spin=True, all=False)
     assert C[(0, "d")] == 0.315910
     assert S is None
-    C = out.read_charge(name='loewdin', projection='orbital', orb_key='d', all=False)
-    S = out.read_charge(name='loewdin', projection='orbital', orb_key='d', spin=True, all=False)
+    C = out.read_charge(name='loewdin', projection='orbital', orbitals='d', all=False)
+    S = out.read_charge(name='loewdin', projection='orbital', orbitals='d', spin=True, all=False)
     assert C[0] == 0.315910
     assert S is None
 

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -16,9 +16,9 @@ _dir = osp.join('sisl', 'io', 'orca')
 def test_tags(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)
-    assert out.completed()
     assert out.na == 2
     assert out.no == 62
+    assert out.completed()
 
 def test_read_electrons(sisl_files):
     f = sisl_files(_dir, 'molecule.output')

--- a/sisl/io/orca/tests/test_output.py
+++ b/sisl/io/orca/tests/test_output.py
@@ -23,8 +23,8 @@ def test_completed(sisl_files):
 def test_mulliken_atom(sisl_files):
     f = sisl_files(_dir, 'molecule.output')
     out = outputSileORCA(f)
-    n = 'mulliken'
-    A = out.read_charge(name=n, projection='atom', all=True)
+    A = out.read_charge(name='mulliken', projection='atom', all=True)
+    assert len(A) == 2
     assert A[0][0, 0] == 0.029160
     assert A[0][0, 1] == 0.687779
     assert A[0][1, 0] == -0.029160
@@ -33,8 +33,71 @@ def test_mulliken_atom(sisl_files):
     assert A[1][0, 1] == 0.687793
     assert A[1][1, 0] == -0.029158
     assert A[1][1, 1] == 0.312207
-    A = out.read_charge(name=n, projection='atom', all=False)
+    A = out.read_charge(name='mulliken', projection='atom', all=False)
     assert A[0, 0] == 0.029158
     assert A[0, 1] == 0.687793
     assert A[1, 0] == -0.029158
     assert A[1, 1] == 0.312207
+
+def test_lowedin_atom(sisl_files):
+    f = sisl_files(_dir, 'molecule.output')
+    out = outputSileORCA(f)
+    A = out.read_charge(name='loewdin', projection='atom', all=True)
+    assert len(A) == 2
+    assert A[0][0, 0] == -0.111221
+    assert A[0][0, 1] == 0.660316
+    assert A[0][1, 0] == 0.111221
+    assert A[0][1, 1] == 0.339684
+    assert A[1][0, 0] == -0.111223
+    assert A[1][0, 1] == 0.660327
+    assert A[1][1, 0] == 0.111223
+    assert A[1][1, 1] == 0.339673
+    A = out.read_charge(name='loewdin', projection='atom', all=False)
+    assert A[0, 0] == -0.111223
+    assert A[0, 1] == 0.660327
+    assert A[1, 0] == 0.111223
+    assert A[1, 1] == 0.339673
+
+def test_mulliken_reduced(sisl_files):
+    f = sisl_files(_dir, 'molecule.output')
+    out = outputSileORCA(f)
+    A = out.read_charge(name='mulliken', projection='orbital', all=True)
+    assert len(A) == 2
+    # first charge block
+    assert A[0][0][(0, 's')] == 3.915850
+    assert A[0][0][(0, 'pz')] == 0.710261
+    assert A[0][0][(1, 'dz2')] == 0.004147
+    assert A[0][0][(1, 'p')] == 4.116068
+    # first spin block
+    assert A[0][1][(0, 'dx2y2')] == 0.001163
+    assert A[0][1][(1, 'f+2')] == -0.000122
+    # last charge block
+    assert A[1][0][(0, 'pz')] == 0.710263
+    assert A[1][0][(0, 'f0')] == 0.000681
+    assert A[1][0][(1, 's')] == 3.860487
+    # last spin block
+    assert A[1][1][(0, 'p')] == 0.685743
+    assert A[1][1][(1, 'dz2')] == -0.000163
+    A = out.read_charge(name='mulliken', projection='orbital', all=False)
+    # last charge block
+    assert A[0][(0, 'pz')] == 0.710263
+    assert A[0][(0, 'f0')] == 0.000681
+    assert A[0][(1, 's')] == 3.860487
+    # last spin block
+    assert A[1][(0, 'p')] == 0.685743
+    assert A[1][(1, 'dz2')] == -0.000163
+
+def test_loewdin_reduced(sisl_files):
+    f = sisl_files(_dir, 'molecule.output')
+    out = outputSileORCA(f)
+    A = out.read_charge(name='loewdin', projection='orbital', all=True)
+    assert len(A) == 2
+    assert A[0][0][(0, 's')] == 3.553405
+    assert A[0][0][(0, 'pz')] == 0.723111
+    assert A[1][0][(0, 'pz')] == 0.723113
+    assert A[1][1][(1, 'pz')] == -0.010829
+    A = out.read_charge(name='loewdin', projection='orbital', all=False)
+    assert A[0][(0, 'f-3')] == 0.017486
+    assert A[1][(1, 'pz')] == -0.010829
+    assert A[0][(0, 'pz')] == 0.723113
+    assert A[1][(1, 'pz')] == -0.010829

--- a/sisl/io/orca/tests/test_txt.py
+++ b/sisl/io/orca/tests/test_txt.py
@@ -64,3 +64,15 @@ def test_read_geometry(sisl_files):
     assert G.xyz[1, 1] == 0.0
     assert G.atoms[0].tag == 'N'
     assert G.atoms[1].tag == 'O'
+
+def test_multiple_calls(sisl_files):
+    f = sisl_files(_dir, 'molecule_property.txt')
+    out = txtSileORCA(f)
+    N = out.read_electrons(all=True)
+    assert len(N) == 2
+    E = out.read_energy(all=True)
+    assert len(E) == 2
+    G = out.read_geometry(all=True)
+    assert len(G) == 2
+    N = out.read_electrons(all=True)
+    assert len(N) == 2

--- a/sisl/io/orca/tests/test_txt.py
+++ b/sisl/io/orca/tests/test_txt.py
@@ -1,0 +1,50 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import sys
+import pytest
+import os.path as osp
+import sisl
+from sisl.io.orca.txt import *
+import numpy as np
+
+
+pytestmark = [pytest.mark.io, pytest.mark.orca]
+_dir = osp.join('sisl', 'io', 'orca')
+
+
+def test_tags(sisl_files):
+    f = sisl_files(_dir, 'molecule_property.txt')
+    out = txtSileORCA(f)
+    assert out.na == 2
+    assert out.no == None
+
+def test_read_energy(sisl_files):
+    f = sisl_files(_dir, 'molecule_property.txt')
+    out = txtSileORCA(f)
+    E = out.read_energy(all=True)
+    assert E[0].total == -129.8161893572
+    assert E[1].exchange == -14.7323176552
+    assert E[1].correlation == -0.4901215624
+    assert E[1].correlation_nl == 0.0
+    assert E[1].xc == -15.2224392176
+    assert E[1].embedding == 0.0
+    assert E[1].total == -129.8161893569
+    E = out.read_energy(all=False)
+    assert E.total == -129.8161893569
+
+def test_read_geometry(sisl_files):
+    f = sisl_files(_dir, 'molecule_property.txt')
+    out = txtSileORCA(f)
+    G = out.read_geometry(all=True)
+    assert G[0].xyz[0, 0] == 0.421218019838
+    assert G[0].xyz[1, 0] == 1.578781980162
+    assert G[1].xyz[0, 0] == 0.421218210279
+    assert G[1].xyz[1, 0] == 1.578781789721
+    G = out.read_geometry(all=False)
+    assert G.xyz[0, 0] == 0.421218210279
+    assert G.xyz[1, 0] == 1.578781789721
+    assert G.xyz[0, 1] == 0.0
+    assert G.xyz[1, 1] == 0.0
+    assert G.atom[0].tag == 'N'
+    assert G.atom[1].tag == 'O'

--- a/sisl/io/orca/tests/test_txt.py
+++ b/sisl/io/orca/tests/test_txt.py
@@ -19,6 +19,16 @@ def test_tags(sisl_files):
     assert out.na == 2
     assert out.no == None
 
+def test_read_electrons(sisl_files):
+    f = sisl_files(_dir, 'molecule_property.txt')
+    out = txtSileORCA(f)
+    N = out.read_electrons(all=True)
+    assert N[0, 0] == 7.9999985377
+    assert N[0, 1] == 6.9999989872
+    N = out.read_electrons(all=False)
+    assert N[0] == 7.9999985377
+    assert N[1] == 6.9999989872
+
 def test_read_energy(sisl_files):
     f = sisl_files(_dir, 'molecule_property.txt')
     out = txtSileORCA(f)

--- a/sisl/io/orca/tests/test_txt.py
+++ b/sisl/io/orca/tests/test_txt.py
@@ -73,5 +73,5 @@ def test_read_geometry(sisl_files):
     assert G.xyz[1, 0] == 1.578781789721
     assert G.xyz[0, 1] == 0.0
     assert G.xyz[1, 1] == 0.0
-    assert G.atom[0].tag == 'N'
-    assert G.atom[1].tag == 'O'
+    assert G.atoms[0].tag == 'N'
+    assert G.atoms[1].tag == 'O'

--- a/sisl/io/orca/tests/test_txt.py
+++ b/sisl/io/orca/tests/test_txt.py
@@ -42,6 +42,8 @@ def test_read_energy(sisl_files):
     assert E[1].total == -129.8161893569
     E = out.read_energy(all=False, convert=False)
     assert E.total == -129.8161893569
+    E = out.read_energy(all=False)
+    assert E.total != -129.8161893569
 
 def test_read_energy_vdw(sisl_files):
     f = sisl_files(_dir, 'molecule2_property.txt')
@@ -54,6 +56,9 @@ def test_read_energy_vdw(sisl_files):
     E = out.read_energy(convert=False)
     assert E.total == -113.2343646534
     assert E.vdw == -0.0004108775
+    E = out.read_energy()
+    assert E.total != -113.2343646534
+    assert E.vdw != -0.0004108775
 
 def test_read_geometry(sisl_files):
     f = sisl_files(_dir, 'molecule_property.txt')

--- a/sisl/io/orca/tests/test_txt.py
+++ b/sisl/io/orca/tests/test_txt.py
@@ -43,6 +43,18 @@ def test_read_energy(sisl_files):
     E = out.read_energy(all=False)
     assert E.total == -129.8161893569
 
+def test_read_energy_vdw(sisl_files):
+    f = sisl_files(_dir, 'molecule2_property.txt')
+    out = txtSileORCA(f)
+    E = out.read_energy(all=True)
+    assert E[0].total == -113.2343646532
+    assert E[0].vdw == -0.0004108775
+    assert E[1].total == -113.2343646534
+    assert E[1].vdw == -0.0004108775
+    E = out.read_energy()
+    assert E.total == -113.2343646534
+    assert E.vdw == -0.0004108775
+
 def test_read_geometry(sisl_files):
     f = sisl_files(_dir, 'molecule_property.txt')
     out = txtSileORCA(f)

--- a/sisl/io/orca/tests/test_txt.py
+++ b/sisl/io/orca/tests/test_txt.py
@@ -32,7 +32,7 @@ def test_read_electrons(sisl_files):
 def test_read_energy(sisl_files):
     f = sisl_files(_dir, 'molecule_property.txt')
     out = txtSileORCA(f)
-    E = out.read_energy(all=True)
+    E = out.read_energy(all=True, convert=False)
     assert E[0].total == -129.8161893572
     assert E[1].exchange == -14.7323176552
     assert E[1].correlation == -0.4901215624
@@ -40,18 +40,18 @@ def test_read_energy(sisl_files):
     assert E[1].xc == -15.2224392176
     assert E[1].embedding == 0.0
     assert E[1].total == -129.8161893569
-    E = out.read_energy(all=False)
+    E = out.read_energy(all=False, convert=False)
     assert E.total == -129.8161893569
 
 def test_read_energy_vdw(sisl_files):
     f = sisl_files(_dir, 'molecule2_property.txt')
     out = txtSileORCA(f)
-    E = out.read_energy(all=True)
+    E = out.read_energy(all=True, convert=False)
     assert E[0].total == -113.2343646532
     assert E[0].vdw == -0.0004108775
     assert E[1].total == -113.2343646534
     assert E[1].vdw == -0.0004108775
-    E = out.read_energy()
+    E = out.read_energy(convert=False)
     assert E.total == -113.2343646534
     assert E.vdw == -0.0004108775
 

--- a/sisl/io/orca/tests/test_txt.py
+++ b/sisl/io/orca/tests/test_txt.py
@@ -32,33 +32,22 @@ def test_read_electrons(sisl_files):
 def test_read_energy(sisl_files):
     f = sisl_files(_dir, 'molecule_property.txt')
     out = txtSileORCA(f)
-    E = out.read_energy(all=True, convert=False)
-    assert E[0].total == -129.8161893572
-    assert E[1].exchange == -14.7323176552
-    assert E[1].correlation == -0.4901215624
-    assert E[1].correlation_nl == 0.0
-    assert E[1].xc == -15.2224392176
-    assert E[1].embedding == 0.0
-    assert E[1].total == -129.8161893569
-    E = out.read_energy(all=False, convert=False)
-    assert E.total == -129.8161893569
+    E = out.read_energy(all=True)
+    assert len(E) == 2
     E = out.read_energy(all=False)
-    assert E.total != -129.8161893569
+    assert E.total == -3532.4797529097723
 
 def test_read_energy_vdw(sisl_files):
     f = sisl_files(_dir, 'molecule2_property.txt')
     out = txtSileORCA(f)
-    E = out.read_energy(all=True, convert=False)
-    assert E[0].total == -113.2343646532
-    assert E[0].vdw == -0.0004108775
-    assert E[1].total == -113.2343646534
-    assert E[1].vdw == -0.0004108775
-    E = out.read_energy(convert=False)
-    assert E.total == -113.2343646534
-    assert E.vdw == -0.0004108775
+    E = out.read_energy(all=True)
+    assert len(E) == 2
+    assert E[0].total == -3081.2651523095283
+    assert E[1].total == -3081.2651523149702
+    assert E[1].vdw == -0.011180550414138613
     E = out.read_energy()
-    assert E.total != -113.2343646534
-    assert E.vdw != -0.0004108775
+    assert E.total == -3081.2651523149702
+    assert E.vdw == -0.011180550414138613
 
 def test_read_geometry(sisl_files):
     f = sisl_files(_dir, 'molecule_property.txt')

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -58,8 +58,13 @@ class txtSileORCA(SileORCA):
 
     @sile_fh_open()
     def read_electrons(self, all=False):
-        """ Number of electrons (alpha, beta) """
+        """ Read number of electrons (alpha, beta)
 
+        Parameters
+        ----------
+        all: bool, optional
+            return electron numbers from all steps (instead of last)
+        """
         def readE(itt, reread=True):
             f = self.step_to("Number of Alpha Electrons", reread=reread)
             if f[0]:

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -37,8 +37,11 @@ class txtSileORCA(SileORCA):
     def na(self):
         """ Number of atoms """
         if self._na is None:
-            v = self.step_to("Number of atoms"[1:])[1].split()
-            self._na = int(v[-1])
+            f = self.step_to("Number of atoms"[1:])
+            if f[0]:
+                self._na = int(f[1].split()[-1])
+            else:
+                return None
         return self._na
 
     @property
@@ -46,8 +49,11 @@ class txtSileORCA(SileORCA):
     def no(self):
         """ Number of orbitals (basis functions) """
         if self._no is None:
-            v = self.step_to("Number of basis functions"[1:])[1].split()
-            self._no = int(v[-1])
+            f = self.step_to("Number of basis functions"[1:])
+            if f[0]:
+                self._no = int(f[1].split()[-1])
+            else:
+                return None
         return self._no
 
     @sile_fh_open()

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -58,8 +58,8 @@ class txtSileORCA(SileORCA):
                 elif v[1] == "DFT":
                     E["total"] = value
                 line = next(itt)
-            f = self.step_to("$ VdW_Correction", reread=False)[0]
-            if f:
+            line = next(itt)
+            if "$ VdW_Correction" in line:
                 v = self.step_to("Van der Waals Correction:", reread=False)[1].split()
                 E["vdw"] = float(v[-1])
                 E["total_vdw"] = E["total"] + float(v[-1])

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -103,8 +103,7 @@ class txtSileORCA(SileORCA):
                 return None
             line = next(itt)
             na = int(line.split()[-1])
-            line = next(itt)
-            gidx = int(line.split()[-1])
+            next(itt) # skip Geometry index
             next(itt) # skip Coordinates line
             atoms = []
             xyz = np.empty([na, 3], np.float64)

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -64,9 +64,9 @@ class txtSileORCA(SileORCA):
         PropertyDict : all data from the "DFT_Energy" segment
         """
 
-        def readE(itt):
+        def readE(itt, reread=True):
             # read the DFT_Energy block
-            f = self.step_to("$ DFT_Energy", reread=False)[0]
+            f = self.step_to("$ DFT_Energy", reread=reread)[0]
             if not f:
                 return None
             next(itt) # description
@@ -93,7 +93,7 @@ class txtSileORCA(SileORCA):
                 line = next(itt)
             line = next(itt)
             if "$ VdW_Correction" in line:
-                v = self.step_to("Van der Waals Correction:", reread=False)[1].split()
+                v = self.step_to("Van der Waals Correction:", reread=reread)[1].split()
                 E["vdw"] = float(v[-1])
                 E["total_vdw"] = E["total"] + float(v[-1])
 
@@ -104,7 +104,7 @@ class txtSileORCA(SileORCA):
         e = readE(itt)
         while e is not None:
             E.append(e)
-            e = readE(itt)
+            e = readE(itt, reread=False)
 
         if all:
             return E
@@ -127,9 +127,9 @@ class txtSileORCA(SileORCA):
             if all is False only one geometry will be returned (or None). Otherwise
             a list of geometries corresponding to each step.
         """
-        def readG(itt):
+        def readG(itt, reread=True):
             # Read the Geometry block
-            f = self.step_to("!GEOMETRY!", reread=False)[0]
+            f = self.step_to("!GEOMETRY!", reread=reread)[0]
             if not f:
                 return None
             line = next(itt)
@@ -150,7 +150,7 @@ class txtSileORCA(SileORCA):
         g = readG(itt)
         while g is not None:
             G.append(g)
-            g = readG(itt)
+            g = readG(itt, reread=False)
 
         if all:
             return G

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -8,6 +8,7 @@ from ..sile import add_sile, sile_fh_open
 from sisl.utils import PropertyDict
 from sisl._internal import set_module
 from sisl import Geometry
+from sisl.unit import units
 
 __all__ = ['txtSileORCA']
 
@@ -102,9 +103,6 @@ class txtSileORCA(SileORCA):
         -------
         PropertyDict : all data from the "DFT_Energy" segment
         """
-
-        Hartree2eV = 27.2113834
-
         def readE(itt, reopen=False):
             # read the DFT_Energy block
             f = self.step_to("$ DFT_Energy", reopen=reopen, allow_reread=False)[0]
@@ -119,7 +117,7 @@ class txtSileORCA(SileORCA):
                 v = line.split()
                 value = float(v[-1])
                 if convert:
-                    value *= Hartree2eV
+                    value *= units('Ha', 'eV')
                 if v[0] == "Exchange":
                     E["exchange"] = value
                 elif v[0] == "Correlation":
@@ -139,7 +137,7 @@ class txtSileORCA(SileORCA):
                 v = self.step_to("Van der Waals Correction:")[1].split()
                 value = float(v[-1])
                 if convert:
-                    value *= Hartree2eV
+                    value *= units('Ha', 'eV')
                 E["vdw"] = value
                 E["total_vdw"] = E["total"] + value
 

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -16,6 +16,40 @@ __all__ = ['txtSileORCA']
 class txtSileORCA(SileORCA):
     """ Output property txt file from ORCA """
 
+    def _setup(self, *args, **kwargs):
+        """ Ensure the class has essential tags """
+        super()._setup(*args, **kwargs)
+        self._na = None
+        self._no = None
+
+    def readline(self, *args, **kwargs):
+        line = super().readline(*args, **kwargs)
+        if self._na is None and "Number of atoms:"[1:] in line:
+            v = line.split()
+            self._na = int(v[-1])
+        elif self._no is None and "Number of basis functions:"[1:] in line:
+            v = line.split()
+            self._no = int(v[-1])
+        return line
+
+    @property
+    @sile_fh_open()
+    def na(self):
+        """ Number of atoms """
+        if self._na is None:
+            v = self.step_to("Number of atoms"[1:])[1].split()
+            self._na = int(v[-1])
+        return self._na
+
+    @property
+    @sile_fh_open()
+    def no(self):
+        """ Number of orbitals (basis functions) """
+        if self._no is None:
+            v = self.step_to("Number of basis functions"[1:])[1].split()
+            self._no = int(v[-1])
+        return self._no
+
     @sile_fh_open()
     def read_energy(self, all=False):
         """ Reads the energy specification from ORCA property txt file and returns 

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -52,12 +52,18 @@ class txtSileORCA(SileORCA):
                     else:
                         E["correlation"] = value
                 elif v[0] == "Exchange-Correlation":
-                    E["exchange-correlation"] = value
+                    E["xc"] = value
                 elif v[0] == "Embedding":
                     E["embedding"] = value
                 elif v[1] == "DFT":
                     E["total"] = value
                 line = next(itt)
+            f = self.step_to("$ VdW_Correction", reread=False)[0]
+            if f:
+                v = self.step_to("Van der Waals Correction:", reread=False)[1].split()
+                E["vdw"] = float(v[-1])
+                E["total_vdw"] = E["total"] + float(v[-1])
+
             return E
 
         itt = iter(self)

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -103,7 +103,7 @@ class txtSileORCA(SileORCA):
         PropertyDict : all data from the "DFT_Energy" segment
         """
 
-        Hartree2eV = 27.211386245988
+        Hartree2eV = 27.2113834
 
         def readE(itt, reread=True):
             # read the DFT_Energy block

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -65,8 +65,8 @@ class txtSileORCA(SileORCA):
         all: bool, optional
             return electron numbers from all steps (instead of last)
         """
-        def readE(itt, reread=True):
-            f = self.step_to("Number of Alpha Electrons", reread=reread)
+        def readE(itt, reopen=False):
+            f = self.step_to("Number of Alpha Electrons", reopen=reopen, allow_reread=False)
             if f[0]:
                 alpha = float(f[1].split()[-1])
                 beta = float(next(itt).split()[-1])
@@ -76,10 +76,10 @@ class txtSileORCA(SileORCA):
 
         itt = iter(self)
         E = []
-        e = readE(itt)
+        e = readE(itt, reopen=True)
         while e is not None:
             E.append(e)
-            e = readE(itt, reread=False)
+            e = readE(itt)
 
         if all:
             return np.array(E)
@@ -105,9 +105,9 @@ class txtSileORCA(SileORCA):
 
         Hartree2eV = 27.2113834
 
-        def readE(itt, reread=True):
+        def readE(itt, reopen=False):
             # read the DFT_Energy block
-            f = self.step_to("$ DFT_Energy", reread=reread)[0]
+            f = self.step_to("$ DFT_Energy", reopen=reopen, allow_reread=False)[0]
             if not f:
                 return None
             next(itt) # description
@@ -136,7 +136,7 @@ class txtSileORCA(SileORCA):
                 line = next(itt)
             line = next(itt)
             if "$ VdW_Correction" in line:
-                v = self.step_to("Van der Waals Correction:", reread=reread)[1].split()
+                v = self.step_to("Van der Waals Correction:")[1].split()
                 value = float(v[-1])
                 if convert:
                     value *= Hartree2eV
@@ -147,10 +147,10 @@ class txtSileORCA(SileORCA):
 
         itt = iter(self)
         E = []
-        e = readE(itt)
+        e = readE(itt, reopen=True)
         while e is not None:
             E.append(e)
-            e = readE(itt, reread=False)
+            e = readE(itt)
 
         if all:
             return E
@@ -173,9 +173,9 @@ class txtSileORCA(SileORCA):
             if all is False only one geometry will be returned (or None). Otherwise
             a list of geometries corresponding to each step.
         """
-        def readG(itt, reread=True):
+        def readG(itt, reopen=False):
             # Read the Geometry block
-            f = self.step_to("!GEOMETRY!", reread=reread)[0]
+            f = self.step_to("!GEOMETRY!", reopen=reopen, allow_reread=False)[0]
             if not f:
                 return None
             line = next(itt)
@@ -193,10 +193,10 @@ class txtSileORCA(SileORCA):
 
         itt = iter(self)
         G = []
-        g = readG(itt)
+        g = readG(itt, reopen=True)
         while g is not None:
             G.append(g)
-            g = readG(itt, reread=False)
+            g = readG(itt)
 
         if all:
             return G

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -65,6 +65,10 @@ class txtSileORCA(SileORCA):
         ----------
         all: bool, optional
             return electron numbers from all steps (instead of last)
+
+        Returns
+        -------
+        ndarray or list of ndarrays : alpha and beta electrons
         """
         def readE(itt, reopen=False):
             f = self.step_to("Number of Alpha Electrons", reopen=reopen, allow_reread=False)
@@ -90,18 +94,18 @@ class txtSileORCA(SileORCA):
 
     @sile_fh_open()
     def read_energy(self, all=False, convert=True):
-        """ Reads the energy specification from ORCA property.txt file.
+        """ Reads the energy blocks
 
         Parameters
         ----------
         all: bool, optional
-            return a list of dictionaries from each step
+            return a list of dictionaries from each step (instead of the last)
         convert: bool, optional
-            convert from Hartree to eV units
+            whether to convert the energies to eV (Ha-values are read)
 
         Returns
         -------
-        PropertyDict : all data from the "DFT_Energy" segment
+        PropertyDict : all data from the "DFT_Energy" and "VdW_Correction" blocks
         """
         def readE(itt, reopen=False):
             # read the DFT_Energy block

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -88,18 +88,22 @@ class txtSileORCA(SileORCA):
         return None
 
     @sile_fh_open()
-    def read_energy(self, all=False):
-        """ Reads the energy specification (in eV) from ORCA property.txt file.
+    def read_energy(self, all=False, convert=True):
+        """ Reads the energy specification from ORCA property.txt file.
 
         Parameters
         ----------
         all: bool, optional
             return a list of dictionaries from each step
+        convert: bool, optional
+            convert from Hartree to eV units
 
         Returns
         -------
         PropertyDict : all data from the "DFT_Energy" segment
         """
+
+        Hartree2eV = 27.211386245988
 
         def readE(itt, reread=True):
             # read the DFT_Energy block
@@ -114,6 +118,8 @@ class txtSileORCA(SileORCA):
             while "----" not in line:
                 v = line.split()
                 value = float(v[-1])
+                if convert:
+                    value *= Hartree2eV
                 if v[0] == "Exchange":
                     E["exchange"] = value
                 elif v[0] == "Correlation":

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -64,7 +64,7 @@ class txtSileORCA(SileORCA):
                 elif v[0] == "Embedding":
                     E["embedding"] = value
                 elif v[1] == "DFT":
-                    E["total_energy"] = value
+                    E["total"] = value
                 line = next(itt)
             return E
 

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -93,19 +93,17 @@ class txtSileORCA(SileORCA):
         return None
 
     @sile_fh_open()
-    def read_energy(self, all=False, convert=True):
+    def read_energy(self, all=False):
         """ Reads the energy blocks
 
         Parameters
         ----------
         all: bool, optional
             return a list of dictionaries from each step (instead of the last)
-        convert: bool, optional
-            whether to convert the energies to eV (Ha-values are read)
 
         Returns
         -------
-        PropertyDict : all data from the "DFT_Energy" and "VdW_Correction" blocks
+        PropertyDict : all data (in eV) from the "DFT_Energy" and "VdW_Correction" blocks
         """
         def readE(itt, reopen=False):
             # read the DFT_Energy block
@@ -119,9 +117,7 @@ class txtSileORCA(SileORCA):
             E = PropertyDict()
             while "----" not in line:
                 v = line.split()
-                value = float(v[-1])
-                if convert:
-                    value *= units('Ha', 'eV')
+                value = float(v[-1]) * units('Ha', 'eV')
                 if v[0] == "Exchange":
                     E["exchange"] = value
                 elif v[0] == "Correlation":
@@ -139,10 +135,7 @@ class txtSileORCA(SileORCA):
             line = next(itt)
             if "$ VdW_Correction" in line:
                 v = self.step_to("Van der Waals Correction:")[1].split()
-                value = float(v[-1])
-                if convert:
-                    value *= units('Ha', 'eV')
-                E["vdw"] = value
+                E["vdw"] = float(v[-1]) * units('Ha', 'eV')
 
             return E
 

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -14,7 +14,7 @@ __all__ = ['txtSileORCA']
 
 @set_module("sisl.io.orca")
 class txtSileORCA(SileORCA):
-    """ Output property txt file from ORCA """
+    """ Output from the ORCA property.txt file """
 
     def _setup(self, *args, **kwargs):
         """ Ensure the class has essential tags """
@@ -52,8 +52,7 @@ class txtSileORCA(SileORCA):
 
     @sile_fh_open()
     def read_energy(self, all=False):
-        """ Reads the energy specification from ORCA property txt file and returns 
-        energy dictionary in units of eV (and related info from the block)
+        """ Reads the energy specification (in eV) from ORCA property.txt file.
 
         Parameters
         ----------
@@ -62,7 +61,7 @@ class txtSileORCA(SileORCA):
 
         Returns
         -------
-        PropertyDict : all data from the "DFT_Energy" segment of ORCA property output
+        PropertyDict : all data from the "DFT_Energy" segment
         """
 
         def readE(itt):
@@ -115,7 +114,7 @@ class txtSileORCA(SileORCA):
 
     @sile_fh_open()
     def read_geometry(self, all=False):
-        """ Reads the geometry from ORCA property txt file
+        """ Reads the geometry from ORCA property.txt file
 
         Parameters
         ----------

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -57,6 +57,32 @@ class txtSileORCA(SileORCA):
         return self._no
 
     @sile_fh_open()
+    def read_electrons(self, all=False):
+        """ Number of electrons (alpha, beta) """
+
+        def readE(itt, reread=True):
+            f = self.step_to("Number of Alpha Electrons", reread=reread)
+            if f[0]:
+                alpha = float(f[1].split()[-1])
+                beta = float(next(itt).split()[-1])
+            else:
+                return None
+            return alpha, beta
+
+        itt = iter(self)
+        E = []
+        e = readE(itt)
+        while e is not None:
+            E.append(e)
+            e = readE(itt, reread=False)
+
+        if all:
+            return np.array(E)
+        if len(E) > 0:
+            return np.array(E[-1])
+        return None
+
+    @sile_fh_open()
     def read_energy(self, all=False):
         """ Reads the energy specification (in eV) from ORCA property.txt file.
 

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -1,0 +1,83 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from .sile import SileORCA
+from ..sile import add_sile, sile_fh_open
+
+from sisl.utils import PropertyDict
+from sisl._internal import set_module
+
+
+__all__ = ['txtSileORCA']
+
+
+@set_module("sisl.io.orca")
+class txtSileORCA(SileORCA):
+    """ Output property txt file from ORCA """
+
+    @sile_fh_open()
+    def read_energy(self, all=False):
+        """ Reads the energy specification from ORCA property txt file and returns 
+        energy dictionary in units of eV (and related info from the block)
+
+        Parameters
+        ----------
+        all: bool, optional
+            return a list of dictionaries from each step
+
+        Returns
+        -------
+        PropertyDict : all data from the "DFT_Energy" segment of ORCA property output
+        """
+
+        def readE(itt):
+            # read the DFT_Energy block
+            f = self.step_to("$ DFT_Energy", reread=False)[0]
+            if not f:
+                return None
+            next(itt) # description
+            next(itt) # geom. index
+            next(itt) # prop. index
+            line = next(itt)
+            E = PropertyDict()
+            while "----" not in line:
+                v = line.split()
+                value = float(v[-1])
+                v.append([]) # ensure at least four entries
+                if v[3] == "Electrons":
+                    if v[2] == "Alpha":
+                        E["elec_alpha"] = value
+                    elif v[2] == "Beta":
+                        E["elec_beta"] = value
+                    else:
+                        E["elec_total"] = value
+                elif v[0] == "Exchange":
+                    E["exchange"] = value
+                elif v[0] == "Correlation":
+                    if v[2] == "NL":
+                        E["correlation_nl"] = value
+                    else:
+                        E["correlation"] = value
+                elif v[0] == "Exchange-Correlation":
+                    E["exchange-correlation"] = value
+                elif v[0] == "Embedding":
+                    E["embedding"] = value
+                elif v[1] == "DFT":
+                    E["total_energy"] = value
+                line = next(itt)
+            return E
+
+        itt = iter(self)
+        E = []
+        e = readE(itt)
+        while e is not None:
+            E.append(e)
+            e = readE(itt)
+
+        if all:
+            return E
+        if len(E) > 0:
+            return E[-1]
+        return None
+
+add_sile('txt', txtSileORCA, gzip=True)

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -57,7 +57,7 @@ class txtSileORCA(SileORCA):
                 return None
         return self._no
 
-    @sile_fh_open()
+    @sile_fh_open(True)
     def read_electrons(self, all=False):
         """ Read number of electrons (alpha, beta)
 
@@ -70,8 +70,8 @@ class txtSileORCA(SileORCA):
         -------
         ndarray or list of ndarrays : alpha and beta electrons
         """
-        def readE(itt, reopen=False):
-            f = self.step_to("Number of Alpha Electrons", reopen=reopen, allow_reread=False)
+        def readE(itt):
+            f = self.step_to("Number of Alpha Electrons", allow_reread=False)
             if f[0]:
                 alpha = float(f[1].split()[-1])
                 beta = float(next(itt).split()[-1])
@@ -81,7 +81,7 @@ class txtSileORCA(SileORCA):
 
         itt = iter(self)
         E = []
-        e = readE(itt, reopen=True)
+        e = readE(itt)
         while e is not None:
             E.append(e)
             e = readE(itt)
@@ -92,7 +92,7 @@ class txtSileORCA(SileORCA):
             return np.array(E[-1])
         return None
 
-    @sile_fh_open()
+    @sile_fh_open(True)
     def read_energy(self, all=False):
         """ Reads the energy blocks
 
@@ -105,9 +105,9 @@ class txtSileORCA(SileORCA):
         -------
         PropertyDict : all data (in eV) from the "DFT_Energy" and "VdW_Correction" blocks
         """
-        def readE(itt, reopen=False):
+        def readE(itt):
             # read the DFT_Energy block
-            f = self.step_to("$ DFT_Energy", reopen=reopen, allow_reread=False)[0]
+            f = self.step_to("$ DFT_Energy", allow_reread=False)[0]
             if not f:
                 return None
             next(itt) # description
@@ -141,7 +141,7 @@ class txtSileORCA(SileORCA):
 
         itt = iter(self)
         E = []
-        e = readE(itt, reopen=True)
+        e = readE(itt)
         while e is not None:
             E.append(e)
             e = readE(itt)
@@ -152,7 +152,7 @@ class txtSileORCA(SileORCA):
             return E[-1]
         return None
 
-    @sile_fh_open()
+    @sile_fh_open(True)
     def read_geometry(self, all=False):
         """ Reads the geometry from ORCA property.txt file
 
@@ -167,9 +167,9 @@ class txtSileORCA(SileORCA):
             if all is False only one geometry will be returned (or None). Otherwise
             a list of geometries corresponding to each step.
         """
-        def readG(itt, reopen=False):
+        def readG(itt):
             # Read the Geometry block
-            f = self.step_to("!GEOMETRY!", reopen=reopen, allow_reread=False)[0]
+            f = self.step_to("!GEOMETRY!", allow_reread=False)[0]
             if not f:
                 return None
             line = next(itt)
@@ -187,7 +187,7 @@ class txtSileORCA(SileORCA):
 
         itt = iter(self)
         G = []
-        g = readG(itt, reopen=True)
+        g = readG(itt)
         while g is not None:
             G.append(g)
             g = readG(itt)

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -137,8 +137,11 @@ class txtSileORCA(SileORCA):
             line = next(itt)
             if "$ VdW_Correction" in line:
                 v = self.step_to("Van der Waals Correction:", reread=reread)[1].split()
-                E["vdw"] = float(v[-1])
-                E["total_vdw"] = E["total"] + float(v[-1])
+                value = float(v[-1])
+                if convert:
+                    value *= Hartree2eV
+                E["vdw"] = value
+                E["total_vdw"] = E["total"] + value
 
             return E
 

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -44,15 +44,7 @@ class txtSileORCA(SileORCA):
             while "----" not in line:
                 v = line.split()
                 value = float(v[-1])
-                v.append([]) # ensure at least four entries
-                if v[3] == "Electrons":
-                    if v[2] == "Alpha":
-                        E["elec_alpha"] = value
-                    elif v[2] == "Beta":
-                        E["elec_beta"] = value
-                    else:
-                        E["elec_total"] = value
-                elif v[0] == "Exchange":
+                if v[0] == "Exchange":
                     E["exchange"] = value
                 elif v[0] == "Correlation":
                     if v[2] == "NL":

--- a/sisl/io/orca/txt.py
+++ b/sisl/io/orca/txt.py
@@ -143,7 +143,6 @@ class txtSileORCA(SileORCA):
                 if convert:
                     value *= units('Ha', 'eV')
                 E["vdw"] = value
-                E["total_vdw"] = E["total"] + value
 
             return E
 


### PR DESCRIPTION
We are currently performing some calculations with ORCA and need to extract various data from its output files.

This branch aims to provide a first simple interface to some ORCA output.

From `_property.txt` files
- [x] `read_electrons(all=False)`
- [x] `read_energy(all=False)`
- [x] `read_geometry(all=False)`

From standard `output` files
- [x] `completed()`
- [x] `read_charge(name='mulliken', projection='orbital', orbitals=None, reduced=True, spin=False, all=False)`
- [x] `read_electrons(all=False)`
- [x] `read_energy(all=False)`
- [x] `read_orbital_energies(all=False)`
