### PR TITLE
Lattice is now owning the boundary conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ we hit release version 1.0.0.
   debugging.
 - marked all `toSphere|toEllipsoid|...` as deprecated
 
+### Changed
+- `Lattice` now holds the boundary conditions (not `Grid`), see #626
+
 
 ## [0.14.2] - 2023-10-04
 

--- a/docs/api/basic.rst
+++ b/docs/api/basic.rst
@@ -30,6 +30,7 @@ Simple objects
    Atoms
    Geometry
    Lattice
+   BoundaryCondition
    Grid
 
 

--- a/src/sisl/geom/_common.py
+++ b/src/sisl/geom/_common.py
@@ -10,15 +10,21 @@ def geometry_define_nsc(geometry, periodic=(True, True, True)):
     """Define the number of supercells for a geometry based on the periodicity """
     if np.all(geometry.maxR(True) > 0.):
         geometry.optimize_nsc()
-        if not periodic[0]:
-            geometry.set_nsc(a=1)
-        if not periodic[1]:
-            geometry.set_nsc(b=1)
-        if not periodic[2]:
-            geometry.set_nsc(c=1)
+        for i, d, per in zip(range(3), "abc", periodic):
+            if per:
+                geometry.lattice.set_boundary_condition(**{d: "Periodic"})
+            else:
+                geometry.set_nsc(**{d: 1})
     else:
         nsc = [3 if p else 1 for p in periodic]
         geometry.set_nsc(nsc)
+
+    for name, per in zip("abc", periodic):
+        if per:
+            per = "Periodic"
+        else:
+            per = "Unknown"
+        geometry.lattice.set_boundary_condition(**{name: per})
 
 
 def geometry2uc(geometry, dx=1e-8):

--- a/src/sisl/io/tests/test_xyz.py
+++ b/src/sisl/io/tests/test_xyz.py
@@ -64,7 +64,8 @@ C   2.00000  0.00000000  0.00000000
     assert np.allclose(g.xyz[:, 0], [0, 1, 2])
     assert np.allclose(g.xyz[:, 1], 0.)
     assert np.allclose(g.xyz[:, 2], 0.)
-    assert np.allclose(g.nsc, [1, 1, 3])
+    assert np.allclose(g.nsc, [1, 1, 1])
+    assert np.allclose(g.pbc, [False, False, True])
 
 
 def test_xyz_arbitrary(sisl_tmp):

--- a/src/sisl/physics/densitymatrix.py
+++ b/src/sisl/physics/densitymatrix.py
@@ -11,6 +11,7 @@ from scipy.sparse import hstack as ss_hstack
 from scipy.sparse import tril, triu
 
 import sisl._array as _a
+from sisl import BoundaryCondition as BC
 from sisl import Geometry, Lattice
 from sisl._indices import indices_fabs_le, indices_le
 from sisl._internal import set_module
@@ -537,7 +538,8 @@ class _densitymatrix(SparseOrbitalBZSpin):
         # 1. Ensure the grid has a geometry associated with it
         lattice = grid.lattice.copy()
         # Find the periodic directions
-        pbc = [bc == grid.PERIODIC or geometry.nsc[i] > 1 for i, bc in enumerate(grid.bc[:, 0])]
+        pbc = [bc == BC.PERIODIC or geometry.nsc[i] > 1
+               for i, bc in enumerate(grid.lattice.boundary_condition[:, 0])]
         if grid.geometry is None:
             # Create the actual geometry that encompass the grid
             ia, xyz, _ = geometry.within_inf(lattice, periodic=pbc)

