### PR TITLE
Make documentation tabs more visual

### DIFF
--- a/docs/_static/css/custom_styles.css
+++ b/docs/_static/css/custom_styles.css
@@ -1,0 +1,24 @@
+/*STYLES TO MAKE TABS MORE VISUAL*/
+
+/*The parent container of tabs*/
+.tab-set {
+  border: 1px solid #ccc
+}
+
+/*Individual box of each tab*/
+.tab-set > label {
+  margin-bottom: 0
+}
+
+/*Container appearing below the tabs, with the contents of the active tab*/
+.tab-content {
+  background-color: aliceblue;
+  padding: 20px
+}
+
+/*Initial paragraph of the content. By default there's a top margin 
+ but we already specify a padding of 20 px for the content no matter what the
+ first child is.*/
+.tab-content > p:first-child {
+  margin-top: 0
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -201,6 +201,11 @@ if os.path.exists('_static'):
 else:
     html_static_path = []
 
+# Add any extra style files that we need
+html_css_files = [
+    'css/custom_styles.css',
+]
+
 # If false, no index is generated.
 html_use_modindex = True
 html_use_index = True


### PR DESCRIPTION
It was very difficult to understand where the content of the tabs ended.

By adding some custom CSS, we have made it more intuitive.

Previous layout:

![Screenshot from 2023-04-19 11-09-49](https://user-images.githubusercontent.com/42074085/233033368-a6e7a249-4772-4b01-a109-0499839a0bde.png)

Current layout:

![Screenshot from 2023-04-19 11-21-53](https://user-images.githubusercontent.com/42074085/233033498-cf4aacf0-5def-433d-a0fc-9fc8eebdf975.png)
