### PR TITLE
WIP: Missing fdf flags error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ we hit release version 1.0.0.
 ## [0.14.4] - YYYY-MM-DD
 
 ### Added
+- better error messages when users request quantities not calculated by Siesta/TBtrans
 - `SparseCSR.toarray` to comply with array handling (equivalent to `todense`)
 - enabled `Grid.to|new` with the most basic stuff
   str|Path|Grid|pyamg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,6 +280,7 @@ known_first_party = ["sisl_toolbox", "sisl"]
 line_length = 88
 overwrite_in_place = true
 extend_skip = ["src/sisl/__init__.py"]
+multi_line_output = "VERTICAL_HANGING_INDENT"
 
 [tool.black]
 line-length = 88

--- a/src/sisl/io/_exceptions.py
+++ b/src/sisl/io/_exceptions.py
@@ -1,0 +1,144 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import warnings
+from functools import wraps
+from typing import Callable, List, Tuple, Union
+
+from sisl._internal import set_module
+from sisl.messages import SislError, SislException, SislInfo, SislWarning, info, warn
+
+__all__ = [
+    "SileError",
+    "SileWarning",
+    "SileInfo",
+    "MissingInputSileError",
+    "MissingInputSileInfo",
+    "MissingInputSileWarning",
+    "missing_input",
+]
+
+
+@set_module("sisl.io")
+class SileError(SislError, IOError):
+    """Define an error object related to the Sile objects"""
+
+    def __init__(self, value, obj=None):
+        self.value = value
+        self.obj = obj
+
+    def __str__(self):
+        if self.obj:
+            return f"{self.value!s} in {self.obj!s}"
+        return self.value
+
+
+@set_module("sisl.io")
+class SileWarning(SislWarning):
+    """Warnings that informs users of things to be carefull about when using their retrieved data
+
+    These warnings should be issued whenever a read/write routine is unable to retrieve all information
+    but are non-influential in the sense that sisl is still able to perform the action.
+    """
+
+
+@set_module("sisl.io")
+class SileInfo(SislInfo):
+    """Information for the user, this is hidden in a warning, but is not as severe so as to issue a warning."""
+
+
+InputsType = Union[List[Tuple[str, str]], List[str]]
+
+
+class MissingInputSileException(SislException):
+    """Container for constructing error/warnings when a fdf flag is missing from the input file.
+
+    This error message should preferably be raised through:
+
+    >>> raise InheritedClass(method, ["Diag.ParallelOverk"]) from exc
+
+    to retain a proper context.
+    """
+
+    def __init__(
+        self,
+        executable: str,
+        inputs: InputsType,
+        method: Callable,
+    ):
+        # Formulate the error message
+        try:
+            name = f"{method.__self__.__class__.__name__}.{method.__name__}"
+        except AttributeError:
+            name = f"{method.__name__}"
+
+        def parse(v):
+            if isinstance(v, str):
+                return f"  * {v}"
+            return f"  * {' '.join(v)}"
+
+        str_except = "\n".join(map(parse, inputs))
+
+        super().__init__(
+            f"Data from method '{name}' failed due to missing output values.\n\n"
+            f"This is because of missing options in the input file for executable {executable}.\n"
+            f"Please read up on the following flags in the manual of '{executable}' to figure out "
+            f"how to retrieve the expected quantities:\n{str_except}"
+        )
+
+
+class MissingInputSileError(MissingInputSileException, SileError):
+    """Issued when specific flags in the input file can be used to extract data"""
+
+
+class MissingInputSileWarning(MissingInputSileException, SileWarning):
+    """Issued when specific flags in the input file can be used to extract data"""
+
+
+class MissingInputSileInfo(MissingInputSileException, SileInfo):
+    """Issued when specific flags in the input file can be used to extract data"""
+
+
+def missing_input(
+    executable: str,
+    inputs: InputsType,
+    what: MissingInputSileException,
+    when_exception: Exception = Exception,
+):
+    """Issues warnings, or errors based on `when` and `what`"""
+
+    def decorator(func):
+        what_inst = what(executable, inputs, func)
+
+        if issubclass(when_exception, Warning):
+            # we should do a warning catch thing
+            @wraps(func)
+            def deco(*args, **kwargs):
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    ret = func(*args, **kwargs)
+
+                if len(w) > 0:
+                    if isinstance(what_inst, MissingInputSileWarning):
+                        warn(what_inst)
+                    elif isinstance(what_inst, MissingInputSileInfo):
+                        info(what_inst)
+                    elif isinstance(what_inst, MissingInputSileError):
+                        raise what_inst
+
+                return ret
+
+        else:
+            # it must be ane error to be raised
+            @wraps(func)
+            def deco(*args, **kwargs):
+                try:
+                    return func(*args, **kwargs)
+                except what as ke:
+                    raise what_inst from ke.__cause__
+                except when_exception as ke:
+                    raise what_inst from ke
+
+        return deco
+
+    return decorator

