### PR TITLE
fixed #633 due to weird combination of boundary lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ we hit release version 1.0.0.
   The _info_attributes_ contains a list of attributes that can be
   discovered while reading ascii files see #509
 
+### Fixed
+- fixed cases where `Geometry.close` would not catch all neighbours, #633
+
 ### Changed
 - `Lattice` now holds the boundary conditions (not `Grid`), see #626
 - Some siles exposed certain properties containing basic information

--- a/src/sisl/geom/_common.py
+++ b/src/sisl/geom/_common.py
@@ -10,7 +10,7 @@ def geometry_define_nsc(geometry, periodic=(True, True, True)):
     """Define the number of supercells for a geometry based on the periodicity """
     if np.all(geometry.maxR(True) > 0.):
         geometry.optimize_nsc()
-        for i, d, per in zip(range(3), "abc", periodic):
+        for d, per in zip("abc", periodic):
             if per:
                 geometry.lattice.set_boundary_condition(**{d: "Periodic"})
             else:

--- a/src/sisl/geometry.py
+++ b/src/sisl/geometry.py
@@ -1749,7 +1749,7 @@ class Geometry(LatticeChild, _Dispatchs,
             R = self.maxR() + 0.001
         if R < 0:
             R = 0.00001
-            warn(self.__class__.__name__ +
+            warn(f"{self.__class__.__name__}"
                  ".optimize_nsc could not determine the radius from the "
                  "internal atoms (defaulting to zero radius).")
 

--- a/src/sisl/geometry.py
+++ b/src/sisl/geometry.py
@@ -892,7 +892,7 @@ class Geometry(LatticeChild, _Dispatchs,
 
         # default block iterator
         if R is None:
-            R = self.maxR() * 1.01
+            R = self.maxR() + 0.001
         if R < 0:
             raise ValueError(f"{self.__class__.__name__}.iR unable to determine a number of atoms within a sphere with negative radius, is maxR() defined?")
 
@@ -924,7 +924,7 @@ class Geometry(LatticeChild, _Dispatchs,
             raise SislError(f'{self.__class__.__name__}.iter_block_rand too small iR!')
 
         if R is None:
-            R = self.maxR() + 0.01
+            R = self.maxR() + 0.001
         # The boundaries (ensure complete overlap)
         R = np.array([iR - 0.5, iR + 0.501]) * R
 
@@ -997,7 +997,7 @@ class Geometry(LatticeChild, _Dispatchs,
         if iR < 2:
             raise SislError(f'{self.__class__.__name__}.iter_block_shape too small iR!')
 
-        R = self.maxR() + 0.01
+        R = self.maxR() + 0.001
         if shape is None:
             # we default to the Cube shapes
             dS = (Cube((iR - 0.5) * R),
@@ -1124,7 +1124,7 @@ class Geometry(LatticeChild, _Dispatchs,
         iR :
             the number of `R` ranges taken into account when doing the iterator
         R :
-            enables overwriting the local R quantity. Defaults to ``self.maxR() + 0.01``
+            enables overwriting the local R quantity. Defaults to ``self.maxR() + 0.001``
         atoms :
             enables only effectively looping a subset of the full geometry
         method : {'rand', 'sphere', 'cube'}
@@ -1150,7 +1150,7 @@ class Geometry(LatticeChild, _Dispatchs,
             yield from self.iter_block_rand(iR, R, atoms)
         elif method in ("sphere", "cube"):
             if R is None:
-                R = self.maxR() + 0.01
+                R = self.maxR() + 0.001
 
             # Create shapes
             if method == 'sphere':
@@ -1746,7 +1746,7 @@ class Geometry(LatticeChild, _Dispatchs,
             axis = _a.asarrayi(axis).ravel()
 
         if R is None:
-            R = self.maxR()
+            R = self.maxR() + 0.001
         if R < 0:
             R = 0.00001
             warn(self.__class__.__name__ +
@@ -2927,7 +2927,7 @@ class Geometry(LatticeChild, _Dispatchs,
         """
         new = self.copy()
         new.set_lattice(self.lattice.add_vacuum(vacuum, axis))
-        if vacuum > self.maxR():
+        if vacuum > self.maxR() + 0.001:
             # only overwrite along axis
             nsc = [None for _ in range(3)]
             nsc[axis] = 1
@@ -3528,13 +3528,19 @@ class Geometry(LatticeChild, _Dispatchs,
         rij
             distance of the indexed atoms to the center coordinate (only for true `ret_rij`)
         """
+        maxR = self.maxR() + 0.001
         if R is None:
-            R = np.array([self.maxR() + 0.01], np.float64)
+            R = np.array([maxR], np.float64)
         elif not isndarray(R):
             R = _a.asarrayd(R).ravel()
 
         # Maximum distance queried
         max_R = R[-1]
+        if atoms is not None and max_R > maxR:
+            warn(f"{self.__class__.__name__}.close_sc has been passed an 'atoms' argument "
+                 "together with an R value larger than the orbital ranges. "
+                 "If used together with 'sparse-matrix.construct' this can result in wrong couplings.",
+                 register=True)
 
         # Convert to actual array
         if atoms is not None:
@@ -3898,7 +3904,7 @@ class Geometry(LatticeChild, _Dispatchs,
             integer lattice offsets for the couplings (related to `rij` without atomic coordinates)
         """
         if R is None:
-            R = self.maxR() + 0.01
+            R = self.maxR() + 0.001
         R = _a.asarrayd(R).ravel()
         nR = R.size
 
@@ -4407,7 +4413,7 @@ class Geometry(LatticeChild, _Dispatchs,
         rij = SparseAtom(self, nnzpr=20, dtype=dtype)
 
         # Get R
-        R = (0.1, self.maxR() + 0.01)
+        R = (0.1, self.maxR() + 0.001)
         iR = self.iR(na_iR)
 
         # Do the loop

--- a/src/sisl/geometry.py
+++ b/src/sisl/geometry.py
@@ -1097,9 +1097,9 @@ class Geometry(LatticeChild, _Dispatchs,
             yield all_idx[0], all_idx[1]
 
         if np.any(not_passed):
-            print(not_passed.nonzero()[0])
-            print(np.sum(not_passed), len(self))
-            raise SislError(f'{self.__class__.__name__}.iter_block_shape error on iterations. Not all atoms have been visited.')
+            not_passed = not_passed.nonzero()[0]
+            raise SislError(f"{self.__class__.__name__}.iter_block_shape error on iterations. Not all atoms have been visited "
+                            f"{not_passed}")
 
     def iter_block(self, iR: int=20, R: float=None,
                    atoms: Optional[AtomsArgument]=None,

--- a/src/sisl/sparse_geometry.py
+++ b/src/sisl/sparse_geometry.py
@@ -726,7 +726,7 @@ class _SparseGeometry(NDArrayOperatorsMixin):
             try:
                 if len(R) > 0:
                     R = R[-1]
-            except:
+            except TypeError:
                 pass
         except AttributeError:
             R = None

--- a/src/sisl/sparse_geometry.py
+++ b/src/sisl/sparse_geometry.py
@@ -721,7 +721,7 @@ class _SparseGeometry(NDArrayOperatorsMixin):
         iR = self.geometry.iR(na_iR)
 
         # Create eta-object
-        eta = progressbar(self.na, self.__class__.__name__ + '.construct', 'atom', eta)
+        eta = progressbar(self.na, f"{self.__class__.__name__ }.construct", 'atom', eta)
 
         # Do the loop
         for ias, idxs in self.geometry.iter_block(iR=iR, method=method):


### PR DESCRIPTION
The problem of close arose when the searched sphere was just crossing a border of the unit-cell (or supercell). In those cases could the translated to unit-cell indices miss a neighbour.

The fix was rather simple; once the atoms closests has been found, only loop over those in the primary unit-cell.

There are many other small changes here, but they
are more cosmetic and should provide more stability when using orbital distances very close to atomic coordinates.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #633 
 - [x] Tests added
 - [x] Ranned `isort .` at top--level
 - [x] Documentation for functionality, `docs/`
 - [x] Changes documented, `CHANGELOG.md`

@tfrederiksen might you have a 2nd look here, I tested on some geometries, all seems fine, but this would warrant a 2nd look