### PR TITLE
cleaned the procedure for locating maxR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ we hit release version 1.0.0.
 
 ### Changed
 - bumped Python requirement to >=3.8
+- orbitals `R` arguments will now by default determine the minimal radii
+  that contains 99.99% of the function integrand. The argument now
+  accepts values -1:0 which is a fraction of the integrand that the function
+  should contain, a positive value will explicitly set the range #574
 - Added printout of the removed couplings in the `RecursiveSI`
 - `SuperCell` class is officially deprecated in favor of `Lattice`, see #95 for details
   The old class will still be accessible and usable for some time (at least a year)

--- a/src/sisl/orbital.py
+++ b/src/sisl/orbital.py
@@ -770,7 +770,7 @@ class SphericalOrbital(Orbital):
 
     def copy(self):
         """ Create an exact copy of this object """
-        return self.__class__(self.l, self._radial, self.q0, self.tag)
+        return self.__class__(self.l, self._radial, R=self.R, q0=self.q0, tag=self.tag)
 
     def equal(self, other, psi=False, radial=False):
         """ Compare two orbitals by comparing their radius, and possibly the radial and psi functions
@@ -1328,7 +1328,7 @@ class HydrogenicOrbital(AtomicOrbital):
 
     def copy(self):
         """ Create an exact copy of this object """
-        return self.__class__(self.n, self.l, self.m, self._Z, q0=self.q0, tag=self.tag)
+        return self.__class__(self.n, self.l, self.m, self._Z, R=self.R, q0=self.q0, tag=self.tag)
 
     def _radial(self, r):
         r""" Radial functional for the Hydrogenic orbital """
@@ -1375,7 +1375,7 @@ class _ExponentialOrbital(Orbital):
         args = list(args)
 
         # Extract shell information
-        n = kwargs.get("n", None)
+        n = kwargs.pop("n", None)
         l = kwargs.pop("l", None)
         m = kwargs.pop("m", None)
         alpha = kwargs.pop("alpha", None)
@@ -1440,7 +1440,7 @@ class _ExponentialOrbital(Orbital):
 
     def copy(self):
         """ Create an exact copy of this object """
-        return self.__class__(n=self.n, l=self.l, m=self.m, R=self.R, alpha=self.alpha, coeff=self.coeff, q0=self.q0, tag=self.tag)
+        return self.__class__(n=self.n, l=self.l, m=self.m, alpha=self.alpha, coeff=self.coeff, R=self.R, q0=self.q0, tag=self.tag)
 
     def __str__(self):
         """ A string representation of the object """

--- a/src/sisl/tests/test_orbital.py
+++ b/src/sisl/tests/test_orbital.py
@@ -154,7 +154,7 @@ class Test_sphericalorbital:
     def test_radial_func1(self):
         r = np.linspace(0, 4, 300)
         f = np.exp(-r)
-        o = SphericalOrbital(1, (r, f))
+        o = SphericalOrbital(1, (r, f), R=4.)
         str(o)
         def i_univariate(r, f):
             return interp.UnivariateSpline(r, f, k=5, s=0, ext=1, check_finite=False)

--- a/src/sisl/tests/test_orbital.py
+++ b/src/sisl/tests/test_orbital.py
@@ -53,6 +53,12 @@ class Test_orbital:
         assert orb == orb.copy()
         assert orb != 1.
 
+    def test_copy(self):
+        orb = Orbital(1.)
+        assert orb.R == orb.copy().R
+        orb = Orbital(-1.)
+        assert orb.R == orb.copy().R
+
     def test_psi1(self):
         # Orbital does not have radial part
         with pytest.raises(NotImplementedError):
@@ -101,6 +107,14 @@ class Test_sphericalorbital:
         str(orb)
         orb = SphericalOrbital(1, rf, tag='none')
         str(orb)
+
+    def test_copy(self):
+        rf = r_f(6)
+        orb = SphericalOrbital(1, rf, R=2.)
+        assert orb.R == orb.copy().R
+        assert orb.R == pytest.approx(2.)
+        orb = SphericalOrbital(1, rf)
+        assert orb.R == orb.copy().R
 
     def test_set_radial1(self):
         rf = r_f(6)
@@ -312,6 +326,14 @@ class Test_atomicorbital:
         with pytest.raises(ValueError):
             AtomicOrbital(5, _max_l + 1, 0)
 
+    def test_copy(self):
+        rf = r_f(6)
+        orb = AtomicOrbital('pzP', rf, R=2.)
+        assert orb.R == orb.copy().R
+        assert orb.R == pytest.approx(2.)
+        orb = AtomicOrbital('pzP', rf)
+        assert orb.R == orb.copy().R
+
     def test_radial1(self):
         rf = r_f(6)
         r = np.linspace(0, 6, 100)
@@ -358,6 +380,22 @@ class Test_hydrogenicorbital:
     def test_init(self):
         orb = HydrogenicOrbital(2, 1, 0, 3.2)
 
+    def test_basic1(self):
+        orb = HydrogenicOrbital(2, 1, 0, 3.2, R=4.)
+        assert orb.R == orb.copy().R
+        assert orb.R == pytest.approx(4.)
+        orb = HydrogenicOrbital(2, 1, 0, 3.2)
+        assert orb.R == orb.copy().R
+
+    def test_copy(self):
+        orb = HydrogenicOrbital(2, 1, 0, 3.2, tag='test', q0=2.5)
+        orb2 = orb.copy()
+        assert orb.n == orb2.n
+        assert orb.l == orb2.l
+        assert orb.m == orb2.m
+        assert orb.q0 == orb2.q0
+        assert orb.tag == orb2.tag
+
     def test_normalization(self):
         for n in range(6):
             zeff = n * 0.9
@@ -377,15 +415,6 @@ class Test_hydrogenicorbital:
                     g = orb.toGrid(0.1)
                     I = (g.grid ** 2).sum() * g.dvolume
                     assert abs(I - 1) < 1e-3
-
-    def test_copy(self):
-        orb = HydrogenicOrbital(2, 1, 0, 3.2, tag='test', q0=2.5)
-        orb2 = orb.copy()
-        assert orb.n == orb2.n
-        assert orb.l == orb2.l
-        assert orb.m == orb2.m
-        assert orb.q0 == orb2.q0
-        assert orb.tag == orb2.tag
 
     def test_pickle(self):
         import pickle as p
@@ -408,6 +437,15 @@ class Test_GTO:
         coeff = [0.1, 0.44]
         orb = GTOrbital(2, 1, 0, alpha, coeff)
         assert orb.R > 0
+
+    def test_copy(self):
+        alpha = [1, 2]
+        coeff = [0.1, 0.44]
+        orb = GTOrbital(2, 1, 0, alpha, coeff, R=4.)
+        assert orb.R == orb.copy().R
+        assert orb.R == pytest.approx(4.)
+        orb = GTOrbital(2, 1, 0, alpha, coeff)
+        assert orb.R == orb.copy().R
 
     def test_gto_funcs(self):
         alpha = [0.1688, 0.6239, 3.425]
@@ -433,6 +471,15 @@ class Test_STO:
         coeff = [0.1, 0.44]
         orb = STOrbital(2, 1, 0, alpha, coeff)
         assert orb.R > 0
+
+    def test_copy(self):
+        alpha = [1, 2]
+        coeff = [0.1, 0.44]
+        orb = STOrbital(2, 1, 0, alpha, coeff, R=4.)
+        assert orb.R == orb.copy().R
+        assert orb.R == pytest.approx(4.)
+        orb = STOrbital(2, 1, 0, alpha, coeff)
+        assert orb.R == orb.copy().R
 
     def test_sto_funcs(self):
         alpha = [0.1688, 0.6239, 3.425]

--- a/src/sisl/tests/test_orbital.py
+++ b/src/sisl/tests/test_orbital.py
@@ -190,7 +190,7 @@ class Test_sphericalorbital:
     def test_same1(self):
         rf = r_f(6)
         o0 = SphericalOrbital(0, rf)
-        o1 = Orbital(5.0)
+        o1 = Orbital(o0.R)
         assert o0.equal(o1)
         assert not o0.equal(Orbital(3.))
 
@@ -359,11 +359,11 @@ class Test_hydrogenicorbital:
         orb = HydrogenicOrbital(2, 1, 0, 3.2)
 
     def test_normalization(self):
-        x = np.linspace(0, 10, 1000)
         for n in range(6):
             zeff = n * 0.9
             for l in range(n):
                 orb = HydrogenicOrbital(n, l, 0, zeff)
+                x = np.linspace(0, orb.R, 1000, endpoint=True)
                 Rnl = orb.radial(x)
                 I = np.trapz(x ** 2 * Rnl ** 2, x=x)
                 assert abs(I - 1) < 1e-4
@@ -407,12 +407,14 @@ class Test_GTO:
         alpha = [1, 2]
         coeff = [0.1, 0.44]
         orb = GTOrbital(2, 1, 0, alpha, coeff)
+        assert orb.R > 0
 
     def test_gto_funcs(self):
         alpha = [0.1688, 0.6239, 3.425]
         coeff = [0.4, 0.7, 1.3]
         x = np.linspace(0, 10, 1000)
         orb = GTOrbital(2, 1, 0, alpha, coeff, R=x[-1])
+        assert orb.R == pytest.approx(x[-1])
         Rnl = orb.radial(x)
 
         R = np.random.rand(10, 3)
@@ -430,12 +432,14 @@ class Test_STO:
         alpha = [1, 2]
         coeff = [0.1, 0.44]
         orb = STOrbital(2, 1, 0, alpha, coeff)
+        assert orb.R > 0
 
     def test_sto_funcs(self):
         alpha = [0.1688, 0.6239, 3.425]
         coeff = [0.4, 0.7, 1.3]
         x = np.linspace(0, 10, 1000)
         orb = STOrbital(2, 1, 0, alpha, coeff, R=x[-1])
+        assert orb.R == pytest.approx(x[-1])
         Rnl = orb.radial(x)
 
         R = np.random.rand(10, 3)


### PR DESCRIPTION
Instead of searching for a 0 in the radial function we now search for an integration that contians 99.99% of the radial function.
The integration uses the trapezoid integration mechanism with f**2*r**2 as that should be normalized for a
radial function.

This should make it much more stable against different radial function arguments and produce more accurate ranges for the orbitals.

Now a warning will be issued when the routine cannot determine a correct R (based on inputs).

Ensured that all orbitals with radial functions
can pre-calculate the R in case user did not supply it. One can always forcefully set it by supplying it.

<!-- Feel free to remove check-list items aren't relevant to your change -->

@sofiasanz @tfrederiksen could you please have a look here, this should better adapt the R discovery of your `HydrogenicOrbital`

 - [X] Closes #574
 - [x] Tests added
 - [x] Documentation for functionality
 - [x] User visible changes (including notable bug fixes) are documented in `CHANGELOG`