--- a/src/sisl/io/_exceptions.py
+++ b/src/sisl/io/_exceptions.py
@@ -12,6 +12,7 @@ __all__ = [
     "SileError",
     "SileWarning",
     "SileInfo",
+    "MissingInputSileException",
     "MissingInputSileError",
     "MissingInputSileInfo",
     "MissingInputSileWarning",
@@ -61,10 +62,7 @@ class MissingInputSileException(SislException):
     """
 
     def __init__(
-        self,
-        executable: str,
-        inputs: InputsType,
-        method: Callable,
+        self, executable: str, inputs: InputsType, method: Callable, msg: str = ""
     ):
         # Formulate the error message
         try:
@@ -80,7 +78,7 @@ class MissingInputSileException(SislException):
         str_except = "\n".join(map(parse, inputs))
 
         super().__init__(
-            f"Data from method '{name}' failed due to missing output values.\n\n"
+            f"{msg}\nData from method '{name}' failed due to missing output values.\n\n"
             f"This is because of missing options in the input file for executable {executable}.\n"
             f"Please read up on the following flags in the manual of '{executable}' to figure out "
             f"how to retrieve the expected quantities:\n{str_except}"

--- a/src/sisl/io/siesta/sile.py
+++ b/src/sisl/io/siesta/sile.py
@@ -1,9 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-from functools import wraps
-from typing import Callable, List, Union
-
 try:
     from . import _siesta
 
@@ -15,6 +12,7 @@ from sisl._internal import set_module
 
 from ..sile import (
     MissingInputSileError,
+    MissingInputSileInfo,
     Sile,
     SileBin,
     SileCDF,
@@ -27,12 +25,18 @@ __all__ = [
     "SileCDFSiesta",
     "SileBinSiesta",
     "MissingFDFSiestaError",
+    "MissingFDFSiestaInfo",
     "missing_input_fdf",
 ]
 
 
 @set_module("sisl.io.siesta")
 class MissingFDFSiestaError(MissingInputSileError):
+    pass
+
+
+@set_module("sisl.io.siesta")
+class MissingFDFSiestaInfo(MissingInputSileInfo):
     pass
 
 

--- a/src/sisl/io/siesta/sile.py
+++ b/src/sisl/io/siesta/sile.py
@@ -1,6 +1,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from functools import wraps
+from typing import Callable, List, Union
 
 try:
     from . import _siesta
@@ -11,9 +13,34 @@ except ImportError:
 
 from sisl._internal import set_module
 
-from ..sile import Sile, SileBin, SileCDF, SileError
+from ..sile import (
+    MissingInputSileError,
+    Sile,
+    SileBin,
+    SileCDF,
+    SileError,
+    missing_input,
+)
 
-__all__ = ["SileSiesta", "SileCDFSiesta", "SileBinSiesta"]
+__all__ = [
+    "SileSiesta",
+    "SileCDFSiesta",
+    "SileBinSiesta",
+    "MissingFDFSiestaError",
+    "missing_input_fdf",
+]
+
+
+@set_module("sisl.io.siesta")
+class MissingFDFSiestaError(MissingInputSileError):
+    pass
+
+
+@set_module("sisl.io.siesta")
+def missing_input_fdf(
+    inputs, executable: str = "siesta", when_exception: Exception = KeyError
+):
+    return missing_input(executable, inputs, MissingFDFSiestaError, when_exception)
 
 
 @set_module("sisl.io.siesta")

--- a/src/sisl/io/tbtrans/_cdf.py
+++ b/src/sisl/io/tbtrans/_cdf.py
@@ -12,7 +12,7 @@ import sisl._array as _a
 from sisl import Atom, Geometry, Lattice
 from sisl._indices import indices
 from sisl._internal import set_module
-from sisl.messages import info, warn
+from sisl.messages import deprecate, info, warn
 from sisl.physics.distribution import fermi_dirac
 from sisl.unit.siesta import unit_convert
 
@@ -88,7 +88,13 @@ class _ncSileTBtrans(SileCDFTBtrans):
         """The associated geometry from this file"""
         return self.read_geometry()
 
-    geom = geometry
+    @property
+    def geom(self):
+        """Same as `geometry`, but deprecated"""
+        deprecate(
+            f"{self.__class__.__name__}.geom is deprecated, please use '.geometry'."
+        )
+        return self.geometry
 
     @property
     @lru_cache(maxsize=1)

--- a/src/sisl/io/tbtrans/pht.py
+++ b/src/sisl/io/tbtrans/pht.py
@@ -41,15 +41,18 @@ class phtavncSilePHtrans(tbtavncSileTBtrans):
         return self._value("kT", self._elec(elec))[0] * Ry2eV
 
 
-for _name in [
+for _name in (
     "chemical_potential",
     "electron_temperature",
     "kT",
+    "orbital_current",
+    "bond_current",
+    "vector_current",
     "current",
     "current_parameter",
     "shot_noise",
     "noise_power",
-]:
+):
     setattr(phtncSilePHtrans, _name, None)
     setattr(phtavncSilePHtrans, _name, None)
 

--- a/src/sisl/io/tbtrans/sile.py
+++ b/src/sisl/io/tbtrans/sile.py
@@ -1,11 +1,32 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from functools import wraps
+
 from sisl._internal import set_module
+from sisl.io.siesta import MissingFDFSiestaError
 
-from ..sile import Sile, SileBin, SileCDF
+from ..sile import Sile, SileBin, SileCDF, missing_input
 
-__all__ = ["SileTBtrans", "SileCDFTBtrans", "SileBinTBtrans"]
+__all__ = [
+    "SileTBtrans",
+    "SileCDFTBtrans",
+    "SileBinTBtrans",
+    "MissingFDFTBtransError",
+    "missing_input_fdf",
+]
+
+
+@set_module("sisl.io.tbtrans")
+class MissingFDFTBtransError(MissingFDFSiestaError):
+    pass
+
+
+@set_module("sisl.io.tbtrans")
+def missing_input_fdf(
+    inputs, executable: str = "siesta", when_exception: Exception = KeyError
+):
+    return missing_input(executable, inputs, MissingFDFTBtransError, when_exception)
 
 
 @set_module("sisl.io.tbtrans")

--- a/src/sisl/io/tbtrans/sile.py
+++ b/src/sisl/io/tbtrans/sile.py
@@ -1,7 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-from functools import wraps
 
 from sisl._internal import set_module
 from sisl.io.siesta import MissingFDFSiestaError

--- a/src/sisl/io/tbtrans/tbt.py
+++ b/src/sisl/io/tbtrans/tbt.py
@@ -9,7 +9,7 @@ except Exception:
     from io import StringIO
 
 import itertools
-from functools import reduce, wraps
+from functools import reduce
 from typing import List, Optional, Union
 
 import numpy as np

--- a/src/sisl/io/tbtrans/tbt.py
+++ b/src/sisl/io/tbtrans/tbt.py
@@ -9,7 +9,8 @@ except Exception:
     from io import StringIO
 
 import itertools
-from functools import reduce
+from functools import reduce, wraps
+from typing import List, Optional, Union
 
 import numpy as np
 
@@ -41,6 +42,7 @@ from sisl.utils import (
 
 from ..sile import add_sile, get_sile, sile_raise_write
 from ._cdf import _devncSileTBtrans
+from .sile import missing_input_fdf
 
 __all__ = ["tbtncSileTBtrans", "tbtavncSileTBtrans"]
 
@@ -150,37 +152,36 @@ class tbtncSileTBtrans(_devncSileTBtrans):
         f = kwargs.get("file", f)
         tbtavncSileTBtrans(f, mode="w", access=0).write_tbtav(self)
 
-    def _value_avg(self, name, tree=None, kavg=False):
+    def _value_avg(
+        self,
+        name: str,
+        tree: Optional[Union[str, List[str]]] = None,
+        kavg: bool = False,
+    ):
         """Local method for obtaining the data from the SileCDF.
 
-        This method checks how the file is access, i.e. whether
+        This method checks how the file is accessed, i.e. whether
         data is stored in the object or it should be read consequtively.
+
+        Parameters
+        ----------
+        name: str
+            name of the variable (located in `tree`)
+        tree: str or list of str, optional
+            the group location of the variable
+        kavg: bool, optional
+            whether to k-average the quantity
         """
         if self._access > 0:
             if name in self._data:
                 return self._data[name]
 
-        try:
-            v = self._variable(name, tree=tree)
-        except KeyError as err:
-            group = None
-            if isinstance(tree, list):
-                group = ".".join(tree)
-            elif not tree is None:
-                group = tree
-            if not group is None:
-                raise KeyError(
-                    f"{self.__class__.__name__} could not retrieve key '{group}.{name}' due to missing flags in the input file."
-                )
-            raise KeyError(
-                f"{self.__class__.__name__} could not retrieve key '{name}' due to missing flags in the input file."
-            )
+        v = self._variable(name, tree=tree)
 
         if self._k_avg:
             return v[:]
 
         # Perform normalization
-        orig_shape = v.shape
         if isinstance(kavg, bool):
             if kavg:
                 wkpt = self.wk
@@ -188,13 +189,11 @@ class tbtncSileTBtrans(_devncSileTBtrans):
                 data = v[0, ...] * wkpt[0]
                 for i in range(1, nk):
                     data += v[i, :] * wkpt[i]
-                data.shape = orig_shape[1:]
             else:
                 data = v[:]
 
         elif isinstance(kavg, Integral):
             data = v[kavg, ...]
-            data.shape = orig_shape[1:]
 
         else:
             raise ValueError(
@@ -204,50 +203,54 @@ class tbtncSileTBtrans(_devncSileTBtrans):
         # Return data
         return data
 
-    def _value_E(self, name, tree=None, kavg=False, E=None):
-        """Local method for obtaining the data from the SileCDF using an E index."""
+    def _value_E(
+        self,
+        name: str,
+        tree: Optional[Union[str, List[str]]] = None,
+        kavg: bool = False,
+        E: Optional[Union[int, float]] = None,
+    ):
+        """Local method for obtaining energy resolved data from the SileCDF.
+
+        This method checks how the file is accessed, i.e. whether
+        data is stored in the object or it should be read consequtively.
+
+        Parameters
+        ----------
+        name: str
+            name of the variable (located in `tree`)
+        tree: str or list of str, optional
+            the group location of the variable
+        kavg: bool, optional
+            whether to k-average the quantity
+        E: int or float, optional
+            if provided, only extract the quantity based on the energy `E`.
+        """
         if E is None:
             return self._value_avg(name, tree, kavg)
 
         # Ensure that it is an index
         iE = self.Eindex(E)
 
-        try:
-            v = self._variable(name, tree=tree)
-        except KeyError:
-            group = None
-            if isinstance(tree, list):
-                group = ".".join(tree)
-            elif not tree is None:
-                group = tree
-            if not group is None:
-                raise KeyError(
-                    f"{self.__class__.__name__} could not retrieve key '{group}.{name}' due to missing flags in the input file."
-                )
-            raise KeyError(
-                f"{self.__class__.__name__} could not retrieve key '{name}' due to missing flags in the input file."
-            )
+        v = self._variable(name, tree=tree)
+
         if self._k_avg:
             return v[iE, ...]
 
         wkpt = self.wk
 
         # Perform normalization
-        orig_shape = v.shape
-
         if isinstance(kavg, bool):
             if kavg:
                 nk = len(wkpt)
                 data = np.array(v[0, iE, ...]) * wkpt[0]
                 for i in range(1, nk):
                     data += v[i, iE, ...] * wkpt[i]
-                data.shape = orig_shape[2:]
             else:
-                data = np.array(v[:, iE, ...])
+                data = v[:, iE, ...]
 
         elif isinstance(kavg, Integral):
-            data = np.array(v[kavg, iE, ...])
-            data.shape = orig_shape[2:]
+            data = v[kavg, iE, ...]
 
         else:
             raise ValueError(
@@ -257,6 +260,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
         # Return data
         return data
 
+    @missing_input_fdf([("TBT.T.All", "True")])
     def transmission(self, elec_from=0, elec_to=1, kavg=True) -> ndarray:
         r"""Transmission from `elec_from` to `elec_to`.
 
@@ -296,6 +300,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
 
         return self._value_avg(f"{elec_to}.T", elec_from, kavg=kavg)
 
+    @missing_input_fdf([("TBT.T.Out", "True"), ("TBT.T.All", "True")])
     def reflection(self, elec=0, kavg=True, from_single=False) -> ndarray:
         r"""Reflection into electrode `elec`
 
@@ -350,6 +355,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
 
         return BT - T
 
+    @missing_input_fdf([("TBT.T.Eig", "<int>")])
     def transmission_eig(self, elec_from=0, elec_to=1, kavg=True) -> ndarray:
         """Transmission eigenvalues from `elec_from` to `elec_to`.
 
@@ -377,6 +383,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
 
         return self._value_avg(f"{elec_to}.T.Eig", elec_from, kavg=kavg)
 
+    @missing_input_fdf([("TBT.T.Bulk", "True")])
     def transmission_bulk(self, elec=0, kavg=True) -> ndarray:
         """Bulk transmission for the `elec` electrode
 
@@ -584,6 +591,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
 
         return nDOS
 
+    @missing_input_fdf([("TBT.DOS.Gf", "True")])
     def DOS(
         self, E=None, kavg=True, atoms=None, orbitals=None, sum=True, norm="none"
     ) -> ndarray:
@@ -628,6 +636,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
             * eV2Ry
         )
 
+    @missing_input_fdf([("TBT.DOS.A", "True")])
     def ADOS(
         self,
         elec=0,
@@ -683,6 +692,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
             * eV2Ry
         )
 
+    @missing_input_fdf([("TBT.DOS.Elecs", "True")])
     def BDOS(self, elec=0, E=None, kavg=True, sum=True, norm="none") -> ndarray:
         r"""Bulk density of states (DOS) (1/eV).
 
@@ -1431,6 +1441,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
         "argument only has been deprecated in favor of what, please update your code.",
         "0.14.0",
     )
