### PR TITLE
Plotly is incompatible with ipywidgets 8.x

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,5 +19,6 @@ plotly
 sphinx-gallery
 sphinx-rtd-theme
 tqdm
-ipywidgets
+ipywidgets==7.7.1 # Plotly is incompatible with ipywidgets 8.x
+jupyterlab-widgets==1.1.1
 kaleido


### PR DESCRIPTION
Apparently plotly is incompatible with ipywidgets 8.x for now (https://github.com/plotly/plotly.py/issues/3686) and this is making the plots in the docs not display properly:

![Screenshot from 2022-11-06 13-53-55](https://user-images.githubusercontent.com/42074085/200171990-3c06250b-cc56-4835-a188-64bdace06688.png)


