### PR TITLE
mnt: make viz work with new spin conventions

### DIFF
--- a/sisl/viz/input_fields/orbital.py
+++ b/sisl/viz/input_fields/orbital.py
@@ -175,7 +175,12 @@ class OrbitalQueries(QueriesInput):
         if spin_in_keys:
             spin_key_i = keys.index("spin")
             keys.remove("spin")
-            spin_options = self.get_param("spin").options
+
+            spin_param = self.get_param("spin")
+            spin_options = spin_param.options
+
+            if spin_param.spin.is_polarized and len(spin_options) > 1:
+                spin_options = (0, 1)
 
             # We might have some constraints on what the spin value can be
             if "spin" in kwargs:

--- a/sisl/viz/input_fields/spin.py
+++ b/sisl/viz/input_fields/spin.py
@@ -39,7 +39,8 @@ class SpinSelect(OptionsInput):
 
     _options = {
         Spin.UNPOLARIZED: [],
-        Spin.POLARIZED: [{"label": "↑", "value": 0}, {"label": "↓", "value": 1}],
+        Spin.POLARIZED: [{"label": "↑", "value": 0}, {"label": "↓", "value": 1}, 
+            {"label": "Total", "value": "total"}, {"label": "Net z", "value": "z"}],
         Spin.NONCOLINEAR: [{"label": val, "value": val} for val in ("total", "x", "y", "z")],
         Spin.SPINORBIT: [{"label": val, "value": val}
                          for val in ("total", "x", "y", "z")]
@@ -74,6 +75,8 @@ class SpinSelect(OptionsInput):
         """
         if not isinstance(spin, Spin):
             spin = Spin(spin)
+
+        self.spin = spin
 
         # Use the default for this input field if only_if_polarized is not provided.
         if only_if_polarized is None:

--- a/sisl/viz/plots/bands.py
+++ b/sisl/viz/plots/bands.py
@@ -395,7 +395,7 @@ class BandsPlot(Plot):
                 return eigenstate.spin_moment().real
 
             extra_vars = ({
-                "coords": ("band", "axis"), "coords_values": dict(axis=["x", "y", "z"]),
+                "coords": ("axis", "band"), "coords_values": dict(axis=["x", "y", "z"]),
                 "name": "spin_moments", "getter": _spin_moment_getter},
             *extra_vars)
 

--- a/sisl/viz/plots/tests/test_bands.py
+++ b/sisl/viz/plots/tests/test_bands.py
@@ -218,7 +218,7 @@ class TestBandsPlot(_TestPlot):
         spin_moments = plot.spin_moments
         assert isinstance(spin_moments, DataArray)
         assert set(spin_moments.dims) == set(('k', 'band', 'axis'))
-        assert spin_moments.shape == (test_attrs['bands_shape'][0], test_attrs['bands_shape'][-1], 3)
+        assert spin_moments.shape == (test_attrs['bands_shape'][0], 3, test_attrs['bands_shape'][-1])
 
     def test_spin_texture(self, plot, test_attrs):
         assert plot._for_backend["draw_bands"]["spin_texture"]["show"] is False


### PR DESCRIPTION
All viz tests pass again.

I added a check for PDOS arrays that have `ndim == 2` because `pdosSileSiesta.read_data` returns an array without spin dimension in unpolarized cases, but the return should probably be changed to 3 dimensions for consistency with the rest of sisl.