### PR TITLE
Fix missing import in siesta_grid.

### DIFF
--- a/src/sisl/io/siesta/siesta_grid.py
+++ b/src/sisl/io/siesta/siesta_grid.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from .sile import SileCDFSiesta
 from ..sile import add_sile, sile_raise_write, SileError
+from .._help import grid_reduce_indices
 
 from sisl._internal import set_module
 from sisl.messages import info, deprecate_argument


### PR DESCRIPTION
This import is needed when the `read_grid` routine receives an array of floats for the kwarg `spin`.

`grid_reduce_indices` was called in line 132 (now 133), but never imported causing a NameError.

This should fix it.