### PR TITLE
bug: outSile.read_scf was not able to read unconverged SCF loops

### DIFF
--- a/sisl/io/siesta/out.py
+++ b/sisl/io/siesta/out.py
@@ -718,7 +718,7 @@ class outSileSiesta(SileSiesta):
             if imd == 0:
                 raise ValueError(f"{self.__class__.__name__}.read_scf requires imd argument to *not* be 0!")
         def reset_d(d, line):
-            if line.startswith('SCF cycle converged'):
+            if line.startswith('SCF cycle converged') or line.startswith('SCF_NOT_CONV'):
                 if len(d['data']) > 0:
                     d['_final_iscf'] = 1
             elif line.startswith('SCF cycle continued'):


### PR DESCRIPTION
The function to find out if the SCF is finished only looked for `SCF cycle converged`, so it couldn't tell that the SCF loop had finished if it was not converged. Now I added a check for `SCF_NOT_CONV` as well.
