### PR TITLE
VASP forces from OUTCAR 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ we hit release version 1.0.0.
 - `BrillouinZone.merge` allows simple merging of several objects, #537
 
 ### Changed
+- `stdoutSileVASP` will not accept `all=` arguments
+- `stdoutSileVASP.read_energy` returns as default the next item (no longer the last)
 - `stdoutSileOrca` will not accept `all=` arguments, see #584
 - `xyzSile` out from sisl will now default to the extended xyz file-format
   Explicitly adding the nsc= value makes it compatible with other exyz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ we hit release version 1.0.0.
 ## [X.Y.Z] - YYYY-MM-DD
 
 ### Added
+- added `read_trajectory` to read cell vectors, atomic positions, and forces from VASP OUTCAR
 - slicing io files multiple output (still WIP), see #584 for details
   Intention is to have all methods use this method for returning
   multiple values, it should streamline the API.

--- a/src/sisl/io/__init__.py
+++ b/src/sisl/io/__init__.py
@@ -141,7 +141,7 @@ VASP
    eigenvalSileVASP
    chgSileVASP
    locpotSileVASP
-   outSileVASP
+   stdoutSileVASP
 
 
 Wannier90

--- a/src/sisl/io/vasp/stdout.py
+++ b/src/sisl/io/vasp/stdout.py
@@ -87,7 +87,7 @@ class stdoutSileVASP(SileVASP):
         -------
         PropertyDict : all energies from the "Free energy of the ion-electron system" segment of VASP output
         """
-        warn(f"{self!s} no longer returns the last entry (but the next in file) as default!")
+        warn(f"{self!s}.read_energy no longer returns the last entry (but the next in file) as default!")
         name_conv = {
             "alpha": "Z",
             "Ewald": "Ewald",

--- a/src/sisl/io/vasp/stdout.py
+++ b/src/sisl/io/vasp/stdout.py
@@ -7,7 +7,7 @@ from .sile import SileVASP
 from ..sile import add_sile, sile_fh_open
 from .._multiple import SileBinder
 
-from sisl.messages import deprecation, warn
+from sisl.messages import deprecation, deprecate_argument
 from sisl.utils import PropertyDict
 from sisl._internal import set_module
 
@@ -59,9 +59,12 @@ class stdoutSileVASP(SileVASP):
 
     @SileBinder()
     @sile_fh_open()
-    @deprecation("all keyword is deprecated, use read_energy[:]() instead", from_version="0.14")
+    @deprecate_argument("all", None, "use read_energy[:]() instead to get all entries", from_version="0.14")
+    @deprecation("WARNING: direct calls to stdoutSileVASP.read_energy() no longer returns the last entry! Now the next block on file is returned.", from_version="0.14")
     def read_energy(self):
-        """ Reads the energy specification from OUTCAR and returns energy dictionary in units of eV
+        """ Reads an energy specification block from OUTCAR
+
+        The function steps to the next occurrence of the "Free energy of the ion-electron system" segment
 
         Notes
         -----
@@ -85,9 +88,9 @@ class stdoutSileVASP(SileVASP):
 
         Returns
         -------
-        PropertyDict : all energies from the "Free energy of the ion-electron system" segment of VASP output
+        PropertyDict : all energies from a single "Free energy of the ion-electron system" segment
         """