+    @missing_input_fdf([("TBT.T.Orbital", "True"), ("TBT.Current.Orb", "True")])
     def orbital_transmission(
         self, E, elec=0, kavg=True, isc=None, what: str = "all", orbitals=None
     ) -> csr_matrix:
@@ -1536,6 +1547,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
         "argument only has been deprecated in favor of what, please update your code.",
         "0.14.0",
     )
+    @missing_input_fdf([("TBT.T.Orbital", "True"), ("TBT.Current.Orb", "True")])
     def orbital_current(
         self,
         elec=0,
@@ -2106,6 +2118,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
 
         return self.sparse_orbital_to_scalar(Jij, activity=activity)
 
+    @missing_input_fdf([("TBT.DM.Gf", "True")])
     def density_matrix(
         self, E, kavg=True, isc=None, orbitals=None, geometry=None
     ) -> csr_matrix:
@@ -2159,6 +2172,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
             None, E, kavg, isc, orbitals=orbitals, geometry=geometry
         )
 
+    @missing_input_fdf([("TBT.DM.A", "True")])
     def Adensity_matrix(
         self, elec, E, kavg=True, isc=None, orbitals=None, geometry=None
     ) -> csr_matrix:
@@ -2223,6 +2237,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
             DM = DensityMatrix.fromsp(geometry, dm)
         return DM
 
