### PR TITLE
first try at implementing bond-order calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ we hit release version 1.0.0.
 ### Added
 - added an efficient neighbor finder, #393
 - enabled reading DFTB+ output Hamiltonian and overlap matrices, #579
+- `bond_order` for `DensityMatrix` objects, #507
 - better error messages when users request quantities not calculated by Siesta/TBtrans
 - functional programming of the basic sisl classes
   Now many of the `Geometry|Lattice|Grid.* manipulation routines which

--- a/src/sisl/io/siesta/_help.py
+++ b/src/sisl/io/siesta/_help.py
@@ -7,6 +7,7 @@ import sisl._array as _a
 from sisl import SislError
 from sisl._core.sparse import _rows_and_cols
 from sisl.messages import warn
+from sisl.sparse import _to_coo
 
 try:
     from . import _siesta

--- a/src/sisl/io/siesta/_help.py
+++ b/src/sisl/io/siesta/_help.py
@@ -5,9 +5,7 @@ import numpy as np
 
 import sisl._array as _a
 from sisl import SislError
-from sisl._core.sparse import _rows_and_cols
 from sisl.messages import warn
-from sisl.sparse import _to_coo
 
 try:
     from . import _siesta

--- a/src/sisl/physics/tests/test_density_matrix.py
+++ b/src/sisl/physics/tests/test_density_matrix.py
@@ -14,6 +14,7 @@ from sisl import (
     Grid,
     Lattice,
     SparseAtom,
+    SparseOrbital,
     SphericalOrbital,
     Spin,
 )
@@ -169,11 +170,17 @@ class TestDensityMatrix:
 
     @pytest.mark.parametrize("method", ["wiberg", "mayer"])
     @pytest.mark.parametrize("option", ["", ":spin"])
-    def test_bond_order(self, setup, method, option):
+    @pytest.mark.parametrize("projection", ["atom", "orbitals"])
+    def test_bond_order(self, setup, method, option, projection):
         D = setup.D.copy()
         D.construct(setup.func)
-        BO = D.bond_order(method + option)
-        assert isinstance(BO, SparseAtom)
+        BO = D.bond_order(method + option, projection)
+        if projection == "atom":
+            assert isinstance(BO, SparseAtom)
+            assert BO.shape[:2] == (D.geometry.na, D.geometry.na_s)
+        elif projection == "orbitals":
+            assert isinstance(BO, SparseOrbital)
+            assert BO.shape[:2] == (D.geometry.no, D.geometry.no_s)
 
     def test_rho1(self, setup):
         D = setup.D.copy()

--- a/src/sisl/physics/tests/test_density_matrix.py
+++ b/src/sisl/physics/tests/test_density_matrix.py
@@ -87,6 +87,7 @@ def setup():
 
 @pytest.mark.physics
 @pytest.mark.density_matrix
+@pytest.mark.densitymatrix
 class TestDensityMatrix:
     def test_objects(self, setup):
         assert len(setup.D.xyz) == 2
@@ -166,7 +167,7 @@ class TestDensityMatrix:
         assert m[0].sum() == pytest.approx(3)
         assert m[1].sum() == pytest.approx(1)
 
-    @pytest.mark.parametrize("method", ["wiberg", "mayer", "bond+anti"])
+    @pytest.mark.parametrize("method", ["wiberg", "mayer"])
     @pytest.mark.parametrize("option", ["", ":spin"])
     def test_bond_order(self, setup, method, option):
         D = setup.D.copy()

--- a/src/sisl/physics/tests/test_density_matrix.py
+++ b/src/sisl/physics/tests/test_density_matrix.py
@@ -13,6 +13,7 @@ from sisl import (
     Geometry,
     Grid,
     Lattice,
+    SparseAtom,
     SphericalOrbital,
     Spin,
 )
@@ -164,6 +165,14 @@ class TestDensityMatrix:
         m = D.mulliken("atom")
         assert m[0].sum() == pytest.approx(3)
         assert m[1].sum() == pytest.approx(1)
+
+    @pytest.mark.parametrize("method", ["wiberg", "mayer", "bond+anti"])
+    @pytest.mark.parametrize("option", ["", ":spin"])
+    def test_bond_order(self, setup, method, option):
+        D = setup.D.copy()
+        D.construct(setup.func)
+        BO = D.bond_order(method + option)
+        assert isinstance(BO, SparseAtom)
 
     def test_rho1(self, setup):
         D = setup.D.copy()


### PR DESCRIPTION
This fixes #507 by adding the Wiberg and Mayer implementations.

I am not fully sure the Mayer is correct, since the expressions are PS_abPS_ba, but due to symmetry, I would expect this to be PS_ab ** 2.

@tfrederiksen would you please have a look at whether this makes sense? I am a bit puzzled about the Mayer implementation, it just looks the same as Wiberg, except the overlap matrix, and perhaps Mayer should be the default.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #507
 - [x] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` at top-level
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`
