### PR TITLE
Wrap fortran files import in try/except block.

### DIFF
--- a/sisl/io/tbtrans/delta.py
+++ b/sisl/io/tbtrans/delta.py
@@ -17,7 +17,10 @@ from sisl.sparse import _ncol_to_indptr
 from sisl.messages import warn, deprecate_argument
 from sisl.unit.siesta import unit_convert
 from ..siesta._help import _csr_to_siesta, _csr_from_sc_off, _mat_spin_convert
-from ..siesta._siesta import siesta_sc_off
+try:
+    from ..siesta._siesta import siesta_sc_off
+except:
+    pass
 
 
 __all__ = ['deltancSileTBtrans']


### PR DESCRIPTION
The rest of files that import fortran modules do this, so I think in this case it should also be done for consistency.
