### PR TITLE
undo change of filenames

### DIFF
--- a/src/sisl/io/orca/tests/test_out.py
+++ b/src/sisl/io/orca/tests/test_out.py
@@ -14,14 +14,14 @@ _dir = osp.join('sisl', 'io', 'orca')
 
 
 def test_tags(sisl_files):
-    f = sisl_files(_dir, 'molecule.out')
+    f = sisl_files(_dir, 'molecule.output')
     out = outSileORCA(f)
     assert out.na == 2
     assert out.no == 62
     assert out.completed()
 
 def test_read_electrons(sisl_files):
-    f = sisl_files(_dir, 'molecule.out')
+    f = sisl_files(_dir, 'molecule.output')
     out = outSileORCA(f)
     N = out.read_electrons(all=True)
     assert N[0, 0] == 7.999998537730
@@ -31,13 +31,13 @@ def test_read_electrons(sisl_files):
     assert N[1] == 6.999998987209
 
 def test_charge_name(sisl_files):
-    f = sisl_files(_dir, 'molecule.out')
+    f = sisl_files(_dir, 'molecule.output')
     out = outSileORCA(f)
     for name in ['mulliken', 'MULLIKEN', 'loewdin', 'Lowdin', 'LÖWDIN']:
         assert out.read_charge(name=name) is not None
 
 def test_charge_mulliken_atom(sisl_files):
-    f = sisl_files(_dir, 'molecule.out')
+    f = sisl_files(_dir, 'molecule.output')
     out = outSileORCA(f)
     C = out.read_charge(name='mulliken', projection='atom', all=True)
     S = out.read_charge(name='mulliken', projection='atom', spin=True, all=True)
@@ -58,7 +58,7 @@ def test_charge_mulliken_atom(sisl_files):
     assert S[1] == 0.312207
 
 def test_lowedin_atom(sisl_files):
-    f = sisl_files(_dir, 'molecule.out')
+    f = sisl_files(_dir, 'molecule.output')
     out = outSileORCA(f)
     C = out.read_charge(name='loewdin', projection='atom', all=True)
     S = out.read_charge(name='loewdin', projection='atom', spin=True, all=True)
@@ -79,7 +79,7 @@ def test_lowedin_atom(sisl_files):
     assert S[1] == 0.339673
 
 def test_charge_mulliken_reduced(sisl_files):
-    f = sisl_files(_dir, 'molecule.out')
+    f = sisl_files(_dir, 'molecule.output')
     out = outSileORCA(f)
     C = out.read_charge(name='mulliken', projection='orbital', all=True)
     S = out.read_charge(name='mulliken', projection='orbital', spin=True, all=True)
@@ -116,7 +116,7 @@ def test_charge_mulliken_reduced(sisl_files):
     assert S[0] == 0.685743
 
 def test_charge_loewdin_reduced(sisl_files):
-    f = sisl_files(_dir, 'molecule.out')
+    f = sisl_files(_dir, 'molecule.output')
     out = outSileORCA(f)
     C = out.read_charge(name='loewdin', projection='orbital', all=True)
     S = out.read_charge(name='loewdin', projection='orbital', spin=True, all=True)
@@ -139,7 +139,7 @@ def test_charge_loewdin_reduced(sisl_files):
     assert C[0] == 0.723113
 
 def test_charge_mulliken_full(sisl_files):
-    f = sisl_files(_dir, 'molecule.out')
+    f = sisl_files(_dir, 'molecule.output')
     out = outSileORCA(f)
     C = out.read_charge(name='mulliken', projection='orbital', reduced=False, all=True)
     S = out.read_charge(name='mulliken', projection='orbital', reduced=False, spin=True, all=True)
@@ -156,7 +156,7 @@ def test_charge_mulliken_full(sisl_files):
     assert S[8] == 0.006429
 
 def test_charge_loewdin_full(sisl_files):
