### PR TITLE
Included missing notebook in the viz docs

### DIFF
--- a/docs/visualization/viz_module/index.rst
+++ b/docs/visualization/viz_module/index.rst
@@ -73,6 +73,7 @@ developer or you are building a framework (e.g. GUI) around `sisl.viz`, this is 
 .. nbgallery::
     :name: viz-plotly-diy-gallery
 
+    diy/Building a new plot.ipynb
     diy/Adding new backends.ipynb
 
 


### PR DESCRIPTION
I don't know why, but there was a notebook that was not included in the `.rst` file (probably I forgot to include it).
