### PR TITLE
Added pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# This config is used by pre-commit to run hooks on files before committing them to git
+# To use it install pre-commit with:
+#     `pip install pre-commit`
+# and run
+#     `pre-commit install`
+# in the root of the repository
+# From that point onwards, pre-commit will run the hooks on every commit.
+# If pre-commit does some modification, the commit will fail. Add the
+# changes done by pre-commit and commit again.
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+# Black to format code with a consistent style
+- repo: https://github.com/psf/black-pre-commit-mirror
+  rev: 24.2.0
+  hooks:
+    - id: black-jupyter
+# isort to automatically sort imports
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+      name: isort (python)


### PR DESCRIPTION
With `pre-commit` changes to versions of the checker tools (e.g. `isort` and `black`) or even addition/removal of tools will be easier to track. That is, if this config changes, `pre-commit` will automatically update the environment when a developer tries to add a new commit. This ensures that everyone is using exactly the same tools, and that they don't forget to run them.

If `pre-commit` is not set up, this file does nothing.

To set it up:
- Install pre-commit: `pip install pre-commit`
- Run install on root directory: `pre-commit install`