-        warn(f"{self!s}.read_energy no longer returns the last entry (but the next in file) as default!")
+
         name_conv = {
             "alpha": "Z",
             "Ewald": "Ewald",
@@ -123,7 +126,6 @@ class stdoutSileVASP(SileVASP):
         v = line.split()
         E.total = float(v[4])
         E.sigma0 = float(v[-1])
-        print(E)
         return E
 
     @SileBinder()

--- a/src/sisl/io/vasp/stdout.py
+++ b/src/sisl/io/vasp/stdout.py
@@ -131,7 +131,18 @@ class stdoutSileVASP(SileVASP):
     @SileBinder()
     @sile_fh_open()
     def read_trajectory(self):
-        f = self.step_to("BASIS-vectors are now", allow_reread=False)[0]
+        """ Reads cell+position+force data from OUTCAR for an ionic trajectory step
+
+        The function steps to the block defined by the "VOLUME and BASIS-vectors are now :"
+        line to first read the cell vectors, then it steps to the "TOTAL-FORCE (eV/Angst)" segment
+        to read the atom positions and forces.
+
+        Returns
+        -------
+        PropertyDict : Trajectory step defined by cell vectors (`.cell`), atom positions (`.xyz`), and forces (`.force`)
+        """
+
+        f = self.step_to("VOLUME and BASIS-vectors are now :", allow_reread=False)[0]
         if not f:
             return None
         for i in range(4):

--- a/src/sisl/io/vasp/tests/test_stdout.py
+++ b/src/sisl/io/vasp/tests/test_stdout.py
@@ -14,9 +14,14 @@ def test_diamond_outcar_energies(sisl_files):
     f = sisl_files(_dir, 'diamond', 'OUTCAR')
     f = stdoutSileVASP(f)
 
-    E = f.read_energy()
-    Eall = f.read_energy(all=True)
+    E0 = f.read_energy()
+    E = f.read_energy[-1]()
+    Eall = f.read_energy[:]()
 
+    assert E0.sigma0 == 0.8569373 # first block
+    assert E.sigma0 == -18.18677613 # last block
+
+    assert E0 == Eall[0]
     assert E == Eall[-1]
     assert len(Eall) > 1
     assert f.completed()

--- a/src/sisl/io/vasp/tests/test_stdout.py
+++ b/src/sisl/io/vasp/tests/test_stdout.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import pytest
 import os.path as osp
-from sisl.io.vasp.stdout import *
+from sisl.io.vasp.stdout import stdoutSileVASP
 import numpy as np
 
 pytestmark = [pytest.mark.io, pytest.mark.vasp]
@@ -35,3 +35,60 @@ def test_diamond_outcar_completed(sisl_files):
     f = stdoutSileVASP(f)
 
     assert f.completed()
+
+
+def test_diamond_outcar_trajectory(sisl_files):
+    f = sisl_files(_dir, 'diamond', 'OUTCAR')
+    f = stdoutSileVASP(f)
+
+    step = f.read_trajectory()
+
+    assert step.xyz[0, 1] == 0.0
+    assert step.xyz[1, 1] == 0.89250
+    assert step.force[0, 1] == 0.0
+    assert step.force[1, 0] == 0.0
+
+    traj = f.read_trajectory[:]()
+    assert len(traj) == 1
+
+
+def test_graphene_relax_outcar_trajectory(sisl_files):
+    f = sisl_files(_dir, 'graphene_relax', 'OUTCAR')
+    f = stdoutSileVASP(f)
+
+    step = f.read_trajectory[9]()
+    assert step.cell[0, 0] == 2.462060590
+    assert step.cell[1, 0] == -1.231030295
+    assert step.cell[2, 2] == 9.804915686
+    assert step.force[0, 2] == -0.006138
+    assert step.force[1, 2] == 0.006138
+
+    traj = f.read_trajectory[:]()
+    assert len(traj) == 10
+    assert traj[0].cell[0, 0] == 2.441046239
+    assert traj[0].xyz[0, 2] == 0.00000
+    assert traj[0].xyz[1, 2] == 0.20000
+    assert traj[0].force[0, 2] == 3.448038
+    assert traj[0].force[1, 2] == -3.448038
+    assert traj[-1].cell[2, 2] == 9.804915686
+    assert traj[-1].xyz[1, 2] == -0.00037
+    assert traj[-1].force[0, 2] == -0.006138
+    assert traj[-1].force[1, 2] == 0.006138
+
+
+def test_graphene_md_outcar_trajectory(sisl_files):
+    f = sisl_files(_dir, 'graphene_md', 'OUTCAR')
+    f = stdoutSileVASP(f)
+
+    step = f.read_trajectory[99]()
+    assert step.xyz[0, 0] == 0.09703
+    assert step.force[0, 2] == -0.278082
+
+    traj = f.read_trajectory[:]()
+    assert len(traj) == 100
+    assert traj[0].xyz[0, 0] == 0.12205
+    assert traj[0].xyz[1, 0] == 0.09520
+    assert traj[0].force[0, 1] == -0.017766
+    assert traj[0].force[1, 1] == 0.017766
+    assert traj[-1].xyz[0, 0] == 0.09703
+    assert traj[-1].force[0, 2] == -0.278082


### PR DESCRIPTION
Nothing fancy, but this PR enables users to read atomic positions and forces from VASP (eg., in a relaxation run) from the OUTCAR file

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [x] Tests added
 - [x] Documentation for functionality
 - [x] User visible changes (including notable bug fixes) are documented in `CHANGELOG`
