### PR TITLE
Sile function `step_to(..., reread=True)`

### DIFF
--- a/sisl/io/sile.py
+++ b/sisl/io/sile.py
@@ -738,8 +738,7 @@ class Sile(BaseSile):
             # Force close and reopen from the beginning
             self.close()
             self._open()
-        # The previously read line...
-        line = self._line
+
         if isinstance(keywords, str):
             # convert to list
             keywords = [keywords]

--- a/sisl/io/sile.py
+++ b/sisl/io/sile.py
@@ -734,6 +734,10 @@ class Sile(BaseSile):
         r""" Steps the file-handle until the keyword(s) is found in the input """
         # If keyword is a list, it just matches one of the inputs
         found = False
+        if reread:
+            # Force close and reopen from the beginning
+            self.close()
+            self._open()
         # The previously read line...
         line = self._line
         if isinstance(keywords, str):
@@ -746,21 +750,6 @@ class Sile(BaseSile):
             if l == '':
                 break
             found = self.line_has_keys(l, keys, case)
-
-        if not found and (l == '' and line > 0) and reread:
-            # We may be in the case where the user request
-            # reading the same twice...
-            # So we need to re-read the file...
-            self.close()
-            # Re-open the file...
-            self._open()
-
-            # Try and read again
-            while not found and self._line <= line:
-                l = self.readline()
-                if l == '':
-                    break
-                found = self.line_has_keys(l, keys, case)
 
         if ret_index:
             idx = -1

--- a/sisl/io/vasp/out.py
+++ b/sisl/io/vasp/out.py
@@ -100,10 +100,10 @@ class outSileVASP(SileVASP):
             "Solvation": "solvation",
         }
 
-        def readE(itt):
+        def readE(itt, reread=True):
             nonlocal name_conv
             # read the energy tables
-            f = self.step_to("Free energy of the ion-electron system", reread=False)[0]
+            f = self.step_to("Free energy of the ion-electron system", reread=reread)[0]
             if not f:
                 return None
             next(itt) # -----
@@ -131,7 +131,7 @@ class outSileVASP(SileVASP):
         e = readE(itt)
         while e is not None:
             E.append(e)
-            e = readE(itt)
+            e = readE(itt, reread=False)
         try:
             # this just puts the job_completed flag. But otherwise not used
             self.cpu_time()


### PR DESCRIPTION
While working on #500 I found (sometimes) an unexpected behaviour of the `step_to(..., reread=True)` function: It would not always read from the very beginning of the sile.

Consider a simple text file `inp.txt` with the following lines:
```
1 a
1 b
2 a
2 b
...
```
and this test script
```python
import sisl
from sisl.io import Sile, add_sile, sile_fh_open

class mySile(Sile):

    @sile_fh_open()
    def read(self):
        self.step_to('b')
        l = self.step_to('a')[1]
        print(l)

add_sile('txt', mySile)

f = sisl.get_sile('inp.txt{mySile}')
f.read()
```
With sisl version 55250091a584f1faa8b1835ba9973d721d3b08c8 the printed line is `2 a`. I would have expected the default value `reread=True` to find the first appearance of "a" in the file, i.e., `1 a`.

This branch forces the file to be reopened from the very beginning when `reread=True`.