### PR TITLE
added an as_supercell which returns geometry in supercell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ we hit release version 1.0.0.
 ## [0.14.3] - YYYY-MM-DD
 
 ### Added
+- added `Geometry.as_supercell` to create the supercell structure,
+  thanks to @pfebrer for the suggestion
 - added `Lattice.to` and `Lattice.new` to function the same
   as `Geometry`, added Lattice.to["Cuboid"]
 - added `Atom.to`, currently only `to.Sphere()`

--- a/src/sisl/tests/test_geometry.py
+++ b/src/sisl/tests/test_geometry.py
@@ -1738,6 +1738,20 @@ def test_translate2uc_axes():
     assert np.allclose(gr_once.xyz, gr_individual.xyz)
 
 
+def test_as_supercell_graphene():
+    gr = sisl_geom.graphene()
+    grsc = gr.as_supercell()
+    assert np.allclose(grsc.xyz[:len(gr)], gr.xyz)
+    assert np.allclose(grsc.axyz(np.arange(gr.na_s)), gr.axyz(np.arange(gr.na_s)))
+
+
+def test_as_supercell_fcc():
+    g = sisl_geom.fcc(2 ** 0.5, Atom(1, R=1.0001))
+    gsc = g.as_supercell()
+    assert np.allclose(gsc.xyz[:len(g)], g.xyz)
+    assert np.allclose(gsc.axyz(np.arange(g.na_s)), g.axyz(np.arange(g.na_s)))
+
+
 def test_sc_warn():
     with pytest.warns(SislDeprecation):
         lattice = sisl_geom.graphene().sc


### PR DESCRIPTION
This will tile the geometry and re-order the atoms such that they correspond to the supercell.

This is primarily useful for analysing real-space quantities or couplings between supercell sites.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Documentation for functionality, `docs/`
 - [x] Changes documented, `CHANGELOG.md`

@pfebrer as we discussed on discord, here is a method to create the supercell geometry. In the end I didn't go for returning the lattice as well. The coordinates are shifted to exactly match those of the supercell, in correct order.