### PR TITLE
Negative start/stop/step in sile_read_multiple

### DIFF
--- a/src/sisl/io/openmx/md.py
+++ b/src/sisl/io/openmx/md.py
@@ -16,8 +16,8 @@ __all__ = ["mdSileOpenMX"]
 @set_module("sisl.io.openmx")
 class mdSileOpenMX(xyzSile, SileOpenMX):
 
-    def read_geometry(self, *args, all=True, **kwargs):
-        return super().read_geometry(*args, all=all, **kwargs)
+    def read_geometry(self, *args, **kwargs):
+        return super().read_geometry(*args, **kwargs)
 
 
 add_sile('md', mdSileOpenMX, gzip=True)

--- a/src/sisl/io/openmx/md.py
+++ b/src/sisl/io/openmx/md.py
@@ -15,9 +15,8 @@ __all__ = ["mdSileOpenMX"]
 
 @set_module("sisl.io.openmx")
 class mdSileOpenMX(xyzSile, SileOpenMX):
-
-    def read_geometry(self, *args, **kwargs):
-        return super().read_geometry(*args, **kwargs)
+    r"""OpenMX MD output (equivalent to `xyzSile`) """
+    pass
 
 
 add_sile('md', mdSileOpenMX, gzip=True)

--- a/src/sisl/io/siesta/ani.py
+++ b/src/sisl/io/siesta/ani.py
@@ -15,6 +15,7 @@ __all__ = ["aniSileSiesta"]
 
 @set_module("sisl.io.siesta")
 class aniSileSiesta(xyzSile, SileSiesta):
+    r"""Animated MD output of Siesta, equivalent to the `xyzSile` """
 
     def read_geometry(self, *args, stop=None, **kwargs):
         return super().read_geometry(*args, stop=stop, **kwargs)

--- a/src/sisl/io/siesta/ani.py
+++ b/src/sisl/io/siesta/ani.py
@@ -16,8 +16,8 @@ __all__ = ["aniSileSiesta"]
 @set_module("sisl.io.siesta")
 class aniSileSiesta(xyzSile, SileSiesta):
 
-    def read_geometry(self, *args, all=True, **kwargs):
-        return super().read_geometry(*args, all=all, **kwargs)
+    def read_geometry(self, *args, **kwargs):
+        return super().read_geometry(*args, **kwargs)
 
 
 add_sile('ANI', aniSileSiesta, gzip=True)

--- a/src/sisl/io/siesta/ani.py
+++ b/src/sisl/io/siesta/ani.py
@@ -16,8 +16,8 @@ __all__ = ["aniSileSiesta"]
 @set_module("sisl.io.siesta")
 class aniSileSiesta(xyzSile, SileSiesta):
 
-    def read_geometry(self, *args, **kwargs):
-        return super().read_geometry(*args, **kwargs)
+    def read_geometry(self, *args, stop=None, **kwargs):
+        return super().read_geometry(*args, stop=stop, **kwargs)
 
 
 add_sile('ANI', aniSileSiesta, gzip=True)

--- a/src/sisl/io/siesta/ani.py
+++ b/src/sisl/io/siesta/ani.py
@@ -17,8 +17,7 @@ __all__ = ["aniSileSiesta"]
 class aniSileSiesta(xyzSile, SileSiesta):
     r"""Animated MD output of Siesta, equivalent to the `xyzSile` """
 
-    def read_geometry(self, *args, stop=None, **kwargs):
-        return super().read_geometry(*args, stop=stop, **kwargs)
-
+    def read_geometry(self, *args, step=1, **kwargs):
+        return super().read_geometry(*args, step=step, **kwargs)
 
 add_sile('ANI', aniSileSiesta, gzip=True)

--- a/src/sisl/io/siesta/tests/test_ani.py
+++ b/src/sisl/io/siesta/tests/test_ani.py
@@ -41,7 +41,7 @@ C   3.00000  0.00000000  0.00000000
     assert len(g) == 3
     assert g[0].na == 2
 