+    @missing_input_fdf([("TBT.COOP.Gf", "True")])
     def orbital_COOP(self, E, kavg=True, isc=None, orbitals=None) -> csr_matrix:
         r""" Orbital COOP analysis of the Green function
 
@@ -2288,6 +2303,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
         """
         return self.orbital_ACOOP(E, None, kavg=kavg, isc=isc, orbitals=orbitals)
 
+    @missing_input_fdf([("TBT.COOP.A", "True")])
     def orbital_ACOOP(
         self, E, elec=0, kavg=True, isc=None, orbitals=None
     ) -> csr_matrix:
@@ -2447,6 +2463,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
         COOP = self.orbital_ACOOP(E, elec, kavg=kavg, isc=isc, orbitals=orbitals)
         return self.sparse_orbital_to_atom(COOP, uc)
 
+    @missing_input_fdf([("TBT.COHP.Gf", "True")])
     def orbital_COHP(self, E, kavg=True, isc=None, orbitals=None) -> csr_matrix:
         r"""Orbital resolved COHP analysis of the Green function
 
@@ -2494,6 +2511,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
         """
         return self.orbital_ACOHP(E, None, kavg=kavg, isc=isc, orbitals=orbitals)
 
+    @missing_input_fdf([("TBT.COHP.A", "True")])
     def orbital_ACOHP(
         self, E, elec=0, kavg=True, isc=None, orbitals=None
     ) -> csr_matrix:
@@ -2772,7 +2790,9 @@ class tbtncSileTBtrans(_devncSileTBtrans):
             truefalse("DOS" in gelec.variables, "DOS bulk", ["TBT.DOS.Elecs"])
             truefalse("ADOS" in gelec.variables, "DOS spectral", ["TBT.DOS.A"])
             truefalse(
-                "J" in gelec.variables, "orbital-transmission", ["TBT.Current.Orb"]
+                "J" in gelec.variables,
+                "orbital-transmission",
+                ["TBT.T.Orbital", "TBT.Current.Orb"],
             )
             truefalse("DM" in gelec.variables, "Density matrix spectral", ["TBT.DM.A"])
             truefalse("COOP" in gelec.variables, "COOP spectral", ["TBT.COOP.A"])

--- a/src/sisl/io/tbtrans/tests/test_tbt.py
+++ b/src/sisl/io/tbtrans/tests/test_tbt.py
@@ -38,9 +38,10 @@ def test_1_graphene_all_content(sisl_files):
     TBT.DOS.A T
     TBT.DOS.A.All T
 
-    # Orbital currents and Crystal-Orbital investigations.
+    # Orbital transmissions and Crystal-Orbital investigations.
     TBT.Symmetry.TimeReversal F
     TBT.Current.Orb T
