### PR TITLE
mnt: changed only= keyword arguments to what=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ we hit release version 1.0.0.
 - `BrillouinZone.merge` allows simple merging of several objects, #537
 
 ### Changed
+- Geometry.rotate(only=) to (what=), this is to unify the interfaces across, #541
+  Also changed the default value to be "xyz" if atoms is Not none
+- tbtncSileTBtrans(only=) arguments are changed to (what=) #541
 - `SelfEnergy.scattering_matrix` is changed to `SelfEnergy.broadening_matrix`
   ince the scattering matrix is an S-matrix usage.
   Also changed `se2scat` to `se2broadening` #529

--- a/sisl/geom/bilayer.py
+++ b/sisl/geom/bilayer.py
@@ -116,7 +116,7 @@ def bilayer(bond=1.42, bottom_atoms=None, top_atoms=None, stacking='AB',
                .tile(rep, axis=0)
                .tile(rep, axis=1)
                .move(align_vec)
-               .rotate(theta, [0, 0, 1]))
+               .rotate(theta, [0, 0, 1], what="abc+xyz"))
 
         inside_idx = cell_box.within_index(top.xyz)
         top = top.sub(inside_idx)
@@ -149,7 +149,7 @@ def bilayer(bond=1.42, bottom_atoms=None, top_atoms=None, stacking='AB',
         vec = bilayer.cell[0] + bilayer.cell[1]
         vec_costh = vec[0] / vec.dot(vec) ** 0.5
         vec_th = -acos(vec_costh) * 180 / pi
-        bilayer = bilayer.move(-offset).rotate(vec_th, [0, 0, 1])
+        bilayer = bilayer.move(-offset).rotate(vec_th, [0, 0, 1], what="xyz+abc")
 
     # Sanity check
     assert len(bilayer) == natoms

--- a/sisl/geom/nanoribbon.py
+++ b/sisl/geom/nanoribbon.py
@@ -56,7 +56,7 @@ def nanoribbon(width, bond, atoms, kind='armchair'):
 
     elif kind == "zigzag":
         # Construct zigzag GNR
-        ribbon = ribbon.rotate(90, [0, 0, -1])
+        ribbon = ribbon.rotate(90, [0, 0, -1], what="abc+xyz")
         if m == 1:
             ribbon = ribbon.tile(n + 1, 0)
             ribbon = ribbon.remove(-1).remove(-1)

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -2299,13 +2299,12 @@ class Geometry(SuperCellChild):
              atoms will be rotated.
         rad : bool, optional
              if ``True`` the angle is provided in radians (rather than degrees)
-        what : {'xyz', 'abc', 'abc+xyz'}
+        what : {'xyz', 'abc', 'abc+xyz', <or combinations of "xyzabc">}
             which coordinate subject should be rotated,
-            if ``abc`` is in this string the cell will be rotated
-            if ``xyz`` is in this string the coordinates will be rotated
-            Each of the coordinates may be individually rotated.
+            if any of ``abc`` is in this string the corresponding cell vector will be rotated
+            if any of ``xyz`` is in this string the corresponding coordinates will be rotated
             If `atoms` is None, this defaults to "abc+xyz", otherwise it defaults
-            to "xyz".
+            to "xyz". See Examples.
 
         Examples
         --------
@@ -2330,6 +2329,7 @@ class Geometry(SuperCellChild):
         if atoms is None:
             if what is None:
                 what = "abc+xyz"
+            # important to not add a new dimension to xyz
             atoms = slice(None)
         else:
             if what is None:

--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -8,6 +8,7 @@ from numbers import Integral, Real
 from math import acos
 from itertools import product
 from collections import OrderedDict
+from functools import reduce
 from pathlib import Path
 import warnings
 
@@ -26,7 +27,7 @@ from . import _array as _a
 from ._math_small import is_ascending, cross3
 from ._indices import indices_in_sphere_with_dist, indices_le, indices_gt_le
 from ._indices import list_index_le
-from .messages import info, warn, SislError
+from .messages import info, warn, SislError, deprecate_argument
 from ._help import isndarray
 from .utils import default_ArgumentParser, default_namespace, cmd, str_spec
 from .utils import angle, direction
@@ -1327,7 +1328,7 @@ class Geometry(SuperCellChild):
         >>> geom.sort(group=('symbol', ['N', 'B'], 'C')) # [B, N], C (B and N unaltered order)
         >>> geom.sort(group=('symbol', ['B', 'N'], 'C')) # [B, N], C (B and N unaltered order)
 
-        A group based sorting can use *anything* that can be fetched from the `Atom` object, 
+        A group based sorting can use *anything* that can be fetched from the `Atom` object,
         sort first according to mass, then for all with the same mass, sort according to atomic
         tag:
 
@@ -2264,13 +2265,19 @@ class Geometry(SuperCellChild):
             return ang
         return np.degrees(ang)
 
-    def rotate(self, angle, v, origin=None, atoms: Optional[AtomsArg]=None, only='abc+xyz', rad=False) -> Geometry:
-        """ Rotate geometry around vector and return a new geometry
+    @deprecate_argument("only", "what",
+                        "argument only has been deprecated in favor of what, please update your code.",
+                        "0.14.0")
+    def rotate(self, angle, v, origin=None,
+               atoms: Optional[AtomsArg]=None,
+               rad: bool=False,
+               what: Optional[str]=None) -> TGeometry:
+        r""" Rotate geometry around vector and return a new geometry
 
         Per default will the entire geometry be rotated, such that everything
         is aligned as before rotation.
 
-        However, by supplying ``only = 'abc|xyz'`` one can designate which
+        However, by supplying ``what = 'abc|xyz'`` one can designate which
         part of the geometry that will be rotated.
 
         Parameters
@@ -2280,7 +2287,9 @@ class Geometry(SuperCellChild):
              argument to use radians.
         v     : int or str or array_like
              the normal vector to the rotated plane, i.e.
-             v = [1,0,0] will rotate the ``yz`` plane
+             v = [1,0,0] will rotate around the :math:`yz` plane.
+             If a str it refers to the Cartesian direction (xyz), or the
+             lattice vectors (abc). Providing several is the combined direction.
         origin : int or array_like, optional
              the origin of rotation. Anything but [0, 0, 0] is equivalent
              to a `self.move(-origin).rotate(...).move(origin)`.
@@ -2288,53 +2297,77 @@ class Geometry(SuperCellChild):
         atoms : int or array_like, optional
              only rotate the given atomic indices, if not specified, all
              atoms will be rotated.
-        only : {'abc+xyz', 'xyz', 'abc'}
-             which coordinate subject should be rotated,
-             if ``abc`` is in this string the cell will be rotated
-             if ``xyz`` is in this string the coordinates will be rotated
         rad : bool, optional
              if ``True`` the angle is provided in radians (rather than degrees)
+        what : {'xyz', 'abc', 'abc+xyz'}
+            which coordinate subject should be rotated,
+            if ``abc`` is in this string the cell will be rotated
+            if ``xyz`` is in this string the coordinates will be rotated
+            Each of the coordinates may be individually rotated.
+            If `atoms` is None, this defaults to "abc+xyz", otherwise it defaults
+            to "xyz".
+
+        Examples
+        --------
+        rotate coordinates around the :math:`x`-axis
+        >>> geom_x45 = geom.rotate(45, [1, 0, 0])
+
+        rotate around the ``(1, 1, 0)`` direction but project the rotation onto the :math:`x`
+        axis
+        >>> geom_xy_x = geom.rotate(45, "xy", what='x')
 
         See Also
         --------
         Quaternion : class to rotate
+        SuperCell.rotate : rotation passed to the contained supercell
         """
         if origin is None:
             origin = [0., 0., 0.]
         elif isinstance(origin, Integral):
             origin = self.axyz(origin)
-        origin = _a.asarrayd(origin)
+        origin = _a.asarrayd(origin).reshape(1, -1)
 
-        if not atoms is None:
+        if atoms is None:
+            if what is None:
+                what = "abc+xyz"
+            atoms = slice(None)
+        else:
+            if what is None:
+                what = "xyz"
             # Only rotate the unique values
             atoms = self.sc2uc(atoms, unique=True)
 
-        if isinstance(v, (str, Integral)):
-            v = direction(v, abc=self.cell, xyz=np.diag([1]*3))
+        if isinstance(v, Integral):
+            v = direction(v, abc=self.cell, xyz=np.diag([1, 1, 1]))
+        elif isinstance(v, str):
+            v = reduce(lambda a, b: a + direction(b, abc=self.cell, xyz=np.diag([1, 1, 1])), v, 0)
 
         # Ensure the normal vector is normalized... (flatten == copy)
         vn = _a.asarrayd(v).flatten()
         vn /= fnorm(vn)
 
         # Rotate by direct call
-        if 'a' in only or 'b' in only or 'c' in only:
-            sc = self.sc.rotate(angle, vn, rad=rad, only=only)
-        else:
-            sc = self.sc.copy()
+        sc = self.sc.rotate(angle, vn, rad=rad, what=what)
 
         # Copy
         xyz = np.copy(self.xyz)
 
-        if 'xyz' in only:
+        idx = []
+        for i, d in enumerate('xyz'):
+            if d in what:
+                idx.append(i)
+
+        # get which coordinates to rotate
+        if idx:
             # Prepare quaternion...
             q = Quaternion(angle, vn, rad=rad)
             q /= q.norm()
             # subtract and add origin, before and after rotation
-            xyz[atoms, :] = q.rotate(xyz[atoms, :] - origin[None, :]) + origin[None, :]
+            xyz[atoms, idx] = (q.rotate(xyz[atoms] - origin) + origin)[:, idx]
 
         return self.__class__(xyz, atoms=self.atoms.copy(), sc=sc)
 
-    def rotate_miller(self, m, v) -> Geometry:
+    def rotate_miller(self, m, v) -> TGeometry:
         """ Align Miller direction along ``v``
 
         Rotate geometry and cell such that the Miller direction
@@ -3059,7 +3092,9 @@ class Geometry(SuperCellChild):
         # Neither of atoms, or isc are `None`, we add the offset to all coordinates
         return self.axyz(atoms) + self.sc.offset(isc)
 
-    def scale(self, scale, what="abc", scale_atoms=True) -> Geometry:
+    def scale(self, scale,
+              what:str ="abc",
+              scale_atoms: bool=True) -> TGeometry:
         """ Scale coordinates and unit-cell to get a new geometry with proper scaling
 
         Parameters
@@ -3071,15 +3106,11 @@ class Geometry(SuperCellChild):
            If three different scale factors are provided, whether each scaling factor
            is to be applied on the corresponding lattice vector ("abc") or on the
            corresponding cartesian coordinate ("xyz").
-        scale_atoms : bool
+        scale_atoms : bool, optional
            whether atoms (basis) should be scaled as well.
         """
         # Ensure we are dealing with a numpy array
         scale = np.asarray(scale)
-        if scale.size == 1:
-            # scaling with a scalar is equivalent to scaling
-            # cartesian coordinates
-            what = "xyz"
 
         # Scale the supercell
         sc = self.sc.scale(scale, what=what)
@@ -3102,6 +3133,8 @@ class Geometry(SuperCellChild):
                 scaled_verts = sc.vertices().reshape(8, 3)
                 scaled_span = scaled_verts.max(axis=0) - scaled_verts.min(axis=0)
                 max_scale = (scaled_span / prev_span).max()
+        else:
+            raise ValueError(f"{self.__class__.__name__}.scale got wrong what argument, must be one of abc|xyz")
 
         if scale_atoms:
             # Atoms are rescaled to the maximum scale factor
@@ -3113,7 +3146,7 @@ class Geometry(SuperCellChild):
 
     def within_sc(self, shapes, isc=None,
                   atoms: Optional[AtomsArg]=None, atoms_xyz=None,
-                  ret_xyz=False, ret_rij=False):
+                  ret_xyz: bool=False, ret_rij: bool=False):
         """ Indices of atoms in a given supercell within a given shape from a given coordinate
 
         This returns a set of atomic indices which are within a
@@ -4498,7 +4531,7 @@ class Geometry(SuperCellChild):
             elif segments == "orbitals":
                 segments = range(self.no)
             elif segments == "all":
-                segments = [np.arange(data.shape[axis])]
+                segments = range(data.shape[axis])
             else:
                 raise ValueError(f"{self.__class__}.apply got wrong argument 'segments'={segments}")
 
@@ -4625,38 +4658,38 @@ class Geometry(SuperCellChild):
                 # Convert value[0] to the direction
                 # The rotate function expects degree
                 ang = angle(values[0], rad=False, in_rad=False)
-                ns._geometry = ns._geometry.rotate(ang, values[1])
+                ns._geometry = ns._geometry.rotate(ang, values[1], what="abc+xyz")
         p.add_argument(*opts('--rotate', '-R'), nargs=2, metavar=('ANGLE', 'DIR'),
                        action=Rotation,
-                       help='Rotate geometry around given axis. ANGLE defaults to be specified in degree. Prefix with "r" for input in radians.')
+                       help='Rotate coordinates and lattice vectors around given axis (x|y|z|a|b|c). ANGLE defaults to be specified in degree. Prefix with "r" for input in radians.')
 
         if not limit_args:
             class RotationX(argparse.Action):
                 def __call__(self, parser, ns, value, option_string=None):
                     # The rotate function expects degree
                     ang = angle(value, rad=False, in_rad=False)
-                    ns._geometry = ns._geometry.rotate(ang, "x")
+                    ns._geometry = ns._geometry.rotate(ang, "x", what="abc+xyz")
             p.add_argument(*opts('--rotate-x', '-Rx'), metavar='ANGLE',
                            action=RotationX,
-                           help='Rotate geometry around first cell vector. ANGLE defaults to be specified in degree. Prefix with "r" for input in radians.')
+                           help='Rotate coordinates and lattice vectors around x axis. ANGLE defaults to be specified in degree. Prefix with "r" for input in radians.')
 
             class RotationY(argparse.Action):
                 def __call__(self, parser, ns, value, option_string=None):
                     # The rotate function expects degree
                     ang = angle(value, rad=False, in_rad=False)
-                    ns._geometry = ns._geometry.rotate(ang, "y")
+                    ns._geometry = ns._geometry.rotate(ang, "y", what="abc+xyz")
             p.add_argument(*opts('--rotate-y', '-Ry'), metavar='ANGLE',
                            action=RotationY,
-                           help='Rotate geometry around second cell vector. ANGLE defaults to be specified in degree. Prefix with "r" for input in radians.')
+                           help='Rotate coordinates and lattice vectors around y axis. ANGLE defaults to be specified in degree. Prefix with "r" for input in radians.')
 
             class RotationZ(argparse.Action):
                 def __call__(self, parser, ns, value, option_string=None):
                     # The rotate function expects degree
                     ang = angle(value, rad=False, in_rad=False)
-                    ns._geometry = ns._geometry.rotate(ang, "z")
+                    ns._geometry = ns._geometry.rotate(ang, "z", what="abc+xyz")
             p.add_argument(*opts('--rotate-z', '-Rz'), metavar='ANGLE',
                            action=RotationZ,
-                           help='Rotate geometry around third cell vector. ANGLE defaults to be specified in degree. Prefix with "r" for input in radians.')
+                           help='Rotate coordinates and lattice vectors around z axis. ANGLE defaults to be specified in degree. Prefix with "r" for input in radians.')
 
         # Reduce size of geometry
         class ReduceSub(argparse.Action):

--- a/sisl/io/tbtrans/tests/test_tbt.py
+++ b/sisl/io/tbtrans/tests/test_tbt.py
@@ -261,12 +261,12 @@ def test_1_graphene_all_content(sisl_files):
     assert orb_right[d2, d1.T].sum() == pytest.approx(-orb_right[d1, d2.T].sum())
 
     orb_left.sort_indices()
-    atom_left = tbt.bond_transmission(E, left, only='all')
+    atom_left = tbt.bond_transmission(E, left, what='all')
     atom_left.sort_indices()
     assert np.allclose(orb_left.data, atom_left.data)
     assert np.allclose(orb_left.data, tbt.sparse_orbital_to_atom(orb_left).data)
     orb_right.sort_indices()
-    atom_right = tbt.bond_transmission(E, right, only='all')
+    atom_right = tbt.bond_transmission(E, right, what='all')
     atom_right.sort_indices()
     assert np.allclose(orb_right.data, atom_right.data)
     assert np.allclose(orb_right.data, tbt.sparse_orbital_to_atom(orb_right).data)
@@ -275,7 +275,7 @@ def test_1_graphene_all_content(sisl_files):
     # For 1-orbital systems the activity and non-activity are equivalent
     assert np.allclose(tbt.atom_transmission(E, left), tbt.atom_transmission(E, left, activity=False))
     tbt.vector_transmission(E, left)
-    assert np.allclose(tbt.sparse_atom_to_vector(atom_left) / 2, tbt.vector_transmission(E, left, only='all'))
+    assert np.allclose(tbt.sparse_atom_to_vector(atom_left) / 2, tbt.vector_transmission(E, left, what='all'))
 
     # Check COOP curves
     coop = tbt.orbital_COOP(E)
@@ -369,9 +369,9 @@ def test_1_graphene_sparse_current(sisl_files, sisl_tmp):
     tbt = sisl.get_sile(sisl_files(_dir, '1_graphene_all.TBT.nc'))
     J = tbt.orbital_current()
     assert np.allclose(J.data, 0)
-    J = tbt.orbital_current(only="+")
+    J = tbt.orbital_current(what="+")
     assert np.allclose(J.data, 0)
-    J = tbt.orbital_current(only="-")
+    J = tbt.orbital_current(what="-")
     assert np.allclose(J.data, 0)
     J = tbt.bond_current()
     assert np.allclose(J.data, 0)

--- a/sisl/io/tests/test_object.py
+++ b/sisl/io/tests/test_object.py
@@ -223,7 +223,7 @@ class TestObject:
             assert isinstance(sile, obj)
 
     def test_write(self, sisl_tmp, sisl_system):
-        G = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :])
+        G = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :], what="xyz+abc")
         G.set_nsc([1, 1, 1])
         f = sisl_tmp("test_write", _dir)
         for sile in get_siles(["write_geometry"]):
@@ -235,7 +235,7 @@ class TestObject:
 
     @pytest.mark.parametrize("sile", _my_intersect(["read_geometry"], ["write_geometry"]))
     def test_read_write_geometry(self, sisl_tmp, sisl_system, sile):
-        G = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :])
+        G = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :], what="xyz+abc")
         G.set_nsc([1, 1, 1])
         f = sisl_tmp("test_read_write_geom.win", _dir)
         # These files does not store the atomic species
@@ -266,7 +266,7 @@ class TestObject:
         if issubclass(sile, _gfSileSiesta):
             return
 
-        G = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :])
+        G = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :], what="xyz+abc")
         H = Hamiltonian(G)
         H.construct([[0.1, 1.45], [0.1, -2.7]])
         f = sisl_tmp("test_read_write_hamiltonian.win", _dir)
@@ -290,7 +290,7 @@ class TestObject:
 
     @pytest.mark.parametrize("sile", _my_intersect(["read_density_matrix"], ["write_density_matrix"]))
     def test_read_write_density_matrix(self, sisl_tmp, sisl_system, sile):
-        G = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :])
+        G = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :], what="xyz+abc")
         DM = DensityMatrix(G, orthogonal=True)
         DM.construct([[0.1, 1.45], [0.1, -2.7]])
         f = sisl_tmp("test_read_write_density_matrix.win", _dir)
@@ -314,7 +314,7 @@ class TestObject:
 
     @pytest.mark.parametrize("sile", _my_intersect(["read_energy_density_matrix"], ["write_energy_density_matrix"]))
     def test_read_write_energy_density_matrix(self, sisl_tmp, sisl_system, sile):
-        G = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :])
+        G = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :], what="xyz+abc")
         EDM = EnergyDensityMatrix(G, orthogonal=True)
         EDM.construct([[0.1, 1.45], [0.1, -2.7]])
         f = sisl_tmp("test_read_write_energy_density_matrix.win", _dir)
@@ -341,7 +341,7 @@ class TestObject:
         if issubclass(sile, _gfSileSiesta):
             return
 
-        G = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :])
+        G = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :], what="xyz+abc")
         H = Hamiltonian(G, orthogonal=False)
         H.construct([[0.1, 1.45], [(0.1, 1), (-2.7, 0.1)]])
         f = sisl_tmp("test_read_write_hamiltonian_overlap.win", _dir)
@@ -366,7 +366,7 @@ class TestObject:
     @pytest.mark.filterwarnings("ignore", message="*gridncSileSiesta.read_grid cannot determine")
     @pytest.mark.parametrize("sile", _my_intersect(["read_grid"], ["write_grid"]))
     def test_read_write_grid(self, sisl_tmp, sisl_system, sile):
-        g = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :])
+        g = sisl_system.g.rotate(-30, sisl_system.g.cell[2, :], what="xyz+abc")
         G = Grid([10, 11, 12])
         G[:, :, :] = np.random.rand(10, 11, 12)
 

--- a/sisl/messages.py
+++ b/sisl/messages.py
@@ -28,7 +28,7 @@ from ._environ import get_environ_variable
 
 
 __all__ = ['SislDeprecation', 'SislInfo', 'SislWarning', 'SislException', 'SislError']
-__all__ += ['warn', 'info', 'deprecate', "deprecate_method"]
+__all__ += ['warn', 'info', 'deprecate', "deprecate_method", "deprecate_argument"]
 __all__ += ['progressbar', 'tqdm_eta']
 
 # The local registry for warnings issued
@@ -79,6 +79,23 @@ def deprecate(message, from_version=None):
     if from_version is not None:
         message = f"{message} [>={from_version}]"
     warnings.warn_explicit(message, SislDeprecation, 'dep', 0, registry=_sisl_warn_registry)
+
+
+@set_module("sisl")
+def deprecate_argument(old, new, message, from_version=None):
+    """ Decorator for deprecating `old` argument, and replacing it with `new`
+
+    The old keyword argument is still retained.
+    """
+    def deco(func):
+        @wraps(func)
+        def wrapped(*args, **kwargs):
+            if old in kwargs:
+                deprecate(f"{func.__name__} {message}", from_version=from_version)
+                kwargs[new] = kwargs.pop(old)
+            return func(*args, **kwargs)
+        return wrapped
+    return deco
 
 
 @set_module("sisl")

--- a/sisl/messages.py
+++ b/sisl/messages.py
@@ -54,8 +54,8 @@ class SislWarning(SislException, UserWarning):
 
 
 @set_module("sisl")
-class SislDeprecation(SislWarning, DeprecationWarning):
-    """ Sisl deprecation warnings """
+class SislDeprecation(SislWarning, FutureWarning):
+    """ Sisl deprecation warnings for end-users """
     pass
 
 

--- a/sisl/supercell.py
+++ b/sisl/supercell.py
@@ -643,7 +643,7 @@ class SuperCell:
         v     : array_like or str or int
              the vector around the rotation is going to happen
              ``v = [1,0,0]`` will rotate in the ``yz`` plane
-        what : ("abc"), str, optional
+        what : combination of ``"abc"``, str, optional
              only rotate the designated cell vectors.
         rad : bool, optional
              Whether the angle is in radians (True) or in degrees (False)

--- a/sisl/supercell.py
+++ b/sisl/supercell.py
@@ -13,6 +13,7 @@ from numbers import Integral
 import numpy as np
 from numpy import ndarray, dot
 
+from .messages import deprecate_argument
 from ._internal import set_module
 from . import _plot as plt
 from . import _array as _a
@@ -624,7 +625,12 @@ class SuperCell:
                                  "float, or an array of values according to axes argument.")
         return self.cell[axes] * (length / self.length[axes]).reshape(-1, 1)
 
-    def rotate(self, angle, v, only='abc', rad=False):
+    @deprecate_argument("only", "what",
+                        "argument only has been deprecated in favor of what, please update your code.",
+                        "0.14.0")
+    def rotate(self, angle, v,
+               rad: bool=False,
+               what: str="abc") -> TSuperCell:
         """ Rotates the supercell, in-place by the angle around the vector
 
         One can control which cell vectors are rotated by designating them
