### PR TITLE
Cleaning tutorial notebooks.

### DIFF
--- a/docs/tutorials/tutorial_es_1.ipynb
+++ b/docs/tutorials/tutorial_es_1.ipynb
@@ -10,6 +10,7 @@
     "from sisl import *\n",
     "import sisl.viz\n",
     "from sisl.viz import merge_plots\n",
+    "from sisl.viz.processors.math import normalize\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
    ]
@@ -245,7 +246,7 @@
     "E = np.linspace(-1, -.5, 100)\n",
     "dE = E[1] - E[0]\n",
     "PDOS = es.PDOS(E).sum((0, 2)) * dE # perform integration\n",
-    "system.plot(axes=\"xy\", atoms_style={\"size\": PDOS * 15})\n",
+    "system.plot(axes=\"xy\", atoms_style={\"size\": normalize(PDOS, 0, 1)})\n",
     "#plt.scatter(system.xyz[:, 0], system.xyz[:, 1], 500 * PDOS);\n",
     "#plt.scatter(xyz_remove[0], xyz_remove[1], c='k', marker='*'); # mark the removed atom"
    ]
@@ -370,7 +371,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "system.plot(axes=\"xy\", atoms_style={\"size\": 150 * PDOS})"
+    "system.plot(axes=\"xy\", atoms_style={\"size\": normalize(PDOS, 0, 1)})"
    ]
   },
   {
@@ -519,7 +520,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/tutorial_siesta_1.ipynb
+++ b/docs/tutorials/tutorial_siesta_1.ipynb
@@ -12,6 +12,7 @@
     "from sisl import *\n",
     "import sisl.viz\n",
     "from sisl.viz import merge_plots\n",
+    "from sisl.viz.processors.math import normalize\n",
     "from functools import partial\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
@@ -237,7 +238,7 @@
     "es = es.sub([idx_lumo - 1, idx_lumo])\n",
     "\n",
     "plots = [\n",
-    "    h2o.plot(axes=\"xy\", atoms_style={\"size\": n * 1.5, \"color\": c})\n",
+    "    h2o.plot(axes=\"xy\", atoms_style={\"size\": normalize(n), \"color\": c})\n",
     "    for n, c in zip(h2o.apply(es.norm2(sum=False),\n",
     "                                           np.sum,\n",
     "                                           mapper=partial(h2o.a2o, all=True),\n",

--- a/docs/tutorials/tutorial_siesta_2.ipynb
+++ b/docs/tutorials/tutorial_siesta_2.ipynb
@@ -148,39 +148,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bz = MonkhorstPack(H, [81, 81, 1])\n",
-    "idx_s = list()\n",
-    "idx_pxy = list()\n",
-    "idx_pz = list()\n",
-    "for i, orb in enumerate(H.geometry.atoms[0]):\n",
-    "    if orb.l == 0:\n",
-    "        idx_s.append(i)\n",
-    "    elif orb.l == 1 and (orb.m in [-1, 1]):\n",
-    "        idx_pxy.append(i)\n",
-    "    elif orb.l == 1 and orb.m == 0:\n",
-    "        idx_pz.append(i)\n",
-    "print('Orbital index of s: {}'.format(idx_s))\n",
-    "print('Orbital index of p_x and p_y: {}'.format(idx_pxy))\n",
-    "print('Orbital index of p_z: {}'.format(idx_pz))\n",
-    "# Get all orbitals\n",
-    "all_s = np.add.outer(H.geometry.a2o([0, 1]), idx_s).ravel()\n",
-    "all_pxy = np.add.outer(H.geometry.a2o([0, 1]), idx_pxy).ravel()\n",
-    "all_pz = np.add.outer(H.geometry.a2o([0, 1]), idx_pz).ravel()\n",
-    "\n",
-    "def wrap(es):\n",
-    "    PDOS = es.PDOS(E)[0]\n",
-    "    pdos_s = PDOS[all_s, :].sum(0)\n",
-    "    pdos_pxy = PDOS[all_pxy, :].sum(0)\n",
-    "    pdos_pz = PDOS[all_pz, :].sum(0)\n",
-    "    return np.stack((pdos_s, pdos_pxy, pdos_pz))\n",
-    "pDOS = bz.apply.average.eigenstate(wrap=wrap)\n",
-    "plt.plot(E, pDOS[0, :], label='$s$');\n",
-    "plt.plot(E, pDOS[1, :], label='$p_x+p_y$');\n",
-    "plt.plot(E, pDOS[2, :], label=r'$p_z$');\n",
-    "plt.xlim(E[0], E[-1]); plt.ylim(0, None)\n",
-    "plt.xlabel(r'$E - E_F$ [eV]')\n",
-    "plt.ylabel(r'DOS [1/eV]')\n",
-    "plt.legend();"
+    "pdos_plot = H.plot.pdos(kgrid=[81, 81, 1], data_Erange=(-6, 4), Erange=[-6, 4], nE=500)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "orb_groups = [\n",
+    "    {\"l\": 0, \"name\": \"s\", \"color\": \"red\"},\n",
+    "    {\"l\": 1, \"m\": [-1, 1], \"name\": \"px + py\", \"color\": \"blue\"},\n",
+    "    {\"l\": 1, \"m\": 0, \"name\": \"pz\", \"color\": \"green\"}\n",
+    "]\n",
+    "pdos_plot.update_inputs(groups=orb_groups)"
    ]
   },
   {
@@ -198,34 +180,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "weight_s = list()\n",
-    "weight_pxy = list()\n",
-    "weight_pz = list()\n",
-    "def wrap_fatbands(eigenstate):\n",
-    "    # The eigenstate object has several features.\n",
-    "    # For now we will simply calculate the <psi_i| S(k) | psi_i> weight for\n",
-    "    # the orbitals we are interested in.\n",
-    "    norm2 = eigenstate.norm2(sum=False)\n",
-    "    weight_s.append(norm2[:, all_s].sum(-1))\n",
-    "    weight_pxy.append(norm2[:, all_pxy].sum(-1))\n",
-    "    weight_pz.append(norm2[:, all_pz].sum(-1))\n",
-    "    return eigenstate.eig\n",
     "# Define the band-structure\n",
     "bz = BandStructure(H, [[0] * 3, [2./3, 1./3, 0], [0.5, 0.5, 0], [1] * 3], 400, \n",
-    "                   names=[r'$\\Gamma$', r'$K$', r'$M$', r'$\\Gamma$'])\n",
-    "\n",
-    "# Calculate all eigenvalues\n",
-    "eig = bz.apply.array.eigenstate(wrap=wrap_fatbands).T\n",
-    "weight_s = np.array(weight_s).T\n",
-    "weight_pxy = np.array(weight_pxy).T\n",
-    "weight_pz = np.array(weight_pz).T"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finally we plot the fat-bands. Our plots split each of the orbitals contributions into their separate fat band. Thus one can see details on multiple orbital contributions for each band."
+    "                   names=[r'$\\Gamma$', r'$K$', r'$M$', r'$\\Gamma$'])"
    ]
   },
   {
@@ -234,41 +191,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linear_k, k_tick, k_label = bz.lineark(True)\n",
-    "\n",
-    "Emin, Emax = -21, 10\n",
-    "# This is to determine the width of the fat-bands\n",
-    "# The width of the fat-bands is dependent on the energy range and also on the variety\n",
-    "# of contributions.\n",
-    "dE = (Emax - Emin) / 20.\n",
-    "plt.ylabel(r'$E-E_F$ [eV]')\n",
-    "plt.xlim(linear_k[0], linear_k[-1]);\n",
-    "plt.xticks(k_tick, k_label);\n",
-    "plt.ylim(Emin, Emax);\n",
-    "\n",
-    "# Now plot the bands\n",
-    "for i, e in enumerate(eig):\n",
-    "    s = np.abs(weight_s[i, :] * dE)\n",
-    "    pxy = np.abs(weight_pxy[i, :] * dE)\n",
-    "    pz = np.abs(weight_pz[i, :] * dE)\n",
-    "    plt.plot(linear_k, e, color='k'); # black-line (band-structure)\n",
-    "    # Full fat-band\n",
-    "    plt.fill_between(linear_k, e - dE, e + dE, color='k', alpha=0.1);\n",
-    "    # pz\n",
-    "    plt.fill_between(linear_k, e + (s + pxy), e + (s + pxy + pz), color='g', alpha=0.5);\n",
-    "    plt.fill_between(linear_k, e - (s + pxy + pz), e - (s + pxy), color='g', alpha=0.5);\n",
-    "    # pxy\n",
-    "    plt.fill_between(linear_k, e + (s), e + (s + pxy), color='b', alpha=0.5);\n",
-    "    plt.fill_between(linear_k, e - (s), e - (s + pxy), color='b', alpha=0.5);\n",
-    "    # s\n",
-    "    plt.fill_between(linear_k, e - (s), e + (s), color='r', alpha=0.5);"
+    "bz.plot.fatbands(groups=orb_groups, Erange=[-21, 10])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- all, gray\n",
+    "- all, black\n",
     "- $p_z$, green\n",
     "- $s$, red\n",
     "- $p_x+p_y$, blue"
@@ -345,6 +275,13 @@
     "    ax.set_xlabel(r'$x$ [Ang]');\n",
     "    ax.set_ylabel(r'$y$ [Ang]');"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/sisl/viz/processors/math.py
+++ b/src/sisl/viz/processors/math.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+def normalize(data, vmin=0, vmax=1):
+    """Normalize data to [vmin, vmax] range.
+
+    Parameters
+    ----------
+    data : array_like
+        Data to normalize.
+    vmin : float, optional
+        Minimum value of normalized data.
+    vmax : float, optional
+        Maximum value of normalized data.
+
+    Returns
+    -------
+    data : array_like
+        Normalized data.
+    """
+    data = np.asarray(data)
+    data_min = np.min(data)
+    data_max = np.max(data)
+    return vmin + (vmax - vmin) * (data - data_min) / (data_max - data_min)

--- a/src/sisl/viz/processors/tests/test_math.py
+++ b/src/sisl/viz/processors/tests/test_math.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+from sisl.viz.processors.math import normalize
+
+def test_normalize():
+
+    data = [0, 1, 2]
+
+    assert np.allclose(normalize(data), [0, 0.5, 1])
+
+    assert np.allclose(normalize(data, vmin=-1, vmax=1), [-1, 0, 1])
+


### PR DESCRIPTION
This is the last one hehe

I added a `normalize` function and used it to normalize sizes of atoms so that we don't need to multiply the PDOS by some strange factor to set it as atoms sizes (which is less prone to visualization bugs).

The second commit changes the siesta tutorial to use sisl.viz to plot PDOS and fatbands. I don't know if you want it or you prefer to show the technical parts of doing the analysis in this tutorial. Feel free to discard that commit :)




