### PR TITLE
bug: register data classes as plotables

### DIFF
--- a/src/sisl/viz/_plotables.py
+++ b/src/sisl/viz/_plotables.py
@@ -187,7 +187,15 @@ def register_data_source(
     data_source_init_kwargs: dict = {},
     **kwargs
 ):
+    
+    # First register the data source itself
+    register_plotable(
+        data_source_cls, plot_cls=plot_cls, setting_key=setting_key,
+        name=name, plot_handler_attr=plot_handler_attr, 
+        **kwargs
+    )
 
+    # And then all its entry points
     plot_cls_params = {
         name: param.replace(kind=inspect.Parameter.KEYWORD_ONLY) 
         for name, param in inspect.signature(plot_cls).parameters.items() if name != setting_key


### PR DESCRIPTION
This one is not that important, you could not `.plot()` on the data classes.

Now this:

```python
from sisl.viz import BandsData

data = BandsData(...)

data.plot.bands()
```

although it is not shown in the tutorials.

I have other little tweak ideas for improvement of `sisl.viz`, but they can wait, no need to rush :)
