### PR TITLE
Some tweaks to atom colors

### DIFF
--- a/src/sisl/viz/data_sources/atom_data.py
+++ b/src/sisl/viz/data_sources/atom_data.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import numpy as np
 
 from sisl._core.atom import AtomGhost, PeriodicTable
@@ -65,10 +67,23 @@ def AtomNOrbitals(geometry, atoms=None):
     return geometry.sub(atoms).orbitals
 
 
-class AtomDefaultColors(AtomData):
-    # Taken from Jmol (https://jmol.sourceforge.net/jscolors/)
+class AtomColors(AtomData):
+    _fallback_color: str = "pink"
+    _atoms_colors: Dict[str, str] = {}
+
+    def function(self, geometry, atoms=None):
+        return np.array(
+            [
+                self._atoms_colors.get(atom.symbol, self._fallback_color)
+                for atom in geometry.sub(atoms).atoms
+            ]
+        )
+
+
+class JMolAtomColors(AtomColors):
+
     _atoms_colors = {
-        "H": "#FFFFFF",
+        "H": "#EDEADE",
         "He": "#D9FFFF",
         "Li": "#CC80FF",
         "Be": "#C2FF00",
@@ -177,16 +192,7 @@ class AtomDefaultColors(AtomData):
         "Bh": "#E00038",
         "Hs": "#E6002E",
         "Mt": "#EB0026",
-        "else": "pink",
     }
-
-    def function(self, geometry, atoms=None):
-        return np.array(
-            [
-                self._atoms_colors.get(atom.symbol, self._atoms_colors["else"])
-                for atom in geometry.sub(atoms).atoms
-            ]
-        )
 
 
 @AtomData.from_func

--- a/src/sisl/viz/processors/geometry.py
+++ b/src/sisl/viz/processors/geometry.py
@@ -14,7 +14,7 @@ from sisl.typing import AtomsArgument
 from sisl.utils.mathematics import fnorm
 from sisl.viz.types import AtomArrowSpec
 
-from ..data_sources.atom_data import AtomDefaultColors, AtomIsGhost, AtomPeriodicTable
+from ..data_sources.atom_data import AtomIsGhost, AtomPeriodicTable, JMolAtomColors
 from .coords import CoordsDataset, projected_1Dcoords, projected_2Dcoords
 
 # from ...types import AtomsArgument, GeometryLike, PathLike
@@ -213,7 +213,7 @@ def parse_atoms_style(
     # Add the default styles first
     atoms_style = [
         {
-            "color": AtomDefaultColors(),
+            "color": JMolAtomColors(),
             "size": AtomPeriodicTable(what="radius"),
             "opacity": AtomIsGhost(fill_true=0.4, fill_false=1.0),
             "vertices": 15,


### PR DESCRIPTION
This PR adds some changes to atom colors:

- There is one base class `AtomColors`, which you can subclass to provide a given color palette. What previously was `AtomDefaultColors` is now `JMolColors`. So now there is room for other color palettes.
- The hydrogen atom color was set to pure white, which was invisible on a white background. Now it is a pale shade of gray.
