### PR TITLE
Add env variable to docs build

### DIFF
--- a/.github/workflows/documentation_ghpages.yaml
+++ b/.github/workflows/documentation_ghpages.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Build the documentation using the sisl-files as well
         run: |
           cd docs
-          SISL_FILES_TESTS=${GITHUB_WORKSPACE}/files/tests make html
+          SISL_NODES_EXPORT_VIS=t SISL_FILES_TESTS=${GITHUB_WORKSPACE}/files/tests make html
           rm -rf build/html/_sources
           touch build/html/.nojekyll
           cd ..


### PR DESCRIPTION
The Nodes and Workflows documentation was not building properly, because the visualization needs an env variable to be set when the jupyter notebook is exported to html.

Otherwise the visualization does not show and it messes with the styles of the page:

![Screenshot from 2023-02-06 11-38-01](https://user-images.githubusercontent.com/42074085/216950456-43f7cbe3-b73f-468e-9677-c9e0497d4fb7.png)
