### PR TITLE
Fix wheels workflow

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -77,6 +77,7 @@ jobs:
       # Upload the wheel to the action's articfact.
       - uses: actions/upload-artifact@v4
         with:
+          name: artifact-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   # Build the source distribution as well
@@ -105,7 +106,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          merge-multiple: True
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.8.11


### PR DESCRIPTION
You don't know it yet, but by updating to upload-artifact@v4, the wheels workflow was deemed to fail because multiple jobs can't upload to the same artifact anymore: https://code.forgejo.org/actions/upload-artifact#not-uploading-to-the-same-artifact

This PR fixes it by creating multiple artifacts and merging all of them on download.