### PR TITLE
Chiral GNRs and [n]-triangulene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ we hit release version 1.0.0.
 ## [0.14.3] - 2023-11-07
 
 ### Added
+- Creation of chiral GNRs (`kind=chiral` in `sisl.geom.nanoribbon`/`sisl.geom.graphene_nanoribbon` as well as `sisl.geom.cgnr`)
+- Creation of [n]-triangulenes (`sisl.geom.triangulene`)
 - Creation of honeycomb flakes (`sisl.geom.honeycomb_flake`,
   `sisl.geom.graphene_flake`). #636
 - added `Geometry.as_supercell` to create the supercell structure,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,18 @@ we hit release version 1.0.0.
 
 ## [0.14.4] - YYYY-MM-DD
 
+### Added
+- Creation of chiral GNRs (`kind=chiral` in `sisl.geom.nanoribbon`/`sisl.geom.graphene_nanoribbon` as well as `sisl.geom.cgnr`)
+- Creation of [n]-triangulenes (`sisl.geom.triangulene`)
+
+
+### Changed
+- `vacuum` is now an optional parameter for all ribbon structures
 
 
 ## [0.14.3] - 2023-11-07
 
 ### Added
-- Creation of chiral GNRs (`kind=chiral` in `sisl.geom.nanoribbon`/`sisl.geom.graphene_nanoribbon` as well as `sisl.geom.cgnr`)
-- Creation of [n]-triangulenes (`sisl.geom.triangulene`)
 - Creation of honeycomb flakes (`sisl.geom.honeycomb_flake`,
   `sisl.geom.graphene_flake`). #636
 - added `Geometry.as_supercell` to create the supercell structure,

--- a/docs/api/default_geom.rst
+++ b/docs/api/default_geom.rst
@@ -42,6 +42,15 @@ Surfaces (slabs)
    fcc_slab
    rocksalt_slab
 
+0D materials
+============
+
+.. autosummary::
+   :toctree: generated/
+
+   honeycomb_flake
+   graphene_flake
+   triangulene
 
 1D materials
 ============
@@ -52,6 +61,7 @@ Surfaces (slabs)
    nanoribbon
    agnr
    zgnr
+   cgnr
    graphene_nanoribbon
    nanotube
    heteroribbon
@@ -67,8 +77,6 @@ Surfaces (slabs)
    honeycomb
    bilayer
    graphene
-   honeycomb_flake
-   graphene_flake
 
 
 Helpers

--- a/src/sisl/geom/flat.py
+++ b/src/sisl/geom/flat.py
@@ -8,11 +8,11 @@ from sisl._internal import set_module
 
 from ._common import geometry_define_nsc
 
-__all__ = ["honeycomb", "graphene", "honeycomb_flake", "graphene_flake"]
+__all__ = ["honeycomb", "graphene", "honeycomb_flake", "graphene_flake", "triangulene"]
 
 
 @set_module("sisl.geom")
-def honeycomb(bond: float, atoms, orthogonal: bool = False):
+def honeycomb(bond: float, atoms, orthogonal: bool = False) -> Geometry:
     """Honeycomb lattice with 2 or 4 atoms per unit-cell, latter orthogonal cell
 
     This enables creating BN lattices with ease, or graphene lattices.
@@ -65,7 +65,7 @@ def honeycomb(bond: float, atoms, orthogonal: bool = False):
 
 
 @set_module("sisl.geom")
-def graphene(bond: float = 1.42, atoms=None, orthogonal: bool = False):
+def graphene(bond: float = 1.42, atoms=None, orthogonal: bool = False) -> Geometry:
     """Graphene lattice with 2 or 4 atoms per unit-cell, latter orthogonal cell
 
     Parameters
