### PR TITLE
Possible bug: within_inf with periodic=False returns sc atoms for nsc > 1

### DIFF
--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -4380,6 +4380,10 @@ class Geometry(SuperCellChild):
         # Now we have to figure out all atomic coordinates within
         cuboid = sc.toCuboid()
 
+        # Make sure that full_geom doesn't return coordinates outside the unit cell
+        # for non periodic directions
+        full_geom.set_nsc([full_geom.nsc[i] if periodic[i] else 1 for i in range(3)])
+
         # Now retrieve all atomic coordinates from the full geometry
         xyz = full_geom.axyz(_a.arangei(full_geom.na_s))
         idx = cuboid.within_index(xyz)

--- a/sisl/tests/test_geometry.py
+++ b/sisl/tests/test_geometry.py
@@ -809,6 +809,25 @@ class TestGeometry:
         sc_3x3 = g.sc.tile(3, 0).tile(3, 1)
         assert len(g.within_inf(sc_3x3)[0]) == len(g) * 3 ** 2
 
+    def test_within_inf_nonperiodic(self, setup):
+        g = setup.g.copy()
+
+        # Even if the geometry has nsc > 1, if we set periodic=False
+        # we should get only the atoms in the unit cell.
+        g.set_nsc([3,3,1])
+
+        ia, xyz, isc = g.within_inf(g.sc, periodic=[False, False, False])
+
+        assert len(ia) == g.na
+        assert np.all(isc == 0)
+
+        # Make sure that it also works with mixed periodic/non periodic directions
+        ia, xyz, isc = g.within_inf(g.sc, periodic=[True, False, False])
+
+        assert len(ia) > g.na
+        assert np.any(isc[:, 0] != 0)
+        assert np.all(isc[:, 1] == 0)
+
     def test_within_inf2(self, setup):
         g = setup.mol.translate([0.05] * 3)
         sc = SuperCell(1.5)


### PR DESCRIPTION
I think I found a bug. If you call `Geometry.within_inf` with `periodic=False` it would work properly only if the geometry had `nsc=[1,1,1]`, otherwise it would basically not care if periodic was set to False and return atoms in neighboring cells.

Or was this intended behavior?
