### PR TITLE
Bugfix for rotate(..., atoms=list) + additional tests

### DIFF
--- a/sisl/geometry.py
+++ b/sisl/geometry.py
@@ -2346,13 +2346,15 @@ class Geometry(SuperCellChild):
             if d in what:
                 idx.append(i)
 
-        # get which coordinates to rotate
         if idx:
             # Prepare quaternion...
             q = Quaternion(angle, vn, rad=rad)
             q /= q.norm()
             # subtract and add origin, before and after rotation
-            xyz[atoms, idx] = (q.rotate(xyz[atoms] - origin) + origin)[:, idx]
+            rotated = (q.rotate(xyz[atoms] - origin) + origin)
+            # get which coordinates to rotate
+            for i in idx:
+                xyz[atoms, i] = rotated[:, i]
 
         return self.__class__(xyz, atoms=self.atoms.copy(), sc=sc)
 

--- a/sisl/tests/test_geometry.py
+++ b/sisl/tests/test_geometry.py
@@ -442,6 +442,28 @@ class TestGeometry:
         assert np.allclose(rot.sc.cell, setup.g.sc.cell)
         assert np.allclose(rot.xyz, setup.g.xyz)
 
+    def test_rotation4(self, setup):
+        ref = setup.g.tile(2, 0).tile(2, 1)
+
+        rot = ref.rotate(10, "z", atoms=1)
+        assert not np.allclose(ref.xyz[1], rot.xyz[1])
+
+        rot = ref.rotate(10, "z", atoms=[1, 2])
+        assert not np.allclose(ref.xyz[1], rot.xyz[1])
+        assert not np.allclose(ref.xyz[2], rot.xyz[2])
+        assert np.allclose(ref.xyz[3], rot.xyz[3])
+
+        rot = ref.rotate(10, "z", atoms=[1, 2], what='y')
+        assert ref.xyz[1, 0] == rot.xyz[1, 0]
+        assert ref.xyz[1, 1] != rot.xyz[1, 1]
+        assert ref.xyz[1, 2] == rot.xyz[1, 2]
+
+        rot = ref.rotate(10, "z", atoms=[1, 2], what='xy', origin=ref.xyz[2])
+        assert ref.xyz[1, 0] != rot.xyz[1, 0]
+        assert ref.xyz[1, 1] != rot.xyz[1, 1]
+        assert ref.xyz[1, 2] == rot.xyz[1, 2]
+        assert np.allclose(ref.xyz[2], rot.xyz[2])
+
     def test_translate(self, setup):
         t = setup.g.translate([0, 0, 1])
         assert np.allclose(setup.g.xyz[:, 0], t.xyz[:, 0])


### PR DESCRIPTION
I believe to have found a bug related to specifying a subset of atoms for rotation. For instance, before this PR:
```
Python 3.10.6 (main, Nov 14 2022, 16:10:14) [GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sisl
>>> g = sisl.geom.graphene() * (2, 2, 1)
>>> g.rotate(30, 'z', atoms=[1, 2])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".local/lib/python3.10/site-packages/sisl/messages.py", line 96, in wrapped
    return func(*args, **kwargs)
  File ".local/lib/python3.10/site-packages/sisl/geometry.py", line 2355, in rotate
    xyz[atoms, idx] = (q.rotate(xyz[atoms] - origin) + origin)[:, idx]
IndexError: shape mismatch: indexing arrays could not be broadcast together with shapes (2,) (3,) 
```
I added a new test function to expose the above (as well as also testing the `origin` keyword).