@@ -634,26 +640,30 @@ class SuperCell:
         ----------
         angle : float
              the angle of which the geometry should be rotated
-        v     : array_like
+        v     : array_like or str or int
              the vector around the rotation is going to happen
              ``v = [1,0,0]`` will rotate in the ``yz`` plane
+        what : ("abc"), str, optional
+             only rotate the designated cell vectors.
         rad : bool, optional
              Whether the angle is in radians (True) or in degrees (False)
-        only : ('abc'), str, optional
-             only rotate the designated cell vectors.
         """
+        if isinstance(v, Integral):
+            v = direction(v, abc=self.cell, xyz=np.diag([1, 1, 1]))
+        elif isinstance(v, str):
+            v = reduce(lambda a, b: a + direction(b, abc=self.cell, xyz=np.diag([1, 1, 1])), v, 0)
         # flatten => copy
         vn = _a.asarrayd(v).flatten()
         vn /= fnorm(vn)
         q = Quaternion(angle, vn, rad=rad)
         q /= q.norm()  # normalize the quaternion
         cell = np.copy(self.cell)
-        if 'a' in only:
-            cell[0, :] = q.rotate(self.cell[0, :])
-        if 'b' in only:
-            cell[1, :] = q.rotate(self.cell[1, :])
-        if 'c' in only:
-            cell[2, :] = q.rotate(self.cell[2, :])
+        idx = []
+        for i, d in enumerate('abc'):
+            if d in what:
+                idx.append(i)
+        if idx:
+            cell[idx, :] = q.rotate(self.cell[idx, :])
         return self.copy(cell)
 
     def offset(self, isc=None):

--- a/sisl/tests/test_geometry.py
+++ b/sisl/tests/test_geometry.py
@@ -9,7 +9,7 @@ import math as m
 import numpy as np
 
 import sisl.geom as sisl_geom
-from sisl import SislWarning, SislError
+from sisl import SislWarning, SislError, SislDeprecation
 from sisl import Cube, Sphere
 from sisl import Geometry, Atom, SuperCell
 
@@ -389,48 +389,56 @@ class TestGeometry:
         assert np.allclose([1, 1, 1], sc.nsc)
         assert len(sc.sc_off) == np.prod(sc.nsc)
 
+    def test_rotate_deprecate(self, setup):
+        rot1 = setup.g.rotate(180, "xz", what="xyz")
+        with pytest.warns(SislDeprecation) as warns:
+            rot2 = setup.g.rotate(180, [1, 0, 1], only="xyz")
+        assert len(warns) == 1
+        assert np.allclose(rot1.cell, rot2.cell)
+        assert np.allclose(rot1.xyz, rot2.xyz)
+
     def test_rotation1(self, setup):
-        rot = setup.g.rotate(180, [0, 0, 1])
+        rot = setup.g.rotate(180, [0, 0, 1], what="xyz+abc")
         rot.sc.cell[2, 2] *= -1
         assert np.allclose(-rot.sc.cell, setup.g.sc.cell)
         assert np.allclose(-rot.xyz, setup.g.xyz)
 
-        rot = setup.g.rotate(np.pi, [0, 0, 1], rad=True)
+        rot = setup.g.rotate(np.pi, [0, 0, 1], rad=True, what="xyz+abc")
         rot.sc.cell[2, 2] *= -1
         assert np.allclose(-rot.sc.cell, setup.g.sc.cell)
         assert np.allclose(-rot.xyz, setup.g.xyz)
 
-        rot = rot.rotate(180, [0, 0, 1])
+        rot = rot.rotate(180, "z", what="xyz+abc")
         rot.sc.cell[2, 2] *= -1
         assert np.allclose(rot.sc.cell, setup.g.sc.cell)
         assert np.allclose(rot.xyz, setup.g.xyz)
 
     def test_rotation2(self, setup):
-        rot = setup.g.rotate(180, [0, 0, 1], only='abc')
+        rot = setup.g.rotate(180, "z", what='abc')
         rot.sc.cell[2, 2] *= -1
         assert np.allclose(-rot.sc.cell, setup.g.sc.cell)
         assert np.allclose(rot.xyz, setup.g.xyz)
 
-        rot = setup.g.rotate(np.pi, [0, 0, 1], rad=True, only='abc')
+        rot = setup.g.rotate(np.pi, [0, 0, 1], rad=True, what='abc')
         rot.sc.cell[2, 2] *= -1
         assert np.allclose(-rot.sc.cell, setup.g.sc.cell)
         assert np.allclose(rot.xyz, setup.g.xyz)
 
-        rot = rot.rotate(180, [0, 0, 1], only='abc')
+        rot = rot.rotate(180, [0, 0, 1], what='abc')
         rot.sc.cell[2, 2] *= -1
         assert np.allclose(rot.sc.cell, setup.g.sc.cell)
         assert np.allclose(rot.xyz, setup.g.xyz)
 
     def test_rotation3(self, setup):
-        rot = setup.g.rotate(180, [0, 0, 1], only='xyz')
+        rot = setup.g.rotate(180, [0, 0, 1], what='xyz')
         assert np.allclose(rot.sc.cell, setup.g.sc.cell)
         assert np.allclose(-rot.xyz, setup.g.xyz)
 
-        rot = setup.g.rotate(np.pi, [0, 0, 1], rad=True, only='xyz')
+        rot = setup.g.rotate(np.pi, [0, 0, 1], rad=True, what='xyz')
         assert np.allclose(rot.sc.cell, setup.g.sc.cell)
         assert np.allclose(-rot.xyz, setup.g.xyz)
 
-        rot = rot.rotate(180, [0, 0, 1], only='xyz')
+        rot = rot.rotate(180, "z", what='xyz')
         assert np.allclose(rot.sc.cell, setup.g.sc.cell)
         assert np.allclose(rot.xyz, setup.g.xyz)
 

--- a/sisl/tests/test_sgeom.py
+++ b/sisl/tests/test_sgeom.py
@@ -1,4 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import pytest
@@ -29,7 +28,7 @@ def setup():
             def sg_g(**kwargs):
                 kwargs['ret_geometry'] = True
                 if 'geometry' not in kwargs:
-                    kwargs['geometry'] = self.g
+                    kwargs['geometry'] = self.g.copy()
                 return sgeom(**kwargs)
 
             self.sg_g = sg_g
@@ -37,7 +36,7 @@ def setup():
             def sg_mol(**kwargs):
                 kwargs['ret_geometry'] = True
                 if 'geometry' not in kwargs:
-                    kwargs['geometry'] = self.mol
+                    kwargs['geometry'] = self.mol.copy()
                 return sgeom(**kwargs)
 
             self.sg_mol = sg_mol
@@ -119,11 +118,13 @@ class TestGeometry:
             assert len(g) == l
 
     def test_rotation1(self, setup):
+        print(setup.g.cell)
         rot = setup.sg_g(argv='--rotate 180 z'.split())
         rot.sc.cell[2, 2] *= -1
         assert np.allclose(-rot.sc.cell, setup.g.sc.cell)
         assert np.allclose(-rot.xyz, setup.g.xyz)
 
+        print(setup.g.cell)
         rot = setup.sg_g(argv='--rotate-z 180'.split())
         rot.sc.cell[2, 2] *= -1
         assert np.allclose(-rot.sc.cell, setup.g.sc.cell)

--- a/sisl/tests/test_supercell.py
+++ b/sisl/tests/test_supercell.py
@@ -341,7 +341,7 @@ class TestSuperCell:
         gbig = g.repeat(40, 0).repeat(40, 1)
         assert g.sc.parallel(gbig.sc)
         assert gbig.sc.parallel(g.sc)
-        g = g.rotate(90, g.cell[0, :])
+        g = g.rotate(90, g.cell[0, :], what="abc")
         assert not g.sc.parallel(gbig.sc)
 
     def test_tile_multiply_orthogonal(self):

--- a/sisl/utils/misc.py
+++ b/sisl/utils/misc.py
@@ -162,7 +162,7 @@ def direction(d, abc=None, xyz=None):
 
     Returns
     -------
-    index : int 
+    index : int
        index of the Cartesian coordinate system, only if both `abc` and `xyz` are none
        or if the requested direction is not present, only returned if the corresponding direction
        is none


### PR DESCRIPTION
This is to unify interfaces that has these kinds of arguments. It affects Geometry|SuperCell.rotate and some tbtrans siles.

To accommodate backwards compatibility for some time I have added a function to decorate methods enabling a keyword argument and replacing the *new* keyword argument with the old keyword argument. I believe users who use the old argument are not aware of the new one and hence it makes more sense.
A deprecation warning is also issued.

The default for Geometry.rotate is now also changed depending on whether atoms argument is supplied.
- atoms is None: what="xyz+abc"
- else what="xyz" when doing sub-rotations it makes more sense to only rotate the atomic coordinates, while rotations of everything makes more sense to also rotate the lattice vectors.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #541
 - [x] Tests added
 - [x] Documentation for functionality
 - [x] User visible changes (including notable bug fixes) are documented in `CHANGELOG`
@tfrederiksen could you please have a look whether this is ok? :)
