### PR TITLE
aniSileSiesta part 2

### DIFF
--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -4891,6 +4891,11 @@ class Geometry(SuperCellChild):
 class GeometryCollection(Collection):
     """ Container for multiple geometries in a single object """
 
+    def __init__(self, geometries):
+        if isinstance(geometries, Geometry):
+            geometries = [geometries]
+        super().__init__(geometries)
+
     @property
     def geometries(self) -> List[Geometry]:
         return self.data

--- a/sisl/io/siesta/ani.py
+++ b/sisl/io/siesta/ani.py
@@ -4,6 +4,7 @@
 """
 Sile object for reading ANI files
 """
+from sisl import GeometryCollection
 from ..xyz import xyzSile
 from ..sile import add_sile
 from sisl._internal import set_module
@@ -15,8 +16,13 @@ __all__ = ["aniSileSiesta"]
 @set_module("sisl.io.siesta")
 class aniSileSiesta(xyzSile):
 
-    def read_geometry(*args, all=True, **kwargs):
-        return super().read_geometry(*args, all=all, **kwargs)
-
+    def read_geometry(self, *args, **kwargs):
+        if 'start' in kwargs or 'stop' in kwargs or 'step' in kwargs:
+            R = super().read_geometry(*args, **kwargs)
+        elif 'all' not in kwargs:
+            R = super().read_geometry(*args, all=True, **kwargs)
+        else:
+            R = super().read_geometry(*args, **kwargs)
+        return GeometryCollection(R)
 
 add_sile('ANI', aniSileSiesta, gzip=True)

--- a/sisl/io/siesta/tests/test_ani.py
+++ b/sisl/io/siesta/tests/test_ani.py
@@ -1,0 +1,55 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import pytest
+import os.path as osp
+import numpy as np
+from sisl.io.siesta import aniSileSiesta
+from sisl import Geometry, GeometryCollection
+
+pytestmark = [pytest.mark.io, pytest.mark.siesta]
+_dir = osp.join('sisl', 'io', 'siesta')
+
+def test_ani(sisl_tmp):
+    f = sisl_tmp('sisl.ANI', _dir)
+    open(f, 'w').write("""1
+
+C   0.00000000  0.00000000  0.00000000
+2
+
+C   0.00000000  0.00000000  0.00000000
+C   1.000000  0.00000000  0.00000000
+3
+
+C   0.00000000  0.00000000  0.00000000
+C   1.000000  0.00000000  0.00000000
+C   2.00000  0.00000000  0.00000000
+4
+
+C   0.00000000  0.00000000  0.00000000
+C   1.000000  0.00000000  0.00000000
+C   2.00000  0.00000000  0.00000000
+C   3.00000  0.00000000  0.00000000
+""")
+    a = aniSileSiesta(f)
+    g = a.read_geometry()
+    assert isinstance(g, GeometryCollection)
+    assert g[0].na == 1
+    g = a.read_geometry(start=1)
+    assert g[0].na == 2
+    g = a.read_geometry(all=True)
+    assert g[0].na == 1 and g[2].na == 3
+    g = a.read_geometry(start=1, step=1)
+    assert g[0].na == 2 and g[1].na == 3
+    g = a.read_geometry(step=2)
+    assert g[0].na == 1 and g[1].na == 3
+    g = a.read_geometry(stop=2, step=1)
+    assert g[0].na == 1 and g[1].na == 2
+    g = a.read_geometry(start=1, step=None)
+    assert g[0].na == 2 and len(g) == 1
+    g = a.read_geometry(start=1, stop=3, step=1)
+    assert g[1].na == 3 and len(g) == 2
+    g = a.read_geometry(start=1, stop=3, step=2, all=True)
+    assert g[0].na == 1 and len(g) == 4
+
+    g = a.read_geometry(sc=None, atoms=None)

--- a/sisl/io/tests/test_xyz.py
+++ b/sisl/io/tests/test_xyz.py
@@ -70,6 +70,7 @@ def test_xyz_arbitrary(sisl_tmp):
     f = sisl_tmp('ase.xyz', _dir)
     with open(f, 'w') as fh:
         fh.write("""3
+
 C   0.00000000  0.00000000  0.00000000
 C   1.000000  0.00000000  0.00000000
 C   2.00000  0.00000000  0.00000000
@@ -103,12 +104,18 @@ C   2.00000  0.00000000  0.00000000
     g = xyzSile(f).read_geometry(start=1)
     assert g.na == 2
     g = xyzSile(f).read_geometry(all=True)
-    assert g[0].na == 1 and g[-1].na == 3
+    assert g[0].na == 1 and g[2].na == 3
     g = xyzSile(f).read_geometry(start=1, step=1)
-    assert g[0].na == 2 and g[-1].na == 3
+    assert g[0].na == 2 and g[1].na == 3
     g = xyzSile(f).read_geometry(step=2)
-    assert g[0].na == 1 and g[-1].na == 3
+    assert g[0].na == 1 and g[1].na == 3
     g = xyzSile(f).read_geometry(stop=2, step=1)
-    assert g[0].na == 1 and g[-1].na == 2
+    assert g[0].na == 1 and g[1].na == 2
+    g = xyzSile(f).read_geometry(start=1, step=None)
+    assert g.na == 2
+    g = xyzSile(f).read_geometry(start=1, stop=3, step=1)
+    assert g[0].na == 2
+    g = xyzSile(f).read_geometry(start=1, stop=3, step=1, all=True)
+    assert g[0].na == 1
 
     g = xyzSile(f).read_geometry(sc=None, atoms=None)


### PR DESCRIPTION
Some further changes seem needed:
- bugfix for single-entry `GeometryCollection`
- reading ANI file should return a `GeometryCollection`
- more tests

Note that in `ani.py` I think the `all=True` keyword should only be passed to `read_geometry` if the user is not already trying to set any of the keywords `start, stop, step, all`.