### PR TITLE
Lazy loading of the viz module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ we hit release version 1.0.0.
 - `vacuum` is now an optional parameter for all ribbon structures
 - enabled `array_fill_repeat` with custom axis, to tile along specific
   dimensions
+- Importing `sisl.viz` explicitly is no longer needed, as it will be lazily
+  loaded whenever it is required.
 
 
 ## [0.14.3] - 2023-11-07

--- a/docs/tutorials/tutorial_es_1.ipynb
+++ b/docs/tutorials/tutorial_es_1.ipynb
@@ -8,7 +8,6 @@
    "source": [
     "import numpy as np\n",
     "from sisl import *\n",
-    "import sisl.viz\n",
     "from sisl.viz import merge_plots\n",
     "from sisl.viz.processors.math import normalize\n",
     "import matplotlib.pyplot as plt\n",

--- a/docs/tutorials/tutorial_es_2.ipynb
+++ b/docs/tutorials/tutorial_es_2.ipynb
@@ -8,7 +8,6 @@
    "source": [
     "import numpy as np\n",
     "from sisl import *\n",
-    "import sisl.viz\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "%matplotlib inline"

--- a/docs/tutorials/tutorial_siesta_1.ipynb
+++ b/docs/tutorials/tutorial_siesta_1.ipynb
@@ -11,7 +11,6 @@
     "os.chdir(\"siesta_1\")\n",
     "import numpy as np\n",
     "from sisl import *\n",
-    "import sisl.viz\n",
     "from sisl.viz import merge_plots\n",
     "from sisl.viz.processors.math import normalize\n",
     "from functools import partial\n",

--- a/docs/tutorials/tutorial_siesta_2.ipynb
+++ b/docs/tutorials/tutorial_siesta_2.ipynb
@@ -11,7 +11,6 @@
     "os.chdir(\"siesta_2\")\n",
     "import numpy as np\n",
     "from sisl import *\n",
-    "import sisl.viz\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "%matplotlib inline"

--- a/docs/visualization/viz_module/basic-tutorials/Demo.ipynb
+++ b/docs/visualization/viz_module/basic-tutorials/Demo.ipynb
@@ -25,42 +25,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Activating the viz framework\n",
-    "\n",
-    "The first thing you will need to do in order to use plots is to import `sisl.viz`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import sisl.viz"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This will load the appropiate things into sisl to use the visualization tools. You can also control the loading of the framework with an environment variable:\n",
-    "\n",
-    "```\n",
-    "SISL_VIZ_AUTOLOAD=True\n",
-    "```\n",
-    "\n",
-    "will load the framework on `import sisl`, so you won't need to explicitly import it.\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "    \n",
-    "Note\n",
-    "    \n",
-    "If you use sisl to run high performance calculations where you initialize sisl frequently it's better to have the autoloading turned off (default), as it might introduce an overhead.\n",
-    "    \n",
-    "</div>\n",
-    "\n",
-    "Now that the framework has been loaded, we can start plotting!\n",
-    "\n",
     "## Your first plots\n",
     "\n",
     "The most straightforward way to plot things in sisl is to call their `plot` method. For example if we have the path to a bands file we can call plot:"

--- a/docs/visualization/viz_module/blender/First animation.rst
+++ b/docs/visualization/viz_module/blender/First animation.rst
@@ -6,9 +6,8 @@ Below is a script that generates an animation of graphene breathing in blender:
 .. code-block:: python
 
     import sisl
-    import sisl.viz
     from sisl.viz import merge_plots
-    
+
     plots = []
     for color, opacity, scale in zip(["red", "orange", "green"], [1, 0.2, 1], [0.5, 1, 0.5]):
         geom_plot = sisl.geom.graphene().plot(backend="blender",
@@ -16,13 +15,11 @@ Below is a script that generates an animation of graphene breathing in blender:
             bonds_scale=0.01,
             atoms_scale=scale
         )
-    
+
         plots.append(geom_plot)
-    
+
     merge_plots(*plots, backend="blender", composite_method="animation", interpolated_frames=50).show()
 
 .. raw:: html
 
     <blockquote class="imgur-embed-pub" lang="en" data-id="AOfYrOD"><a href="https://imgur.com/AOfYrOD">View post on imgur.com</a></blockquote><script async src="//s.imgur.com/min/embed.js" charset="utf-8"></script>
-
-

--- a/docs/visualization/viz_module/blender/Getting started.rst
+++ b/docs/visualization/viz_module/blender/Getting started.rst
@@ -11,14 +11,14 @@ the one shipped with blender.
 
 Following, you have a step by step guide to get blender ready for plotting with sisl:
 
-1. **Install blender**. You can install by downloading it directly from their official webpage, or in any other way. 
+1. **Install blender**. You can install by downloading it directly from their official webpage, or in any other way.
 Check `their installation documentation <https://docs.blender.org/manual/en/latest/getting_started/installing/index.html>`_
 
 In ubuntu we can install it with:
 
 .. code-block:: bash
 
-    snap install blender    
+    snap install blender
 
 2. **Find out blender's python version**. You should check what is the version that blender is
 shipped with. Being `blender` the name of the executable, you can run:
@@ -53,7 +53,7 @@ Then install all the packages you want to use in blender:
     conda activate blender-python
     python -m pip install sisl[viz]
 
-4. **Find the path to the python libraries of your environment**. There are many ways to get this. 
+4. **Find the path to the python libraries of your environment**. There are many ways to get this.
 In conda, this path is in the ``CONDA_PREFIX`` environment variable. So you can just:
 
 .. code-block:: bash
@@ -93,7 +93,7 @@ What you see in the center of the screen is the default cube, you can just delet
 just press ``Supr``.
 
 Currently, you are now in the ``Layout`` tab. The easiest way to start programming is to go to the
-``Scripting`` tab. It is the last tab at the right of the tool bar. 
+``Scripting`` tab. It is the last tab at the right of the tool bar.
 
 You should see an interactive console and a text editor to write our scripts. Let's make our first
 plot using the console!
@@ -103,7 +103,6 @@ We want to plot graphene, so the simplest way is
 .. code-block:: python
 
     import sisl
-    import sisl.viz
     geom_plot = sisl.geom.graphene().plot(backend="blender", bonds_scale=0.01)
     geom_plot.show()
 
@@ -111,13 +110,13 @@ If we write these lines on the console, we should get the graphene structure in 
 
 This is the 3D model. To get an image, we need to **render**. Rendering is a process that generates an image
 from a camera (in our case the camera is the black wireframe that we see in the viewport) and the 3D model (objects, materials, lighting...).
-We can trigger our first render by pressing ``F12`` or ``Render > Render image``. 
+We can trigger our first render by pressing ``F12`` or ``Render > Render image``.
 
 There are infinite things that you can tweak in blender, but one important thing to know about is the rendering engine.
 For this image, you have used ``Eeve`` which is the default engine. It is very fast, which makes it suitable for real-time
 rendering applications. For single images that you want to publish, it is **usually worth it to use the** ``Cycles``
 **engine**. This engine does more complex calculations (following light rays as they travel through the scene). You can change it
-in the right hand side of the window, by clicking the tab with the microwave icon (*Render properties*). This should give you more realistic 
+in the right hand side of the window, by clicking the tab with the microwave icon (*Render properties*). This should give you more realistic
 looking results.
 
 Now you **know how to use sisl inside blender** play with all the settings of the ``GeometryPlot``, move the camera,
@@ -125,6 +124,3 @@ change the lighting, the background, etc... to **get amazing images for your tal
 
 Notice that not only ``GeometryPlot`` has support for blender, ``GridPlot`` and ``GeometryPlot`` also support it.
 Try to plot a grid and let's see how it looks!
-
-
-

--- a/docs/visualization/viz_module/diy/Adding new backends.ipynb
+++ b/docs/visualization/viz_module/diy/Adding new backends.ipynb
@@ -20,7 +20,6 @@
    "outputs": [],
    "source": [
     "import sisl\n",
-    "import sisl.viz\n",
     "\n",
     "geom = sisl.geom.graphene(orthogonal=True)\n",
     "H = sisl.Hamiltonian(geom)\n",

--- a/docs/visualization/viz_module/showcase/AtomicMatrixPlot.ipynb
+++ b/docs/visualization/viz_module/showcase/AtomicMatrixPlot.ipynb
@@ -31,7 +31,6 @@
    "outputs": [],
    "source": [
     "import sisl\n",
-    "import sisl.viz\n",
     "\n",
     "import numpy as np"
    ]

--- a/docs/visualization/viz_module/showcase/BandsPlot.ipynb
+++ b/docs/visualization/viz_module/showcase/BandsPlot.ipynb
@@ -28,7 +28,6 @@
    "outputs": [],
    "source": [
     "import sisl\n",
-    "import sisl.viz\n",
     "\n",
     "# This is just for convenience to retreive files\n",
     "siesta_files = (\n",

--- a/docs/visualization/viz_module/showcase/FatbandsPlot.ipynb
+++ b/docs/visualization/viz_module/showcase/FatbandsPlot.ipynb
@@ -27,8 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sisl\n",
-    "import sisl.viz"
+    "import sisl"
    ]
   },
   {

--- a/docs/visualization/viz_module/showcase/GeometryPlot.ipynb
+++ b/docs/visualization/viz_module/showcase/GeometryPlot.ipynb
@@ -28,7 +28,6 @@
    "outputs": [],
    "source": [
     "import sisl\n",
-    "import sisl.viz\n",
     "import numpy as np"
    ]
   },

--- a/docs/visualization/viz_module/showcase/GridPlot.ipynb
+++ b/docs/visualization/viz_module/showcase/GridPlot.ipynb
@@ -36,7 +36,6 @@
    "outputs": [],
    "source": [
     "import sisl\n",
-    "import sisl.viz\n",
     "import numpy as np\n",
     "\n",
     "# This is just for convenience to retreive files\n",

--- a/docs/visualization/viz_module/showcase/PdosPlot.ipynb
+++ b/docs/visualization/viz_module/showcase/PdosPlot.ipynb
@@ -28,7 +28,6 @@
    "outputs": [],
    "source": [
     "import sisl\n",
-    "import sisl.viz\n",
     "\n",
     "# This is just for convenience to retreive files\n",
     "siesta_files = (\n",

--- a/docs/visualization/viz_module/showcase/SitesPlot.ipynb
+++ b/docs/visualization/viz_module/showcase/SitesPlot.ipynb
@@ -32,7 +32,6 @@
    "outputs": [],
    "source": [
     "import sisl\n",
-    "import sisl.viz\n",
     "import numpy as np"
    ]
   },

--- a/docs/visualization/viz_module/showcase/WavefunctionPlot.ipynb
+++ b/docs/visualization/viz_module/showcase/WavefunctionPlot.ipynb
@@ -37,8 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sisl\n",
-    "import sisl.viz"
+    "import sisl"
    ]
   },
   {

--- a/docs/visualization/viz_module/showcase/_template/Showcase template.ipynb
+++ b/docs/visualization/viz_module/showcase/_template/Showcase template.ipynb
@@ -27,8 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sisl\n",
-    "import sisl.viz"
+    "import sisl"
    ]
   },
   {

--- a/src/sisl/__init__.py
+++ b/src/sisl/__init__.py
@@ -156,8 +156,25 @@ Lattice.to.register("Sile", Lattice.to._dispatchs[str])
 # sisl.geom.graphene
 import sisl.geom as geom
 
-if _environ.get_environ_variable("SISL_VIZ_AUTOLOAD"):
-    from . import viz
+# Set all the placeholders for the plot attribute
+# of sisl classes
+from ._lazy_viz import set_viz_placeholders
+
+set_viz_placeholders()
+
+# If someone tries to get the viz attribute, we will load the viz module
+_LOADED_VIZ = False
+
+
+def __getattr__(name):
+    global _LOADED_VIZ
+    if name == "viz" and not _LOADED_VIZ:
+        _LOADED_VIZ = True
+        import sisl.viz
+
+        return sisl.viz
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
 
 from ._ufuncs import expose_registered_methods
 

--- a/src/sisl/_environ.py
+++ b/src/sisl/_environ.py
@@ -129,19 +129,6 @@ register_environ_variable(
 )
 
 register_environ_variable(
-    "SISL_VIZ_AUTOLOAD",
-    "false",
-    dedent(
-        """\
-                          Determines whether the visualization module is automatically loaded.
-                          It may be good to leave auto load off if you are doing performance critical
-                          calculations to avoid the overhead of loading the visualization module.
-                          """
-    ),
-    process=lambda val: val and val.lower().strip() in ["1", "t", "true"],
-)
-
-register_environ_variable(
     "SISL_SHOW_PROGRESS",
     "false",
     "Whether routines which can enable progress bars should show them by default or not.",

--- a/src/sisl/_lazy_viz.py
+++ b/src/sisl/_lazy_viz.py
@@ -1,0 +1,50 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Module that sets a placeholder for the plot method in sisl classes.
+
+When the plot attribute is accessed, sisl.viz is imported and the placeholders are
+all removed, presumably to be replaced by the actual plot handlers."""
+import sisl
+
+__all__ = ["set_viz_placeholders", "clear_viz_placeholders"]
+
+# Classes that will have a plot attribute placeholder
+lazy_viz_classes = [
+    sisl.Geometry,
+    sisl.Grid,
+    sisl.BrillouinZone,
+    sisl.SparseCSR,
+    sisl.SparseOrbital,
+    sisl.SparseAtom,
+    sisl.EigenstateElectron,
+    sisl.io.Sile,
+]
+
+
+class PlotHandlerPlaceholder:
+    """Placeholder to set as "plot" attribute for plotables while sisl.viz is not imported."""
+
+    def __get__(self, instance, owner):
+        # Import sisl.viz, which will remove all the placeholders and
+        # set the actual plot handlers as the "plot" attribute.
+        import sisl.viz
+
+        # Return the plot handler
+        if instance is None:
+            return owner.plot
+        else:
+            return instance.plot
+
+
+def set_viz_placeholders():
+    """Set the plot attribute to a placeholder for all the classes."""
+    placeholder = PlotHandlerPlaceholder()
+    # Set the plot attribute to the placeholder for all the classes
+    for cls in lazy_viz_classes:
+        cls.plot = placeholder
+
+
+def clear_viz_placeholders():
+    for cls in lazy_viz_classes:
+        del cls.plot

--- a/src/sisl/viz/__init__.py
+++ b/src/sisl/viz/__init__.py
@@ -9,6 +9,13 @@ Visualization utilities
 
 import os
 
+# Placeholders for 'plot' attributes are set in the classes while
+# sisl.viz is not loaded. Now we are loading it, so just remove those
+# placeholders.
+from sisl._lazy_viz import clear_viz_placeholders
+
+clear_viz_placeholders()
+
 from sisl._environ import register_environ_variable
 
 try:

--- a/src/sisl/viz/_plotables_register.py
+++ b/src/sisl/viz/_plotables_register.py
@@ -8,17 +8,18 @@ It does so by patching them accordingly
 """
 import sisl
 import sisl.io.siesta as siesta
-
-# import sisl.io.tbtrans as tbtrans
 from sisl.io.sile import BaseSile, get_siles
 
 from ._plotables import register_data_source, register_plotable, register_sile_method
 from .data import *
 from .plots import *
 
-# from .old_plot import Plot
-# from .plotutils import get_plot_classes
-
+# ======================
+#     IMPORTANT NOTE
+# ======================
+# If you register a new plotable class, make sure it is included in the
+# lazy_viz_classes list in sisl/_lazy_viz.py, so that a placeholder is set for
+# its plot attribute.
 
 __all__ = []
 


### PR DESCRIPTION
 - [x] Closes #690 
 - [x] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` [24.2.0] at top-level
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`

As proposed in #690, now the sisl module is lazily loaded, so no need for explicitly importing `sisl.viz` or the existence of the `SISL_VIZ_AUTOLOAD` variable anymore. 

I updated the documentation accordingly.