-    g = a.read_geometry(all=True)
+    g = a.read_geometry()
     assert len(g) == 4
     assert g[0].na == 1 and g[2].na == 3
 
@@ -60,13 +60,13 @@ C   3.00000  0.00000000  0.00000000
     g = a.read_geometry(start=1, step=None)
     assert g[0].na == 2 and len(g) == 3
 
-    g = a.read_geometry(start=1, all=False)
+    g = a.read_geometry(start=1, stop=2)
     assert g.na == 2
 
     g = a.read_geometry(start=1, stop=3, step=1)
     assert g[1].na == 3 and len(g) == 2
 
-    g = a.read_geometry(start=1, stop=3, step=2, all=True)
-    assert g[0].na == 2 and len(g) == 1
+    g = a.read_geometry(start=1, stop=3, step=2)
+    assert g.na == 2
 
     g = a.read_geometry(lattice=None, atoms=None)

--- a/src/sisl/io/siesta/tests/test_ani.py
+++ b/src/sisl/io/siesta/tests/test_ani.py
@@ -60,13 +60,13 @@ C   3.00000  0.00000000  0.00000000
     g = a.read_geometry(start=1, step=None)
     assert g[0].na == 2 and len(g) == 3
 
-    g = a.read_geometry(start=1, stop=2)
+    g = a.read_geometry(start=1, step=0)
     assert g.na == 2
 
     g = a.read_geometry(start=1, stop=3, step=1)
     assert g[1].na == 3 and len(g) == 2
 
     g = a.read_geometry(start=1, stop=3, step=2)
-    assert g.na == 2
+    assert len(g) == 1
 
     g = a.read_geometry(lattice=None, atoms=None)

--- a/src/sisl/io/sile.py
+++ b/src/sisl/io/sile.py
@@ -664,7 +664,7 @@ def sile_read_multiple(start: Optional[int]=None,
                        pre_call: Optional[Callable[..., Optional[Any]]]=None,
                        post_call: Optional[Callable[..., Optional[Any]]]=None,
                        postprocess: Optional[Callable[..., Any]]=None):
-    """ Method decorator for doing multiple reads
+    r""" Method decorator for doing multiple reads
 
     Parameters
     ----------

--- a/src/sisl/io/tests/test_xsf.py
+++ b/src/sisl/io/tests/test_xsf.py
@@ -57,28 +57,24 @@ def test_axsf_geoms(sisl_tmp):
             s.write_geometry(g)
 
     with xsfSile(f) as s:
-        rgeoms = s.read_geometry(start=0, stop=2)
-        assert len(rgeoms) == 2
+        rgeoms = s.read_geometry(step=1)
+        assert len(rgeoms) == 3
         assert all(isinstance(rg, Geometry) for rg in rgeoms)
-        print()
-        #for g, rg in zip(geoms, rgeoms):
-        #    print(g)
-        #    print(rg)
         assert all(g.equal(rg) for g, rg in zip(geoms, rgeoms))
 
     with xsfSile(f) as s:
-        rgeoms = s.read_geometry(start=1, stop=2)
+        rgeoms = s.read_geometry(start=1)
         assert isinstance(rgeoms, Geometry)
         assert geoms[1].equal(rgeoms)
 
     with xsfSile(f) as s:
-        rgeoms = s.read_geometry(stop=None)
+        rgeoms = s.read_geometry(step=1)
         assert len(rgeoms) == len(geoms)
         assert all(isinstance(rg, Geometry) for rg in rgeoms)
         assert all(g.equal(rg) for g, rg in zip(geoms, rgeoms))
 
     with xsfSile(f) as s:
-        rgeoms, rdata = s.read_geometry(stop=None, ret_data=True)
+        rgeoms, rdata = s.read_geometry(step=1, ret_data=True)
         assert len(rgeoms) == 3
         assert all(g.equal(rg) for g, rg in zip(geoms, rgeoms))
         for dat in rdata:
@@ -96,13 +92,12 @@ def test_axsf_data(sisl_tmp):
             s.write_geometry(g, data=dat)
 
     with xsfSile(f) as s:
-        rgeoms, rdata = s.read_geometry(stop=None, ret_data=True)
+        rgeoms, rdata = s.read_geometry(step=1, ret_data=True)
         assert len(rgeoms) == len(geoms)
         assert all(g.equal(rg) for g, rg in zip(geoms, rgeoms))
         assert all(np.allclose(d0, d1) for d0, d1 in zip(rdata, data))
 
     with xsfSile(f) as s:
-        rgeoms, rdata = s.read_geometry(start=0, ret_data=True)
+        rgeoms, rdata = s.read_geometry(ret_data=True)
         assert geoms[0].equal(rgeoms)
         assert np.allclose(rdata, data[0])
-

--- a/src/sisl/io/tests/test_xsf.py
+++ b/src/sisl/io/tests/test_xsf.py
@@ -67,18 +67,18 @@ def test_axsf_geoms(sisl_tmp):
         assert all(g.equal(rg) for g, rg in zip(geoms, rgeoms))
 
     with xsfSile(f) as s:
-        rgeoms = s.read_geometry(start=1)
+        rgeoms = s.read_geometry(start=1, stop=2)
         assert isinstance(rgeoms, Geometry)
         assert geoms[1].equal(rgeoms)
 
     with xsfSile(f) as s:
-        rgeoms = s.read_geometry(all=True)
+        rgeoms = s.read_geometry(stop=None)
         assert len(rgeoms) == len(geoms)
         assert all(isinstance(rg, Geometry) for rg in rgeoms)
         assert all(g.equal(rg) for g, rg in zip(geoms, rgeoms))
 
     with xsfSile(f) as s:
-        rgeoms, rdata = s.read_geometry(all=True, ret_data=True)
+        rgeoms, rdata = s.read_geometry(stop=None, ret_data=True)
         assert len(rgeoms) == 3
         assert all(g.equal(rg) for g, rg in zip(geoms, rgeoms))
         for dat in rdata:
@@ -96,7 +96,7 @@ def test_axsf_data(sisl_tmp):
             s.write_geometry(g, data=dat)
 
     with xsfSile(f) as s:
-        rgeoms, rdata = s.read_geometry(all=True, ret_data=True)
+        rgeoms, rdata = s.read_geometry(stop=None, ret_data=True)
         assert len(rgeoms) == len(geoms)
         assert all(g.equal(rg) for g, rg in zip(geoms, rgeoms))
         assert all(np.allclose(d0, d1) for d0, d1 in zip(rdata, data))

--- a/src/sisl/io/tests/test_xyz.py
+++ b/src/sisl/io/tests/test_xyz.py
@@ -111,7 +111,7 @@ C   3.00000  0.00000000  0.00000000
     g = xyzSile(f).read_geometry(start=1, stop=2)
     assert g.na == 2
 
-    g = xyzSile(f).read_geometry()
+    g = xyzSile(f).read_geometry(stop=None)
     assert len(g) == 4
     assert g[0].na == 1 and g[1].na == 2
 

