### PR TITLE
Growth direction of zigzag heteroribbons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ we hit release version 1.0.0.
 
 ## [0.14.4] - YYYY-MM-DD
 
+### Fixed
+- growth direction for zigzag heteroribbons
 
 
 ## [0.14.3] - 2023-11-07

--- a/src/sisl/geom/nanoribbon.py
+++ b/src/sisl/geom/nanoribbon.py
@@ -237,10 +237,8 @@ class _heteroribbon_section(CompositeGeometrySection):
     invert_first: bool = field(default=False, repr=False)
 
     def __post_init__(self):
-        if self.kind == "armchair":
+        if self.kind in ("armchair", "zigzag"):
             self.long_ax, self.trans_ax = 0, 1
-        elif self.kind == "zigzag":
-            self.long_ax, self.trans_ax = 1, 0
         else:
             raise ValueError("Unknown kind={kind}, must be one of zigzag or armchair")
 


### PR DESCRIPTION
The growth direction for heteroribbons should be the `x`-axis also for `kind=zigzag`. This PR produces expected structures, eg.:
```python
import sisl
import sisl.viz
g = sisl.geom.graphene_heteroribbon([(5, 2), (6, 3)], kind='zigzag')
g.plot(axes="xy", atoms_scale=0.6, nsc=[6, 2, 1])
```
![newplot](https://github.com/zerothi/sisl/assets/11407069/935a4ae8-089f-451b-933e-c93bb0bbd81e)

 - [ ] Closes #x
 - [ ] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` at top-level
 - [ ] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`