@@ -204,3 +204,33 @@ def graphene_flake(
     if atoms is None:
         atoms = Atom(Z=6, R=bond * 1.01)
     return honeycomb_flake(shells, bond, atoms, vacuum)
+
+
+@set_module("sisl.geom")
+def triangulene(n: int, bond: float = 1.42, atoms=None) -> Geometry:
+    """Construction of an [n]-triangulene geometry
+
+    Parameters
+    ----------
+    n :
+       size of the triangulene
+    bond :
+       bond length between atoms (*not* lattice constant)
+    atoms :
+        the atom (or atoms) that the honeycomb lattice consists of.
+        Default to Carbon atom.
+    """
+    if atoms is None:
+        atoms = Atom(Z=6, R=bond * 1.01)
+    geom = graphene(bond=bond, atoms=atoms) * (n + 1, n + 1, 1)
+    idx = np.where(geom.xyz[:, 0] <= geom.cell[0, 0] + 0.01)[0]
+    geom = geom.sub(idx[1:])
+    geom.cell[:2] *= (n + 4) / (n + 1)
+
+    # Center the molecule in cell
+    geom = geom.move([geom.cell[0, 0] - geom.xyz[-1, 0], 0, geom.cell[2, 2] / 2])
+
+    # Set boundary conditions
+    geometry_define_nsc(geom, [False, False, False])
+
+    return geom

--- a/src/sisl/geom/flat.py
+++ b/src/sisl/geom/flat.py
@@ -207,7 +207,9 @@ def graphene_flake(
 
 
 @set_module("sisl.geom")
-def triangulene(n: int, bond: float = 1.42, atoms=None, vacuum: float = 20.0) -> Geometry:
+def triangulene(
+    n: int, bond: float = 1.42, atoms=None, vacuum: float = 20.0
+) -> Geometry:
     """Construction of an [n]-triangulene geometry
 
     Parameters

--- a/src/sisl/geom/flat.py
+++ b/src/sisl/geom/flat.py
@@ -231,7 +231,7 @@ def triangulene(
     geom = geom.sub(idx[1:])
 
     # Set the cell according to the requested vacuum
-    size = np.max(geom.xyz[:], axis=0) - np.min(geom.xyz[:], axis=0)
+    size = geom.xyz.max(axis=0) - geom.xyz.min(axis=0)
     geom.cell[:] = np.diag(size + vacuum)
 
     # Center the molecule in cell

--- a/src/sisl/geom/nanoribbon.py
+++ b/src/sisl/geom/nanoribbon.py
@@ -322,6 +322,7 @@ class _heteroribbon_section(CompositeGeometrySection):
     atoms: Atom = None
     bond: float = None
     kind: str = "armchair"
+    vacuum: float = 20.0
     shift_quantum: bool = False
     on_lone_atom: str = field(default="ignore", repr=False)
     invert_first: bool = field(default=False, repr=False)
@@ -422,7 +423,7 @@ class _heteroribbon_section(CompositeGeometrySection):
 
     def build_section(self, prev):
         new_section = nanoribbon(
-            bond=self.bond, atoms=self.atoms, width=self.W, kind=self.kind
+            bond=self.bond, atoms=self.atoms, width=self.W, kind=self.kind, vacuum=self.vacuum,
         )
 
         align, offset = self._align_offset(prev, new_section)
@@ -511,7 +512,7 @@ class _heteroribbon_section(CompositeGeometrySection):
         new_min = new_section[:, self.trans_ax].min()
         new_max = new_section[:, self.trans_ax].max()
         if new_min < 0:
-            cell_offset = -new_min + 14
+            cell_offset = -new_min + self.vacuum
             geom = geom.add_vacuum(cell_offset, self.trans_ax)
             move = np.zeros(3)
             move[self.trans_ax] = cell_offset
@@ -519,7 +520,7 @@ class _heteroribbon_section(CompositeGeometrySection):
             new_section = new_section.move(move)
         if new_max > geom.cell[1, 1]:
             geom = geom.add_vacuum(
-                new_max - geom.cell[self.trans_ax, self.trans_ax] + 14, self.trans_ax
+                new_max - geom.cell[self.trans_ax, self.trans_ax] + self.vacuum, self.trans_ax
             )
 
         self.xyz = new_section.xyz

--- a/src/sisl/geom/nanoribbon.py
+++ b/src/sisl/geom/nanoribbon.py
@@ -423,7 +423,11 @@ class _heteroribbon_section(CompositeGeometrySection):
 
     def build_section(self, prev):
         new_section = nanoribbon(
-            bond=self.bond, atoms=self.atoms, width=self.W, kind=self.kind, vacuum=self.vacuum,
+            bond=self.bond,
+            atoms=self.atoms,
+            width=self.W,
+            kind=self.kind,
+            vacuum=self.vacuum,
         )
 
         align, offset = self._align_offset(prev, new_section)
@@ -520,7 +524,8 @@ class _heteroribbon_section(CompositeGeometrySection):
             new_section = new_section.move(move)
         if new_max > geom.cell[1, 1]:
             geom = geom.add_vacuum(
-                new_max - geom.cell[self.trans_ax, self.trans_ax] + self.vacuum, self.trans_ax
+                new_max - geom.cell[self.trans_ax, self.trans_ax] + self.vacuum,
+                self.trans_ax,
             )
 
         self.xyz = new_section.xyz

--- a/src/sisl/geom/nanoribbon.py
+++ b/src/sisl/geom/nanoribbon.py
@@ -69,6 +69,7 @@ def nanoribbon(
     n, m = width // 2, width % 2
 
     ribbon = geom.honeycomb(bond, atoms, orthogonal=True)
+    angle = 0
 
     kind = kind.lower()
     if kind == "armchair":
@@ -121,7 +122,12 @@ def nanoribbon(
 
     geometry_define_nsc(ribbon, [True, False, False])
 
+    # move geometry into middle of the cell
     ribbon = ribbon.move(ribbon.center(what="cell") - ribbon.center())
+
+    # first atom to zero along the first lattice vector
+    x = ribbon.xyz[0]
+    ribbon = ribbon.move([x[1] * np.tan(angle) - x[0], 0, 0])
 
     return ribbon
 

--- a/src/sisl/geom/nanoribbon.py
+++ b/src/sisl/geom/nanoribbon.py
@@ -161,11 +161,11 @@ def graphene_nanoribbon(
     """
     if atoms is None:
         atoms = Atom(Z=6, R=bond * 1.01)
-    return nanoribbon(width, bond, atoms, kind=kind, chirality=chirality)
+    return nanoribbon(width, bond, atoms, kind=kind, vacuum=vacuum, chirality=chirality)
 
 
 @set_module("sisl.geom")
-def agnr(width: int, bond: float = 1.42, atoms=None) -> Geometry:
+def agnr(width: int, bond: float = 1.42, atoms=None, vacuum: float = 20.0) -> Geometry:
     r"""Construction of an armchair graphene nanoribbon
 
     Parameters
@@ -176,6 +176,8 @@ def agnr(width: int, bond: float = 1.42, atoms=None) -> Geometry:
        C-C bond length
     atoms : Atom, optional
        atom (or atoms) in the honeycomb lattice. Defaults to ``Atom(6)``
+    vacuum :
+       separation in transverse direction
 
     See Also
     --------
@@ -186,11 +188,11 @@ def agnr(width: int, bond: float = 1.42, atoms=None) -> Geometry:
     zgnr : zigzag graphene nanoribbon
     cgnr : chiral graphene nanoribbon
     """
-    return graphene_nanoribbon(width, bond, atoms, kind="armchair")
+    return graphene_nanoribbon(width, bond, atoms, kind="armchair", vacuum=vacuum)
 
 
 @set_module("sisl.geom")
-def zgnr(width: int, bond: float = 1.42, atoms=None) -> Geometry:
+def zgnr(width: int, bond: float = 1.42, atoms=None, vacuum: float = 20.0) -> Geometry:
     r"""Construction of a zigzag graphene nanoribbon
 
     Parameters
@@ -201,6 +203,9 @@ def zgnr(width: int, bond: float = 1.42, atoms=None) -> Geometry:
        C-C bond length
     atoms : Atom, optional
        atom (or atoms) in the honeycomb lattice. Defaults to ``Atom(6)``
+    vacuum :
+       separation in transverse direction
+
 
     See Also
     --------
@@ -211,25 +216,31 @@ def zgnr(width: int, bond: float = 1.42, atoms=None) -> Geometry:
     agnr : armchair graphene nanoribbon
     cgnr : chiral graphene nanoribbon
     """
-    return graphene_nanoribbon(width, bond, atoms, kind="zigzag")
+    return graphene_nanoribbon(width, bond, atoms, kind="zigzag", vacuum=vacuum)
 
 
 @set_module("sisl.geom")
-def cgnr(n: int, m: int, width: int, bond: float = 1.42, atoms=None) -> Geometry:
+def cgnr(
+    width: int,
+    chirality: Tuple[int, int],
+    bond: float = 1.42,
+    atoms=None,
+    vacuum: float = 20.0,
+) -> Geometry:
     r"""Construction of an (n, m, w)-chiral graphene nanoribbon
 
     Parameters
     ----------
-    n :
-       first chirality index (zigzag segments)
-    m :
-       second chirality index (armchair segments)
     width :
        number of atoms in the transverse direction
+    chirality :
+       index (n, m)
     bond :
        C-C bond length
     atoms : Atom, optional
        atom (or atoms) in the honeycomb lattice. Defaults to ``Atom(6)``
+    vacuum :
+       separation in transverse direction
 
     See Also
     --------
@@ -240,7 +251,9 @@ def cgnr(n: int, m: int, width: int, bond: float = 1.42, atoms=None) -> Geometry
     agnr : armchair graphene nanoribbon
     zgnr : zigzag graphene nanoribbon
     """
-    return graphene_nanoribbon(width, bond, atoms, kind="chiral", chirality=(n, m))
+    return graphene_nanoribbon(
+        width, bond, atoms, kind="chiral", vacuum=vacuum, chirality=chirality
+    )
 
 
 @set_module("sisl.geom")

--- a/src/sisl/geom/nanoribbon.py
+++ b/src/sisl/geom/nanoribbon.py
@@ -294,6 +294,8 @@ class _heteroribbon_section(CompositeGeometrySection):
         The bond length of the ribbon.
     kind: {'armchair', 'zigzag'}
         The kind of ribbon that this section should be.
+    vacuum :
+        minimum separation in transverse direction
     shift_quantum: bool, optional
         Whether the implementation will assist avoiding lone atoms (< 2 neighbours).
 

--- a/src/sisl/geom/nanoribbon.py
+++ b/src/sisl/geom/nanoribbon.py
@@ -107,7 +107,9 @@ def nanoribbon(
             ribbon = ribbon.remove(range(width))
             # determine rotation angle
             x = ribbon.cell[0]
-            angle = np.arccos(x.dot([1, 0, 0]) / x.dot(x) ** 0.5)
+            angle = np.arccos(
+                x.dot([1, 0, 0]) / x.dot(x) ** 0.5
+            )  # angle of vectors, x and b=[1, 0, 0]
             ribbon = ribbon.rotate(
                 angle, [0, 0, -1], origin=ribbon.xyz[0], rad=True, what="abc+xyz"
             )
@@ -234,7 +236,7 @@ def cgnr(
     width :
        number of atoms in the transverse direction
     chirality :
-       index (n, m)
+       index (n, m) corresponding to an edge with n zigzag segments followed by m armchair segments
     bond :
        C-C bond length
     atoms : Atom, optional

--- a/src/sisl/geom/nanoribbon.py
+++ b/src/sisl/geom/nanoribbon.py
@@ -42,7 +42,7 @@ def nanoribbon(
     kind : {'armchair', 'zigzag', 'chiral'}
        type of ribbon
     index :
-       chiral index (n, m), only processed for chiral types
+       chiral index (n, m), only used if `kind=chiral`
 
     See Also
     --------
@@ -71,7 +71,7 @@ def nanoribbon(
         else:
             ribbon = ribbon.repeat(n, 1)
 
-    elif kind in ["zigzag", "chiral"]:
+    elif kind in ("zigzag", "chiral"):
         # Construct zigzag GNR
         ribbon = ribbon.rotate(90, [0, 0, -1], what="abc+xyz")
         if m == 1:
@@ -137,10 +137,10 @@ def graphene_nanoribbon(
        C-C bond length
     atoms : Atom, optional
        atom (or atoms) in the honeycomb lattice. Defaults to ``Atom(6)``
-    kind : {'armchair', 'zigzag', 'chiral}
+    kind : {'armchair', 'zigzag', 'chiral'}
        type of ribbon
     index :
-       chiral index (n, m), only processed for chiral types
+       chiral index (n, m), only used if `kind=chiral`
 
     See Also
     --------
@@ -213,9 +213,9 @@ def cgnr(n: int, m: int, width: int, bond: float = 1.42, atoms=None) -> Geometry
     Parameters
     ----------
     n :
-       first chiral index
+       first chirality index (zigzag segments)
     m :
-       second chiral index
+       second chirality index (armchair segments)
     width :
        number of atoms in the transverse direction
     bond :

--- a/src/sisl/geom/nanoribbon.py
+++ b/src/sisl/geom/nanoribbon.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from dataclasses import dataclass, field
 from numbers import Integral
+from typing import Tuple
 
 import numpy as np
 
@@ -25,7 +26,11 @@ __all__ = [
 
 @set_module("sisl.geom")
 def nanoribbon(
-    width: int, bond: float, atoms, kind: str = "armchair", index: (int, int) = (3, 1)
+    width: int,
+    bond: float,
+    atoms,
+    kind: str = "armchair",
+    chirality: Tuple[int, int] = (3, 1),
 ) -> Geometry:
     r"""Construction of a nanoribbon unit cell of type armchair, zigzag or (n,m)-chiral.
 
@@ -41,8 +46,8 @@ def nanoribbon(
        atom (or atoms) in the honeycomb lattice
     kind : {'armchair', 'zigzag', 'chiral'}
        type of ribbon
-    index :
-       chiral index (n, m), only used if `kind=chiral`
+    chirality :
+       index (n, m), only used if `kind=chiral`
 
     See Also
     --------
@@ -90,7 +95,7 @@ def nanoribbon(
 
         if kind == "chiral":
             # continue with the zigzag ribbon as building block
-            n, m = index
+            n, m = chirality
             ribbon = ribbon.tile(n + 1, 0)
             r = ribbon.xyz[1] - ribbon.xyz[width]
             ribbon.cell[0] += r + (m - 1) * (ribbon.xyz[2] - ribbon.xyz[0])
@@ -125,7 +130,7 @@ def graphene_nanoribbon(
     bond: float = 1.42,
     atoms=None,
     kind: str = "armchair",
-    index: (int, int) = (3, 1),
+    chirality: Tuple[int, int] = (3, 1),
 ) -> Geometry:
     r"""Construction of a graphene nanoribbon
 
@@ -139,8 +144,8 @@ def graphene_nanoribbon(
        atom (or atoms) in the honeycomb lattice. Defaults to ``Atom(6)``
     kind : {'armchair', 'zigzag', 'chiral'}
        type of ribbon
-    index :
-       chiral index (n, m), only used if `kind=chiral`
+    chirality :
+       index (n, m), only used if `kind=chiral`
 
     See Also
     --------
@@ -153,7 +158,7 @@ def graphene_nanoribbon(
     """
     if atoms is None:
         atoms = Atom(Z=6, R=bond * 1.01)
-    return nanoribbon(width, bond, atoms, kind=kind, index=index)
+    return nanoribbon(width, bond, atoms, kind=kind, chirality=chirality)
 
 
 @set_module("sisl.geom")
@@ -232,7 +237,7 @@ def cgnr(n: int, m: int, width: int, bond: float = 1.42, atoms=None) -> Geometry
     agnr : armchair graphene nanoribbon
     zgnr : zigzag graphene nanoribbon
     """
-    return graphene_nanoribbon(width, bond, atoms, kind="chiral", index=(n, m))
+    return graphene_nanoribbon(width, bond, atoms, kind="chiral", chirality=(n, m))
 
 
 @set_module("sisl.geom")

--- a/src/sisl/geom/tests/test_geom.py
+++ b/src/sisl/geom/tests/test_geom.py
@@ -125,7 +125,7 @@ def test_nanoribbon():
         nanoribbon(w, 1.42, Atom(6), kind="armchair")
         nanoribbon(w, 1.42, Atom(6), kind="zigzag")
         nanoribbon(w, 1.42, Atom(6), kind="chiral")
-        nanoribbon(w, 1.42, Atom(6), kind="chiral", index=(2, 2))
+        nanoribbon(w, 1.42, Atom(6), kind="chiral", chirality=(2, 2))
         nanoribbon(w, 1.42, (Atom(5), Atom(7)), kind="armchair")
         a = nanoribbon(w, 1.42, (Atom(5), Atom(7)), kind="zigzag")
         assert is_right_handed(a)

--- a/src/sisl/geom/tests/test_geom.py
+++ b/src/sisl/geom/tests/test_geom.py
@@ -156,9 +156,9 @@ def test_zgnr():
 
 
 def test_cgnr():
-    a = cgnr(3, 1, 6)
-    a = cgnr(3, 1, 6, bond=1.6)
-    a = cgnr(3, 1, 6, atoms=["B", "N"])
+    cgnr(6, (3, 1), vacuum=0)
+    cgnr(6, (3, 1), bond=1.6)
+    a = cgnr(6, (3, 1), atoms=["B", "N"])
     assert is_right_handed(a)
 
 

--- a/src/sisl/geom/tests/test_geom.py
+++ b/src/sisl/geom/tests/test_geom.py
@@ -74,6 +74,14 @@ def test_flat_flakes():
     )
 
 
+def test_triangulene():
+    g = triangulene(3)
+    assert g.na == 22
+    g = triangulene(3, atoms=["B", "N"])
+    assert g.atoms.nspecie == 2
+    g = triangulene(3, bond=1.6)
+
+
 def test_nanotube():
     a = nanotube(1.42)
     assert is_right_handed(a)
@@ -116,6 +124,8 @@ def test_nanoribbon():
     for w in range(0, 5):
         nanoribbon(w, 1.42, Atom(6), kind="armchair")
         nanoribbon(w, 1.42, Atom(6), kind="zigzag")
+        nanoribbon(w, 1.42, Atom(6), kind="chiral")
+        nanoribbon(w, 1.42, Atom(6), kind="chiral", index=(2, 2))
         nanoribbon(w, 1.42, (Atom(5), Atom(7)), kind="armchair")
         a = nanoribbon(w, 1.42, (Atom(5), Atom(7)), kind="zigzag")
         assert is_right_handed(a)
@@ -128,6 +138,9 @@ def test_nanoribbon():
 
 
 def test_graphene_nanoribbon():
+    graphene_nanoribbon(6, kind="armchair")
+    graphene_nanoribbon(6, kind="zigzag")
+    graphene_nanoribbon(6, kind="chiral")
     a = graphene_nanoribbon(5)
     assert is_right_handed(a)
 
@@ -139,6 +152,13 @@ def test_agnr():
 
 def test_zgnr():
     a = zgnr(5)
+    assert is_right_handed(a)
+
+
+def test_cgnr():
+    a = cgnr(3, 1, 6)
+    a = cgnr(3, 1, 6, bond=1.6)
+    a = cgnr(3, 1, 6, atoms=["B", "N"])
     assert is_right_handed(a)
 
 


### PR DESCRIPTION
Following #636 I would like to propose another two characteristic honeycomb geometries, namely chiral-GNRs [characterized by the chirality index `(n, m)`] as well as [`n`]-triangulene.

 - [x] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` at top-level
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`

**Examples**
```python
import sisl
import sisl.viz
sisl.geom.cgnr(3, 2, 12).plot(axes='xy', atoms_scale=0.6, nsc=[4, 1, 1])
```
![newplot](https://github.com/zerothi/sisl/assets/11407069/12975a93-7796-453f-addf-7b9e70833492)
```python
g = sisl.geom.nanoribbon(8, bond=1.6, atoms=("B", "N"), kind="chiral", index=(3, 1))
g.plot(axes='xy', atoms_scale=0.6, nsc=[4, 1, 1])
```
![newplot](https://github.com/zerothi/sisl/assets/11407069/833cdfc2-ab3a-44d3-9a02-b70846bd403e)
```python
sisl.geom.triangulene(3).plot(axes='xy', nsc=[2, 2, 1])
```
![newplot](https://github.com/zerothi/sisl/assets/11407069/4bcb8632-cb81-4fc5-8a6e-51118e31da38)
```python
sisl.geom.triangulene(6, bond=1.6, atoms=("B", "N")).plot(axes='xy', atoms_scale=0.6)
```
![newplot](https://github.com/zerothi/sisl/assets/11407069/3bf57ce8-d4f7-4335-9ce8-9646f0f773a5)