--- a/src/sisl/io/tests/test_xyz.py
+++ b/src/sisl/io/tests/test_xyz.py
@@ -105,13 +105,13 @@ C   1.00000  0.00000000  0.00000000
 C   2.00000  0.00000000  0.00000000
 C   3.00000  0.00000000  0.00000000
 """)
-    g = xyzSile(f).read_geometry()
+    g = xyzSile(f).read_geometry(stop=1)
     assert g.na == 1
 
-    g = xyzSile(f).read_geometry(start=1)
+    g = xyzSile(f).read_geometry(start=1, stop=2)
     assert g.na == 2
 
-    g = xyzSile(f).read_geometry(all=True)
+    g = xyzSile(f).read_geometry()
     assert len(g) == 4
     assert g[0].na == 1 and g[1].na == 2
 
@@ -127,14 +127,7 @@ C   3.00000  0.00000000  0.00000000
     assert len(g) == 2
     assert g[0].na == 1 and g[1].na == 2
 
-    g = xyzSile(f).read_geometry(start=1, step=None)
-    assert g.na == 2
-
     g = xyzSile(f).read_geometry(start=1, stop=3, step=1)
-    assert len(g) == 2
-    assert g[0].na == 2 and g[1].na == 3
-
-    g = xyzSile(f).read_geometry(start=1, stop=3, step=1, all=True)
     assert len(g) == 2
     assert g[0].na == 2 and g[1].na == 3
 
@@ -142,11 +135,11 @@ C   3.00000  0.00000000  0.00000000
     g = xyzSile(f).read_geometry(start=-1)
     assert g.na == 4
 
-    g = xyzSile(f).read_geometry(start=-2, all=True)
+    g = xyzSile(f).read_geometry(start=-2)
     assert len(g) == 2
     assert g[0].na == 3
 
-    g = xyzSile(f).read_geometry(stop=-1, all=True)
+    g = xyzSile(f).read_geometry(stop=-1)
     assert len(g) == 3
     assert g[0].na == 1
     assert g[2].na == 3

--- a/src/sisl/io/tests/test_xyz.py
+++ b/src/sisl/io/tests/test_xyz.py
@@ -88,44 +88,81 @@ def test_xyz_multiple(sisl_tmp):
     with open(f, 'w') as fh:
         fh.write("""1
 
-C   0.00000000  0.00000000  0.00000000
+C   0.00000  0.00000000  0.00000000
 2
 
-C   0.00000000  0.00000000  0.00000000
-C   1.000000  0.00000000  0.00000000
+C   0.00000  0.00000000  0.00000000
+C   1.00000  0.00000000  0.00000000
 3
 
-C   0.00000000  0.00000000  0.00000000
-C   1.000000  0.00000000  0.00000000
+C   0.00000  0.00000000  0.00000000
+C   1.00000  0.00000000  0.00000000
 C   2.00000  0.00000000  0.00000000
