### PR TITLE
ensure that workflows have (and transmit) the right state

### DIFF
--- a/src/sisl/nodes/workflow.py
+++ b/src/sisl/nodes/workflow.py
@@ -816,6 +816,22 @@ class Workflow(Node):
 
     network = NetworkDescriptor()
 
+    def _set_outdated(self, value: bool):
+        self.nodes.output._outdated = value
+
+    def _get_outdated(self) -> bool:
+        return self.nodes.output._outdated
+
+    _outdated = property(fset=_set_outdated, fget=_get_outdated)
+
+    def _receive_output_link(self, node):
+        super()._receive_output_link(node)
+        self.nodes.output._receive_output_link(node)
+
+    def _receive_output_unlink(self, node):
+        super()._receive_output_unlink(node)
+        self.nodes.output._receive_output_unlink(node)
+
     @classmethod
     def from_node_tree(cls, output_node: Node, workflow_name: Union[str, None] = None):
         """Creates a workflow class from a node.
@@ -967,7 +983,12 @@ class Workflow(Node):
 
         It will recompute it if necessary.
         """
-        return self.nodes.output.get()
+        self._errored = False
+        try:
+            return self.nodes.output.get()
+        except:
+            self._errored = True
+            raise
 
     def update_inputs(self, **inputs):
         """Updates the inputs of the workflow."""
@@ -981,6 +1002,8 @@ class Workflow(Node):
             self.nodes.inputs[input_key].update_inputs(value=value)
 
         self._inputs.update(inputs)
+
+        self._receive_outdated()
 
         return self
 


### PR DESCRIPTION
Workflows (as opposed to simple nodes) didn't know when they were outdated or errored. This fixes it.

These fixes are part of something cool that I'm creating in the GUI:

![Screenshot from 2024-01-04 13-42-43](https://github.com/zerothi/sisl/assets/42074085/43f5672b-baa4-43c8-b0f5-db58acf130d4)

:smile: 

