### PR TITLE
Optionally avoid custom node errors.

### DIFF
--- a/src/sisl/nodes/context.py
+++ b/src/sisl/nodes/context.py
@@ -9,7 +9,11 @@ SISL_NODES_CONTEXT = dict(
     # On initialization, should the node compute? If None, defaults to `lazy`.
     lazy_init=None,
     # The level of logs stored in the node.
-    log_level="INFO"
+    log_level="INFO",
+    # Whether to raise a custom error exception (e.g. NodeCalcError) By default 
+    # it is turned off because it can obscure the real problem by not showing it
+    # in the last traceback frame.
+    raise_custom_errors=False,
 )
 
 # Temporal contexts stack. It should not be used directly by users, the aim of this


### PR DESCRIPTION
Custom node errors (e.g. `NodeCalcError`), when shown directly, obscure the real cause of the error by only showing it in the handled exception's traceback. In this PR I introduce a context key to choose whether the original error or a custom node error should be raised. By default, the original error is raised now.

This should make it easier for users to understand what went wrong when running a node or workflow (plots in the viz module, for example)