+4
+
+C   0.00000  0.00000000  0.00000000
+C   1.00000  0.00000000  0.00000000
+C   2.00000  0.00000000  0.00000000
+C   3.00000  0.00000000  0.00000000
 """)
     g = xyzSile(f).read_geometry()
     assert g.na == 1
+
     g = xyzSile(f).read_geometry(start=1)
     assert g.na == 2
+
     g = xyzSile(f).read_geometry(all=True)
-    assert len(g) == 3
-    assert g[0].na == 1 and g[1].na == 2 and g[-1].na == 3
+    assert len(g) == 4
+    assert g[0].na == 1 and g[1].na == 2
+
     g = xyzSile(f).read_geometry(start=1, step=1)
-    assert len(g) == 2
-    assert g[0].na == 2 and g[-1].na == 3
-    g = xyzSile(f).read_geometry(start=1, stop=-1)
-    assert len(g) == 2
-    assert g[0].na == 2 and g[-1].na == 3
+    assert len(g) == 3
+    assert g[0].na == 2 and g[1].na == 3
+
     g = xyzSile(f).read_geometry(step=2)
     assert len(g) == 2
-    assert g[0].na == 1 and g[-1].na == 3
+    assert g[0].na == 1 and g[1].na == 3
+
     g = xyzSile(f).read_geometry(stop=2, step=1)
     assert len(g) == 2
     assert g[0].na == 1 and g[1].na == 2
+
     g = xyzSile(f).read_geometry(start=1, step=None)
     assert g.na == 2
+
     g = xyzSile(f).read_geometry(start=1, stop=3, step=1)
     assert len(g) == 2
     assert g[0].na == 2 and g[1].na == 3
+
     g = xyzSile(f).read_geometry(start=1, stop=3, step=1, all=True)
     assert len(g) == 2
     assert g[0].na == 2 and g[1].na == 3
+
+    # check negative start/stop/step
+    g = xyzSile(f).read_geometry(start=-1)
+    assert g.na == 4
+
+    g = xyzSile(f).read_geometry(start=-2, all=True)
+    assert len(g) == 2
+    assert g[0].na == 3
+
+    g = xyzSile(f).read_geometry(stop=-1, all=True)
+    assert len(g) == 3
+    assert g[0].na == 1
+    assert g[2].na == 3
+
+    g = xyzSile(f).read_geometry(start=-2, stop=-1)
+    assert g.na == 3
+
+    g = xyzSile(f).read_geometry(start=-4, step=2)
+    assert len(g) == 2
+    assert g[0].na == 1
+    assert g[1].na == 3
+
+    g = xyzSile(f).read_geometry(start=-1, stop=-4, step=-2)
+    assert len(g) == 2
+    assert g[0].na == 4
+    assert g[1].na == 2
 
     # ensure it works with other arguments
     g = xyzSile(f).read_geometry(lattice=None, atoms=None)

--- a/src/sisl/io/tests/test_xyz.py
+++ b/src/sisl/io/tests/test_xyz.py
@@ -115,15 +115,15 @@ C   3.00000  0.00000000  0.00000000
     assert len(g) == 4
     assert g[0].na == 1 and g[1].na == 2
 
-    g = xyzSile(f).read_geometry(start=1, step=1)
+    g = xyzSile(f).read_geometry(start=1, step=1, stop=None)
     assert len(g) == 3
     assert g[0].na == 2 and g[1].na == 3
 
-    g = xyzSile(f).read_geometry(step=2)
+    g = xyzSile(f).read_geometry(step=2, stop=None)
     assert len(g) == 2
     assert g[0].na == 1 and g[1].na == 3
 
-    g = xyzSile(f).read_geometry(stop=2, step=1)
+    g = xyzSile(f).read_geometry(stop=2)
     assert len(g) == 2
     assert g[0].na == 1 and g[1].na == 2
 
@@ -132,10 +132,10 @@ C   3.00000  0.00000000  0.00000000
     assert g[0].na == 2 and g[1].na == 3
 
     # check negative start/stop/step
-    g = xyzSile(f).read_geometry(start=-1)
+    g = xyzSile(f).read_geometry(start=-1, stop=None)
     assert g.na == 4
 
-    g = xyzSile(f).read_geometry(start=-2)
+    g = xyzSile(f).read_geometry(start=-2, stop=None)
     assert len(g) == 2
     assert g[0].na == 3
 
@@ -147,7 +147,7 @@ C   3.00000  0.00000000  0.00000000
     g = xyzSile(f).read_geometry(start=-2, stop=-1)
     assert g.na == 3
 
-    g = xyzSile(f).read_geometry(start=-4, step=2)
+    g = xyzSile(f).read_geometry(start=-4, step=2, stop=None)
     assert len(g) == 2
     assert g[0].na == 1
     assert g[1].na == 3

--- a/src/sisl/io/tests/test_xyz.py
+++ b/src/sisl/io/tests/test_xyz.py
@@ -105,25 +105,25 @@ C   1.00000  0.00000000  0.00000000
 C   2.00000  0.00000000  0.00000000
 C   3.00000  0.00000000  0.00000000
 """)
-    g = xyzSile(f).read_geometry(stop=1)
+    g = xyzSile(f).read_geometry()
     assert g.na == 1
 
-    g = xyzSile(f).read_geometry(start=1, stop=2)
+    g = xyzSile(f).read_geometry(start=1)
     assert g.na == 2
 
-    g = xyzSile(f).read_geometry(stop=None)
+    g = xyzSile(f).read_geometry(step=1)
     assert len(g) == 4
     assert g[0].na == 1 and g[1].na == 2
 
-    g = xyzSile(f).read_geometry(start=1, step=1, stop=None)
+    g = xyzSile(f).read_geometry(start=1, step=1)
     assert len(g) == 3
     assert g[0].na == 2 and g[1].na == 3
 
-    g = xyzSile(f).read_geometry(step=2, stop=None)
+    g = xyzSile(f).read_geometry(step=2)
     assert len(g) == 2
     assert g[0].na == 1 and g[1].na == 3
 
-    g = xyzSile(f).read_geometry(stop=2)
+    g = xyzSile(f).read_geometry(stop=2, step=1)
     assert len(g) == 2
     assert g[0].na == 1 and g[1].na == 2
 
