### PR TITLE
Fix reading of basis

### DIFF
--- a/sisl/io/siesta/orb_indx.py
+++ b/sisl/io/siesta/orb_indx.py
@@ -83,11 +83,11 @@ class orbindxSileSiesta(SileSiesta):
         orbs = []
         specs = []
         ia = 1
+        i_s = 0
         for _ in range(no):
             line = self.readline().split()
 
             i_a = int(line[1])
-            i_s = int(line[2]) - 1
             spec = line[3]
             if i_a != ia:
                 if i_s not in specs:
@@ -95,6 +95,8 @@ class orbindxSileSiesta(SileSiesta):
                 specs.append(i_s)
                 ia = i_a
                 orbs = []
+
+            i_s = int(line[2]) - 1
 
             if i_s in specs:
                 continue

--- a/sisl/io/siesta/tests/test_orb_indx.py
+++ b/sisl/io/siesta/tests/test_orb_indx.py
@@ -18,5 +18,18 @@ def test_si_pdos_kgrid_orb_indx(sisl_files):
     atoms = orbindxSileSiesta(f).read_basis()
 
     assert len(atoms) == 2
+    assert atoms.nspecie == 1
     assert len(atoms[0]) == 13
     assert len(atoms[1]) == 13
+
+
+def test_sih_orb_indx(sisl_files):
+    f = sisl_files(_dir, 'sih.ORB_INDX')
+    nsc = orbindxSileSiesta(f).read_supercell_nsc()
+    assert np.all(nsc == 1)
+    atoms = orbindxSileSiesta(f).read_basis()
+
+    assert len(atoms) == 65
+    assert atoms.nspecie == 2
+    assert len(atoms[0]) == 4
+    assert len(atoms[-1]) == 1


### PR DESCRIPTION
This partially reverts a change that breaks the reading of basis orbitals from 'ORB_INDEX' file when multiple species are present.

The current version works fine for the first species. However, not for the next species.

This happens because, as soon as the loop reaches a new species it will try to create a new atom. Instead of first reading all orbitals for the new species. When checking whether the current `i_s` is in the list of `species` we really want to check it for the previous atom, not for the current atom. 

Hence, moving the definition of `i_s`  below is necessary.

I assume this change was intended to avoid, accessing `i_s` or `spec`  before they are first assigned.

Instead, I suggest assigning an arbitrary value before the loop. The initial value will never to used, because `i_a != ia` can not happen before the second iteration of the loop.