+    TBT.T.Orbital T
     TBT.COOP.Gf T
     TBT.COOP.A T
     TBT.COHP.Gf T
@@ -439,8 +440,6 @@ def test_1_graphene_sparse_current(sisl_files, sisl_tmp):
 
     J = tbt.orbital_current(what="+")
     assert np.allclose(J.data, 0)
-    J = tbt.orbital_current(what="-")
-    assert np.allclose(J.data, 0)
 
 
 @pytest.mark.filterwarnings("ignore:.*requesting energy")
@@ -644,3 +643,10 @@ def test_1_graphene_all_sparse_data_orbitals(sisl_files):
     J_12 = tbt.orbital_transmission(204, 0, orbitals=[2, 3])
 
     assert J_12.nnz < J_all.nnz // 2
+
+
+def test_2_projection_raise(sisl_files):
+    tbt = sisl.get_sile(sisl_files(_dir, "2_projection.TBT.nc"))
+
+    with pytest.raises(sisl.io.tbtrans.MissingFDFTBtransError):
+        tbt.orbital_transmission(2, 0)

--- a/src/sisl/messages.py
+++ b/src/sisl/messages.py
@@ -38,35 +38,25 @@ _sisl_warn_registry = {}
 class SislException(Exception):
     """Sisl exception"""
 
-    pass
-
 
 @set_module("sisl")
 class SislError(SislException):
     """Sisl error"""
-
-    pass
 
 
 @set_module("sisl")
 class SislWarning(SislException, UserWarning):
     """Sisl warnings"""
 
-    pass
-
 
 @set_module("sisl")
 class SislDeprecation(SislWarning, FutureWarning):
     """Sisl deprecation warnings for end-users"""
 
-    pass
-
 
 @set_module("sisl")
 class SislInfo(SislWarning):
     """Sisl informations"""
-
-    pass
 
 
 @set_module("sisl")


### PR DESCRIPTION
Allows sisl to issue warnings that hints at what flags/arguments might be necessary for the parent executable (e.g. `siesta`) to enable certain outputs.

This was inspired by many issues related to missing `orbital_transmission` output. It is thus non-intrusive, but is a nice to have feature for end-users.

 - [x] Closes #386 and #669
 - [ ] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` at top-level
 - [ ] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`