@@ -132,22 +132,22 @@ C   3.00000  0.00000000  0.00000000
     assert g[0].na == 2 and g[1].na == 3
 
     # check negative start/stop/step
-    g = xyzSile(f).read_geometry(start=-1, stop=None)
+    g = xyzSile(f).read_geometry(start=-1)
     assert g.na == 4
 
-    g = xyzSile(f).read_geometry(start=-2, stop=None)
+    g = xyzSile(f).read_geometry(start=-2, step=1)
     assert len(g) == 2
     assert g[0].na == 3
 
-    g = xyzSile(f).read_geometry(stop=-1)
+    g = xyzSile(f).read_geometry(stop=-1, step=1)
     assert len(g) == 3
     assert g[0].na == 1
     assert g[2].na == 3
 
-    g = xyzSile(f).read_geometry(start=-2, stop=-1)
+    g = xyzSile(f).read_geometry(start=-2)
     assert g.na == 3
 
-    g = xyzSile(f).read_geometry(start=-4, step=2, stop=None)
+    g = xyzSile(f).read_geometry(start=-4, step=2)
     assert len(g) == 2
     assert g[0].na == 1
     assert g[1].na == 3

--- a/src/sisl/io/xsf.py
+++ b/src/sisl/io/xsf.py
@@ -317,7 +317,7 @@ class xsfSile(Sile):
             return geom, _a.arrayd(data)
         return geom
 
-    @sile_read_multiple(postprocess=postprocess(GeometryCollection, Collection))
+    @sile_read_multiple(stop=1, postprocess=postprocess(GeometryCollection, Collection))
     @deprecate_argument("sc", "lattice", "use lattice= instead of sc=", from_version="0.15")
     def read_geometry(self, lattice=None, atoms=None, ret_data=False):
         """ Geometry contained in file, and optionally the associated data
@@ -341,9 +341,6 @@ class xsfSile(Sile):
             stop reading geometries at `stop`
         step : int, optional
             step-count between reading geometries
-        all : bool, optional
-            set `start`, `step` and `stop` (if not set) to read
-            as many geometries as possible.
         """
         return self._r_geometry_next(lattice=lattice, atoms=atoms, ret_data=ret_data)
 

--- a/src/sisl/io/xsf.py
+++ b/src/sisl/io/xsf.py
@@ -58,7 +58,7 @@ def postprocess(*funcs):
 # if there are no empty lines!
 @set_module("sisl.io")
 class xsfSile(Sile):
-    """ XSF file for XCrySDen
+    r""" XSF file for XCrySDen
 
     When creating an XSF file one must denote how many geometries to write out.
     It is also necessary to use the xsf in a context manager, otherwise it will
@@ -107,7 +107,7 @@ class xsfSile(Sile):
     @sile_fh_open(reset=reset_values(("_geometry_write", 0), animsteps=True))
     @deprecate_argument("sc", "lattice", "use lattice= instead of sc=", from_version="0.15")
     def write_lattice(self, lattice, fmt='.8f'):
-        """ Writes the supercell to the contained file
+        r""" Writes the supercell to the contained file
 
         Parameters
         ----------
@@ -151,7 +151,7 @@ class xsfSile(Sile):
 
     @sile_fh_open(reset=reset_values(("_geometry_write", 0), animsteps=True))
     def write_geometry(self, geometry, fmt='.8f', data=None):
-        """ Writes the geometry to the contained file
+        r""" Writes the geometry to the contained file
 
         Parameters
         ----------
@@ -317,14 +317,14 @@ class xsfSile(Sile):
             return geom, _a.arrayd(data)
         return geom
 
-    @sile_read_multiple(stop=1, postprocess=postprocess(GeometryCollection, Collection))
+    @sile_read_multiple(step=0, postprocess=postprocess(GeometryCollection, Collection))
     @deprecate_argument("sc", "lattice", "use lattice= instead of sc=", from_version="0.15")
     def read_geometry(self, lattice=None, atoms=None, ret_data=False):
