### PR TITLE
added sanitize to SparseCSR and __setitem__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ we hit release version 1.0.0.
 
 ## [0.14.4] - YYYY-MM-DD
 
+### Fixed
+- enabled slicing in matrix assignments, #650
+
 
 
 ## [0.14.3] - 2023-11-07

--- a/src/sisl/geometry.py
+++ b/src/sisl/geometry.py
@@ -384,6 +384,18 @@ class Geometry(
         return atoms
 
     @_sanitize_atoms.register
+    def _(self, atoms: slice) -> ndarray:
+        # TODO consider doing range(self.na)[atoms]
+        start, stop, step = atoms.start, atoms.stop, atoms.step
+        if start is None:
+            start = 0
+        if stop is None:
+            stop = self.na
+        if step is None:
+            step = 1
+        return np.arange(start, stop, step)
+
+    @_sanitize_atoms.register
     def _(self, atoms: str) -> ndarray:
         return self.names[atoms]
 
@@ -448,6 +460,17 @@ class Geometry(
     def _(self, orbitals: str) -> ndarray:
         atoms = self._sanitize_atoms(orbitals)
         return self.a2o(atoms, all=True)
+
+    @_sanitize_orbs.register
+    def _(self, orbitals: slice) -> ndarray:
+        start, stop, step = orbitals.start, orbitals.stop, orbitals.step
+        if start is None:
+            start = 0
+        if stop is None:
+            stop = self.na
+        if step is None:
+            step = 1
+        return np.arange(start, stop, step)
 
     @_sanitize_orbs.register
     def _(self, orbitals: AtomCategory) -> ndarray:

--- a/src/sisl/io/orca/tests/test_stdout.py
+++ b/src/sisl/io/orca/tests/test_stdout.py
@@ -271,7 +271,6 @@ def test_charge_orbital_reduced_unpol(sisl_files):
     assert S is None
 
 
-@pytest.mark.only
 def test_charge_orbital_full_unpol(sisl_files):
     f = sisl_files(_dir, "molecule2.output")
     out = stdoutSileORCA(f)
@@ -284,7 +283,6 @@ def test_charge_orbital_full_unpol(sisl_files):
     assert S is None
 
 
-@pytest.mark.only
 def test_read_energy(sisl_files):
     f = sisl_files(_dir, "molecule.output")
     out = stdoutSileORCA(f)

--- a/src/sisl/sparse_geometry.py
+++ b/src/sisl/sparse_geometry.py
@@ -1225,7 +1225,6 @@ class SparseAtom(_SparseGeometry):
         Override set item for slicing operations and enables easy
         setting of parameters in a sparse matrix
         """
-        dd = self._def_dim
         if len(key) > 2:
             # This may be a specification of supercell indices
             if isinstance(key[-1], tuple):
@@ -1233,6 +1232,10 @@ class SparseAtom(_SparseGeometry):
                 off = self.geometry.sc_index(key[-1]) * self.na
                 key = [el for el in key[:-1]]
                 key[1] = self.geometry.sc2uc(key[1]) + off
+        key = tuple(
+            self.geometry._sanitize_atoms(k) if i < 2 else k for i, k in enumerate(key)
+        )
+        dd = self._def_dim
         if dd >= 0:
             key = tuple(key) + (dd,)
             self._def_dim = -1
@@ -1648,7 +1651,6 @@ class SparseOrbital(_SparseGeometry):
         Override set item for slicing operations and enables easy
         setting of parameters in a sparse matrix
         """
-        dd = self._def_dim
         if len(key) > 2:
             # This may be a specification of supercell indices
             if isinstance(key[-1], tuple):
@@ -1656,6 +1658,10 @@ class SparseOrbital(_SparseGeometry):
                 off = self.geometry.sc_index(key[-1]) * self.no
                 key = [el for el in key[:-1]]
                 key[1] = self.geometry.osc2uc(key[1]) + off
+        key = tuple(
+            self.geometry._sanitize_orbs(k) if i < 2 else k for i, k in enumerate(key)
+        )
+        dd = self._def_dim
         if dd >= 0:
             key = tuple(key) + (dd,)
             self._def_dim = -1

--- a/src/sisl/tests/test_sparse_geometry.py
+++ b/src/sisl/tests/test_sparse_geometry.py
@@ -509,6 +509,12 @@ class TestSparseAtom:
         S.finalize()
         assert np.sum(S, axis=(0, 1)) == pytest.approx(1 * 2 * 2)
 
+    def test_sanitize_atoms_assign(self, setup):
+        g = graphene(atoms=Atom(6, R=1.43))
+        S = SparseAtom(g)
+        for i in range(2):
+            S[i, 1:4] = 1
+
     def test_fromsp1(self, setup):
         g = setup.g.repeat(2, 0).tile(2, 1)
         lil = sc.sparse.lil_matrix((g.na, g.na_s), dtype=np.int32)
@@ -769,3 +775,10 @@ def test_translate_sparse_atoms():
     assert transl_both[1, 1] == 2
     assert transl_both[0, 1] == 0
     assert transl_both[0, 3] == 3
+
+
+def test_sanitize_orbs_assign():
+    g = graphene(atoms=Atom(6, R=[1.43, 1.66]))
+    S = SparseOrbital(g)
+    for i in range(2):
+        S[i, 1:4] = 1


### PR DESCRIPTION
This should now work more succintly by
using a good sanitizer.
It slows down the code, a tad. The test suite
is new 3:12, vs 3:10 (with one more test).
So very little.

It should fix problem #650 and allow more easier
access to the matrix elements.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #650 
 - [x] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` at top-level
 - [x] Changes documented in `CHANGELOG.md`
