### PR TITLE
New keywords in `step_to()`

### DIFF
--- a/sisl/io/ham.py
+++ b/sisl/io/ham.py
@@ -118,7 +118,7 @@ class hamiltonianSile(Sile):
 
         # Start reading in the supercell
         while True:
-            found, l = self.step_to('matrix', reread=False)
+            found, l = self.step_to('matrix', allow_reread=False)
             if not found:
                 break
 

--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -100,7 +100,7 @@ class outSileSiesta(SileSiesta):
             line = self.readline().split("=")
             tag = line[0].split()[0]
             atoms[tag]["mass"] = float(line[2].split()[0])
-            found, line = self.step_to("<basis_specs>", reread=False)
+            found, line = self.step_to("<basis_specs>", allow_reread=False)
 
         block = []
         found, line = self.step_to("%block PAO.Basis")
@@ -591,7 +591,7 @@ class outSileSiesta(SileSiesta):
         -------
         PropertyDict : dictionary like lookup table ionic energies are stored in a nested `PropertyDict` at the key ``ion`` (all energies in eV)
         """
-        found = self.step_to("siesta: Final energy", reread=False)[0]
+        found = self.step_to("siesta: Final energy", allow_reread=False)[0]
         out = PropertyDict()
         out.ion = PropertyDict()
         if not found:
@@ -1155,7 +1155,7 @@ class outSileSiesta(SileSiesta):
         FOUND_FINAL = False
 
         # TODO whalrus
-        ret = self.step_to(search_keys, case=True, ret_index=True, reread=False)
+        ret = self.step_to(search_keys, case=True, ret_index=True, allow_reread=False)
         while ret[0]:
             if ret[2] in IDX_SCF_END:
                 # we finished all SCF iterations
@@ -1218,7 +1218,7 @@ class outSileSiesta(SileSiesta):
                 current_state = state.CHARGE
 
             # step to next entry
-            ret = self.step_to(search_keys, case=True, ret_index=True, reread=False)
+            ret = self.step_to(search_keys, case=True, ret_index=True, allow_reread=False)
 
         if not any((FOUND_SCF, FOUND_MD, FOUND_FINAL)):
             raise SileError(f"{self!s} does not contain any charges ({name})")

--- a/sisl/io/sile.py
+++ b/sisl/io/sile.py
@@ -730,8 +730,39 @@ class Sile(BaseSile):
             self._line += 1
         return l
 
-    def step_to(self, keywords, case=True, reread=True, ret_index=False):
-        r""" Steps the file-handle until the keyword(s) is found in the input """
+    def step_to(self, keywords, case=True, allow_reread=True, ret_index=False, reopen=False):
+        r""" Steps the file-handle until the keyword(s) is found in the input
+
+        Parameters
+        ----------
+        keywords : str or list
+            keyword(s) to find in the sile
+        case : bool, optional
+            whether to search case sensitive
+        allow_reread : bool, optional
+            whether the search from current position is allowed to
+            loop back to the beginning
+        ret_index : bool, optional
+            returns the index in the keyword list that was matched in the search
+        reopen : bool, optional
+            if True, the search is forced to start from the beginning
+            of the sile (search after sile close and reopen)
+
+        Returns
+        -------
+        found : bool
+            whether the search was successful or not
+        l : str
+            the found line that matches the keyword(s)
+        idx : int, optional
+            index of the keyword from the list that was matched
+        """
+
+        if reopen:
+            # ensure file is read from the beginning
+            self.close()
+            self._open()
+
         # If keyword is a list, it just matches one of the inputs
         found = False
         # The previously read line...
@@ -747,7 +778,7 @@ class Sile(BaseSile):
                 break
             found = self.line_has_keys(l, keys, case)
 
-        if not found and (l == '' and line > 0) and reread:
+        if not found and (l == '' and line > 0) and allow_reread:
             # We may be in the case where the user request
             # reading the same twice...
             # So we need to re-read the file...

--- a/sisl/io/vasp/out.py
+++ b/sisl/io/vasp/out.py
@@ -41,7 +41,7 @@ class outSileVASP(SileVASP):
         else:
             raise ValueError(f"{self.__class__.__name__}.cpu_time unknown flag '{flag}'")
 
-        found = self.step_to(flag, reread=False)[0]
+        found = self.step_to(flag, allow_reread=False)[0]
         if found:
             self._completed = True
             for _ in range(nskip):
@@ -103,7 +103,7 @@ class outSileVASP(SileVASP):
         def readE(itt):
             nonlocal name_conv
             # read the energy tables
-            f = self.step_to("Free energy of the ion-electron system", reread=False)[0]
+            f = self.step_to("Free energy of the ion-electron system", allow_reread=False)[0]
             if not f:
                 return None
             next(itt) # -----


### PR DESCRIPTION
As discussed in #505, this branch introduces `allow_reread` and `reopen` as new keywords to the sile function `step_to`.