-    f = sisl_files(_dir, 'molecule.out')
+    f = sisl_files(_dir, 'molecule.output')
     out = outSileORCA(f)
     C = out.read_charge(name='loewdin', projection='orbital', reduced=False, all=True)
     S = out.read_charge(name='loewdin', projection='orbital', reduced=False, spin=True, all=True)
@@ -173,7 +173,7 @@ def test_charge_loewdin_full(sisl_files):
     assert S[8] == 0.005159
 
 def test_charge_atom_unpol(sisl_files):
-    f = sisl_files(_dir, 'molecule2.out')
+    f = sisl_files(_dir, 'molecule2.output')
     out = outSileORCA(f)
     C = out.read_charge(name='mulliken', projection='atom', all=True)
     S = out.read_charge(name='mulliken', projection='atom', spin=True, all=True)
@@ -190,7 +190,7 @@ def test_charge_atom_unpol(sisl_files):
     assert S is None
 
 def test_charge_orbital_reduced_unpol(sisl_files):
-    f = sisl_files(_dir, 'molecule2.out')
+    f = sisl_files(_dir, 'molecule2.output')
     out = outSileORCA(f)
     C = out.read_charge(name='mulliken', projection='orbital', all=True)
     S = out.read_charge(name='mulliken', projection='orbital', spin=True, all=True)
@@ -216,7 +216,7 @@ def test_charge_orbital_reduced_unpol(sisl_files):
     assert S is None
 
 def test_charge_orbital_full_unpol(sisl_files):
-    f = sisl_files(_dir, 'molecule2.out')
+    f = sisl_files(_dir, 'molecule2.output')
     out = outSileORCA(f)
     C = out.read_charge(name='mulliken', projection='orbital', reduced=False)
     S = out.read_charge(name='mulliken', projection='orbital', reduced=False, spin=True)
@@ -224,7 +224,7 @@ def test_charge_orbital_full_unpol(sisl_files):
     assert S is None
 
 def test_read_energy(sisl_files):
-    f = sisl_files(_dir, 'molecule.out')
+    f = sisl_files(_dir, 'molecule.output')
     out = outSileORCA(f)
     E = out.read_energy(all=True)
     assert len(E) == 2
@@ -233,14 +233,14 @@ def test_read_energy(sisl_files):
     assert pytest.approx(E.total) == -3532.4784695729268
 
 def test_read_energy_vdw(sisl_files):
-    f = sisl_files(_dir, 'molecule2.out')
+    f = sisl_files(_dir, 'molecule2.output')
     out = outSileORCA(f)
     E = out.read_energy()
     assert E.vdw != 0
     assert pytest.approx(E.total) == -3081.2640328972802
 
 def test_read_orbital_energies(sisl_files):
-    f = sisl_files(_dir, 'molecule.out')
+    f = sisl_files(_dir, 'molecule.output')
     out = outSileORCA(f)
     E = out.read_orbital_energies(all=True)
     assert pytest.approx(E[0][0, 0]) == -513.8983
@@ -256,7 +256,7 @@ def test_read_orbital_energies(sisl_files):
     assert pytest.approx(E[61, 0]) == 1173.4259
 
 def test_read_orbital_energies_unpol(sisl_files):
-    f = sisl_files(_dir, 'molecule2.out')
+    f = sisl_files(_dir, 'molecule2.output')
     out = outSileORCA(f)
     E = out.read_orbital_energies(all=True)
     assert pytest.approx(E[0][0]) == -513.0978
@@ -269,7 +269,7 @@ def test_read_orbital_energies_unpol(sisl_files):
     assert pytest.approx(E[61]) == 1171.5967
 
 def test_multiple_calls(sisl_files):
-    f = sisl_files(_dir, 'molecule2.out')
+    f = sisl_files(_dir, 'molecule2.output')
     out = outSileORCA(f)
     N = out.read_electrons(all=True)
     assert len(N) == 2


### PR DESCRIPTION
Filenames in the orca tests were (accidentally?) changed from `.output` to `.out` in da3c29b422164a9aaf8fa3aba7a91ff29a9f0e41, not consistent with the `sisl-files` repo. This branch reverts the change.  