### PR TITLE
maint: Adapt to breaking changes in scipy.sparse.isspmatrix

### DIFF
--- a/src/sisl/io/tbtrans/tbt.py
+++ b/src/sisl/io/tbtrans/tbt.py
@@ -16,7 +16,7 @@ import numpy as np
 ndarray = np.ndarray
 
 # The sparse matrix for the orbital/bond currents
-from scipy.sparse import SparseEfficiencyWarning, csr_matrix, isspmatrix_csr
+from scipy.sparse import SparseEfficiencyWarning, csr_matrix, issparse
 
 import sisl._array as _a
 from sisl import Atoms, Geometry, constant
@@ -1158,7 +1158,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
             map_col = o2a
 
         # Lets do array notation for speeding up the computations
-        if not isspmatrix_csr(Dij):
+        if not (issparse(Dij) and Dij.format == 'csr'):
             Dij = Dij.tocsr()
 
         # Check for the simple case of 1-orbital systems

--- a/src/sisl/physics/electron.py
+++ b/src/sisl/physics/electron.py
@@ -65,7 +65,7 @@ from numpy import (
     sort,
     zeros,
 )
-from scipy.sparse import csr_matrix, hstack, identity, isspmatrix
+from scipy.sparse import csr_matrix, hstack, identity, issparse
 
 import sisl._array as _a
 from sisl import Geometry, Grid, Lattice, constant, units
@@ -374,7 +374,7 @@ def COP(E, eig, state, M, distribution="gaussian", tol=1e-10):
 
         cop = oplist(tosize(d, idx) for d in cop)
 
-    elif isspmatrix(M):
+    elif issparse(M):
 
         # create the new list
         cop0 = M.multiply(0.).real

--- a/src/sisl/physics/sparse.py
+++ b/src/sisl/physics/sparse.py
@@ -10,7 +10,7 @@ import sisl._array as _a
 import sisl.linalg as lin
 from sisl._internal import set_module
 from sisl.messages import warn
-from sisl.sparse import isspmatrix
+from sisl.sparse import issparse
 from sisl.sparse_geometry import SparseOrbital
 
 from ._matrix_ddk import matrix_ddk, matrix_ddk_nc, matrix_ddk_nc_diag, matrix_ddk_so
@@ -148,7 +148,7 @@ class SparseOrbitalBZ(SparseOrbital):
              a new sparse matrix that holds the passed geometry and the elements of `P` and optionally being non-orthogonal if `S` is not none
         """
         # Ensure list of csr format (to get dimensions)
-        if isspmatrix(P):
+        if issparse(P):
             P = [P]
         if isinstance(P, tuple):
             P = list(P)

--- a/src/sisl/physics/tests/test_hamiltonian.py
+++ b/src/sisl/physics/tests/test_hamiltonian.py
@@ -7,7 +7,7 @@ from functools import partial
 import numpy as np
 import pytest
 from scipy.linalg import block_diag
-from scipy.sparse import SparseEfficiencyWarning, isspmatrix
+from scipy.sparse import SparseEfficiencyWarning, issparse
 
 from sisl import (
     Atom,
@@ -1240,7 +1240,7 @@ class TestHamiltonian:
         for k in ([0] *3, [0.2] * 3):
             es = HS.eigenstate(k)
             COOP_sp = es.COOP(E, 'lorentzian')
-            assert isspmatrix(COOP_sp[0])
+            assert issparse(COOP_sp[0])
 
             es = HS.eigenstate(k, format='array')
             COOP_np = es.COOP(E, 'lorentzian')

--- a/src/sisl/sparse_geometry.py
+++ b/src/sisl/sparse_geometry.py
@@ -39,7 +39,7 @@ from .atom import Atom
 from .geometry import Geometry
 from .messages import SislError, SislWarning, progressbar, warn
 from .orbital import Orbital
-from .sparse import SparseCSR, _ncol_to_indptr, isspmatrix
+from .sparse import SparseCSR, _ncol_to_indptr, issparse
 from .utils.ranges import list2str
 
 __all__ = ['SparseAtom', 'SparseOrbital']
@@ -1078,7 +1078,7 @@ class _SparseGeometry(NDArrayOperatorsMixin):
              a new sparse matrix that holds the passed geometry and the elements of `P`
         """
         # Ensure list of * format (to get dimensions)
-        if isspmatrix(P):
+        if issparse(P):
             P = [P]
         if isinstance(P, tuple):
             P = list(P)

--- a/src/sisl/tests/test_sparse.py
+++ b/src/sisl/tests/test_sparse.py
@@ -1357,10 +1357,10 @@ def test_sparse_column_out_of_bounds(j):
     with pytest.raises(IndexError):
         S[0, j] = 1
 
-
 def test_fromsp_csr():
     csr1 = sc.sparse.random(10, 100, 0.01, random_state=24812)
     csr2 = sc.sparse.random(10, 100, 0.02, random_state=24813)
+
     csr = SparseCSR.fromsp(csr1, csr2)
     csr_1 = csr.tocsr(0)
     csr_2 = csr.tocsr(1)

--- a/src/sisl_toolbox/btd/_btd.py
+++ b/src/sisl_toolbox/btd/_btd.py
@@ -918,7 +918,7 @@ class DeviceGreen:
         BI = BM.block_indexer
         c = self.btd_cum0
         nb = len(BI)
-        if ssp.isspmatrix(M):
+        if ssp.issparse(M):
             for jb in range(nb):
                 for ib in range(max(0, jb-1), min(jb+2, nb)):
                     BI[ib, jb] = M[c[ib]:c[ib+1], c[jb]:c[jb+1]].toarray()


### PR DESCRIPTION
In this PR: https://github.com/scipy/scipy/pull/18528 scipy introduced a breaking change which has already been released in `1.11`. 

`isspmatrix` no longer returns `True` if you pass a sparse array (instead of a sparse matrix).

To keep the old behavior, we should use `scipy.sparse.issparse` instead. `isspmatrix_fmt` (e.g. `isspmatrix_csr`) becomes more cumbersome because there is no equivalent function in scipy to check for sparse arrays as well, and you have to go `issparse(matrix) and matrix.format == "fmt"`.

These changes keep the old behavior of sisl even with `scipy >= 1.11` and don't introduce backwards incompatibilities, so no need to bump the `scipy` dependency (I think). 