--- a/src/sisl/physics/electron.py
+++ b/src/sisl/physics/electron.py
@@ -68,6 +68,7 @@ from numpy import (
 from scipy.sparse import csr_matrix, hstack, identity, issparse
 
 import sisl._array as _a
+from sisl import BoundaryCondition as BC
 from sisl import Geometry, Grid, Lattice, constant, units
 from sisl._help import dtype_complex_to_real, dtype_real_to_complex
 from sisl._indices import indices_le
@@ -1253,8 +1254,8 @@ def wavefunction(v, grid, geometry=None, k=None, spinor=0, spin=None, eta=None):
     lattice = grid.lattice.copy()
 
     # Find the periodic directions
-    pbc = [bc == grid.PERIODIC or geometry.nsc[i] > 1
-           for i, bc in enumerate(grid.bc[:, 0])]
+    pbc = [bc == BC.PERIODIC or geometry.nsc[i] > 1
+           for i, bc in enumerate(grid.lattice.boundary_condition[:, 0])]
     if grid.geometry is None:
         # Create the actual geometry that encompass the grid
         ia, xyz, _ = geometry.within_inf(lattice, periodic=pbc)

--- a/src/sisl/tests/test_grid.py
+++ b/src/sisl/tests/test_grid.py
@@ -386,32 +386,12 @@ class TestGrid:
         with pytest.raises(ValueError):
             g.set_grid([2, 2, 2, 4])
 
-    def test_bc1(self, setup):
-        assert np.all(setup.g.bc == setup.g.PERIODIC)
-        setup.g.set_bc(a=setup.g.NEUMANN)
-        setup.g.set_bc(b=setup.g.NEUMANN, c=setup.g.NEUMANN)
-        assert np.all(setup.g.bc == setup.g.NEUMANN)
-        setup.g.set_bc(setup.g.PERIODIC)
-        assert np.all(setup.g.bc == setup.g.PERIODIC)
-
-    def test_bc2(self, setup):
-        g = setup.g.copy()
-        P = g.PERIODIC
-        D = g.DIRICHLET
-        N = g.NEUMANN
-        assert np.all(g.bc == P)
-        g.set_bc(N)
-        assert np.all(g.bc == setup.g.NEUMANN)
-        bc = [[P, P], [N, D], [D, N]]
-        g.set_bc(bc)
-        assert np.all(g.bc == bc)
-
     def test_argumentparser(self, setup):
         setup.g.ArgumentParser()
 
     def test_pyamg1(self, setup):
         g = setup.g.copy()
-        g.set_bc(g.PERIODIC) # periodic boundary conditions
+        g.lattice.set_boundary_condition(g.PERIODIC) # periodic boundary conditions
         n = np.prod(g.shape)
         A = csr_matrix((n, n))
         b = np.zeros(A.shape[0])
@@ -439,7 +419,7 @@ class TestGrid:
         bc = [[g.PERIODIC] * 2,
               [g.NEUMANN, g.DIRICHLET],
               [g.DIRICHLET, g.NEUMANN]]
-        g.set_bc(bc)
+        g.lattice.set_boundary_condition(bc)
         n = np.prod(g.shape)
         A = csr_matrix((n, n))
         b = np.zeros(A.shape[0])

--- a/src/sisl/tests/test_lattice.py
+++ b/src/sisl/tests/test_lattice.py
@@ -9,7 +9,7 @@ from pytest import approx
 
 import sisl
 import sisl.linalg as lin
-from sisl import Lattice, LatticeChild, SuperCell
+from sisl import BoundaryCondition, Lattice, LatticeChild, SuperCell
 from sisl.geom import graphene
 
 pytestmark = [pytest.mark.supercell, pytest.mark.sc, pytest.mark.lattice]
@@ -487,3 +487,24 @@ def test_lattice_indices():
 def test_supercell_warn():
     with pytest.warns(sisl.SislDeprecation):
         lattice = SuperCell([1] * 3, nsc=[3, 5, 7])
+
+
+#####
+# boundary-condition tests
+#####
+
+@pytest.mark.parametrize("bc", list(BoundaryCondition))
+def test_lattice_bc_init(bc):
+    Lattice(1, boundary_condition=bc)
+    Lattice(1, boundary_condition=[bc, bc, bc])
+    Lattice(1, boundary_condition=[[bc, bc],
+                                   [bc, bc],
+                                   [bc, bc]])
+
+def test_lattice_bc_set():
+    lat = Lattice(1, boundary_condition=Lattice.BC.PERIODIC)
+    assert lat.pbc.all()
+    lat.boundary_condition = Lattice.BC.UNKNOWN
+    assert not lat.pbc.any()
+    assert (lat.boundary_condition == Lattice.BC.UNKNOWN).all()
+

--- a/src/sisl/tests/test_lattice.py
+++ b/src/sisl/tests/test_lattice.py
@@ -508,3 +508,34 @@ def test_lattice_bc_set():
     assert not lat.pbc.any()
     assert (lat.boundary_condition == Lattice.BC.UNKNOWN).all()
 
+    lat.boundary_condition = ['per', "unkn", [3, 4]]
+
+    for n in "abc":
+        lat.set_boundary_condition(**{n: "per"})
+        lat.set_boundary_condition(**{n: [3, Lattice.BC.UNKNOWN]})
+        lat.set_boundary_condition(**{n: [True, Lattice.BC.PERIODIC]})
+
+    bc = [
+            "per",
+            ["Dirichlet", Lattice.BC.NEUMANN],
+            ["un", "neu"]
+    ]
+    lat.set_boundary_condition(bc)
+    assert np.all(lat.boundary_condition[1] == [Lattice.BC.DIRICHLET, Lattice.BC.NEUMANN])
+    assert np.all(lat.boundary_condition[2] == [Lattice.BC.UNKNOWN, Lattice.BC.NEUMANN])
+    lat.set_boundary_condition(["per", None, ["dirichlet", "unkno"]])
+    assert np.all(lat.boundary_condition[1] == [Lattice.BC.DIRICHLET, Lattice.BC.NEUMANN])
+    assert np.all(lat.boundary_condition[2] == [Lattice.BC.DIRICHLET, Lattice.BC.UNKNOWN])
+    lat.set_boundary_condition("ppu")
+    assert np.all(lat.pbc == [True, True, False])
+
+
+def test_lattice_bc_fail():
+    lat = Lattice(1)
+    with pytest.raises(ValueError):
+        lat.boundary_condition = False
+    with pytest.raises(ValueError):
+        lat.set_boundary_condition(b=False)
+    with pytest.raises(KeyError):
+        lat.set_boundary_condition(b="eusoatuhesoau")
+

--- a/src/sisl/tests/test_lattice.py
+++ b/src/sisl/tests/test_lattice.py
@@ -539,3 +539,11 @@ def test_lattice_bc_fail():
     with pytest.raises(KeyError):
         lat.set_boundary_condition(b="eusoatuhesoau")
 
+
+def test_lattice_info():
+    lat = Lattice(1, nsc=[3, 3, 3])
+    with pytest.warns(sisl.SislInfo) as record:
+        lat.set_boundary_condition(b=Lattice.BC.DIRICHLET)
+        lat.set_boundary_condition(c=Lattice.BC.PERIODIC)
+        assert len(record) == 1
+

--- a/src/sisl_toolbox/transiesta/poisson/fftpoisson_fix.py
+++ b/src/sisl_toolbox/transiesta/poisson/fftpoisson_fix.py
@@ -213,11 +213,13 @@ def solve_poisson(geometry, shape, radius="empirical",
         # Change boundaries to always use dirichlet
         # This ensures that once we set the boundaries we don't
         # get any side-effects
-        periodic = grid.bc[:, 0] == grid.PERIODIC
-        bc = np.repeat(np.array([grid.DIRICHLET], np.int32), 6).reshape(3, 2)
+        BC = si.BoundaryCondition
+        periodic = [bc == BC.PERIODIC or geometry.nsc[i] > 1
+                    for i, bc in enumerate(grid.lattice.boundary_condition[:, 0])]
+        bc = np.repeat(np.array([BC.DIRICHLET], np.int32), 6).reshape(3, 2)
         for i in (0, 1, 2):
             if periodic[i]:
-                bc[i, :] = grid.PERIODIC
+                bc[i, :] = BC.PERIODIC
         grid.set_bc(bc)
         A, b = grid.topyamg()
 


### PR DESCRIPTION
This should be a first step towards moving the
nsc attribute from Lattice to somewhere more
appropriate.

This also makes the boundary conditions in the
Grid more manageable since it is the lattice which keeps the information.

Simplified reading xyz files since the boundary
conditions are now explicit.

<!-- Feel free to remove check-list items aren't relevant to your change -->

@tfrederiksen and @pfebrer a review please. :)

 - [x] Closes #626 #625 
 - [x] Tests added
 - [x] Ranned `isort .` at top--level
 - [x] Documentation for functionality, `docs/`
 - [x] Changes documented, `CHANGELOG.md`

A small snippet showing its use:
```python
from sisl import BoundaryCondition as BC, Lattice

print("Available boundary conditions:")
for b in BC:
    print("  ", b)

# Define a lattice
print(Lattice(1, boundary_condition=BC.PERIODIC))
print(Lattice(1, boundary_condition=[BC.DIRICHLET, BC.NEUMANN, BC.PERIODIC]))
print(Lattice(1, boundary_condition=[BC.DIRICHLET, [BC.NEUMANN, BC.DIRICHLET], BC.PERIODIC]))


print("Setting new boundary conditions:")
latt = Lattice(1, boundary_condition=BC.PERIODIC)
print(latt)
latt.set_boundary_condition(c=[BC.NEUMANN, BC.DIRICHLET])
print(latt)
latt.set_boundary_condition(BC.PERIODIC)

print("Printing stuff")
print(latt.boundary_condition)
print(latt.pbc)

# doing
latt.boundary_condition = ...
# is equivalent to latt.set_boundary_condition
```