-        """ Geometry contained in file, and optionally the associated data
+        r""" Geometry contained in file, and optionally the associated data
 
         If the file contains more geometries, one can read multiple geometries
         by using the arguments `start`, `stop` and `step`.
-        The default is to read the first geometry, only.
+        The default is to read the first geometry, only (`stop=0`).
 
         Parameters
         ----------
@@ -346,7 +346,7 @@ class xsfSile(Sile):
 
     @sile_fh_open()
     def write_grid(self, *args, **kwargs):
-        """ Store grid(s) data to an XSF file
+        r""" Store grid(s) data to an XSF file
 
         Examples
         --------
@@ -448,7 +448,7 @@ class xsfSile(Sile):
         return self.read_geometry().ArgumentParser(p, *args, **newkw)
 
     def ArgumentParser_out(self, p, *args, **kwargs):
-        """ Adds arguments only if this file is an output file
+        r""" Adds arguments only if this file is an output file
 
         Parameters
         ----------

--- a/src/sisl/io/xyz.py
+++ b/src/sisl/io/xyz.py
@@ -102,8 +102,8 @@ class xyzSile(Sile):
     @sile_fh_open()
     @sile_read_multiple(skip_call=_r_geometry_skip, postprocess=GeometryCollection)
     @deprecate_argument("sc", "lattice", "use lattice= instead of sc=", from_version="0.15")
-    def read_geometry(self, atoms=None, lattice=None):
-        """ Returns Geometry object from the XYZ file
+    def read_geometry(self, stop=1, atoms=None, lattice=None):
+        """ Returns Geometry object(s) from the XYZ file
 
         If the file contains more geometries, one can read multiple geometries
         by using the arguments `start`, `stop` and `step`.
@@ -121,9 +121,6 @@ class xyzSile(Sile):
             stop reading geometries at `stop`
         step : int, optional
             step-count between reading geometries
-        all : bool, optional
-            set `start`, `step` and `stop` (if not set) to read
-            as many geometries as possible.
         """
         line = self.readline()
         if line == '':

--- a/src/sisl/io/xyz.py
+++ b/src/sisl/io/xyz.py
@@ -100,9 +100,9 @@ class xyzSile(Sile):
         return na
 
     @sile_fh_open()
-    @sile_read_multiple(skip_call=_r_geometry_skip, postprocess=GeometryCollection)
+    @sile_read_multiple(stop=1, skip_call=_r_geometry_skip, postprocess=GeometryCollection)
     @deprecate_argument("sc", "lattice", "use lattice= instead of sc=", from_version="0.15")
-    def read_geometry(self, stop=1, atoms=None, lattice=None):
+    def read_geometry(self, atoms=None, lattice=None):
         """ Returns Geometry object(s) from the XYZ file
 
         If the file contains more geometries, one can read multiple geometries

--- a/src/sisl/io/xyz.py
+++ b/src/sisl/io/xyz.py
@@ -100,14 +100,14 @@ class xyzSile(Sile):
         return na
 
     @sile_fh_open()
-    @sile_read_multiple(stop=1, skip_call=_r_geometry_skip, postprocess=GeometryCollection)
+    @sile_read_multiple(step=0, skip_call=_r_geometry_skip, postprocess=GeometryCollection)
     @deprecate_argument("sc", "lattice", "use lattice= instead of sc=", from_version="0.15")
     def read_geometry(self, atoms=None, lattice=None):
         """ Returns Geometry object(s) from the XYZ file
 
         If the file contains more geometries, one can read multiple geometries
         by using the arguments `start`, `stop` and `step`.
-        The default is to read the first geometry, only.
+        The default is to read the first geometry, only (`step=0`).
 
         Parameters
         ----------


### PR DESCRIPTION
Here an attempt to handle negative `start/stop/step` in `sile_read_multiple` as discussed in #577 . If one specifies only `start=-1` one now gets the last entry.

If a negative `start/stop/step` is provided, the code reads all entries and returns `slice(start, stop, step)`.

NB I am unsure if all corner cases are appropriately handled.