### PR TITLE
added typing in lots of io places, added SileSlicer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ we hit release version 1.0.0.
 - removed `Selector` and `TimeSelector`, they were never used internally
 
 ### Changed
+- `stdoutSileSiesta.read_*` now defaults to read the *next* entry, and not the last
+- `stdoutSileSiesta.read_*` changed MD output functionality, see #586 for details
 - `AtomNeighbours` changed name to `AtomNeighbor` to follow #393
 - removed `Lattice.translate|move`, they did not make sense, and so their
   usage should be deferred to `Lattice.add` instead.
@@ -66,7 +68,7 @@ we hit release version 1.0.0.
 
 ### Added
 - Creation of honeycomb flakes (`sisl.geom.honeycomb_flake`,
-  `sisl.geom.graphene_flake`). #636
+  `sisl.geom.graphene_flake`), #636
 - added `Geometry.as_supercell` to create the supercell structure,
   thanks to @pfebrer for the suggestion
 - added `Lattice.to` and `Lattice.new` to function the same

--- a/src/sisl/_core/lattice.py
+++ b/src/sisl/_core/lattice.py
@@ -23,7 +23,7 @@ from sisl._dispatch_class import _Dispatchs
 from sisl._dispatcher import AbstractDispatch, ClassDispatcher, TypeDispatcher
 from sisl._internal import set_module
 from sisl._math_small import cross3, dot3
-from sisl.messages import SislError, deprecate, deprecation, info, warn
+from sisl.messages import SislError, deprecate, deprecation, warn
 from sisl.shape.prism4 import Cuboid
 from sisl.typing import Axes, Axies, Axis
 from sisl.utils.mathematics import fnorm
@@ -274,7 +274,7 @@ class Lattice(
                     "must have that BC."
                 )
             if changed.any() and (~bc).all() and nsc > 1:
-                info(
+                warn(
                     f"{self.__class__.__name__}.set_boundary_condition is having image connections (nsc={nsc}>1) "
                     "while having a non-periodic boundary condition."
                 )

--- a/src/sisl/_core/tests/test_lattice.py
+++ b/src/sisl/_core/tests/test_lattice.py
@@ -563,7 +563,7 @@ def test_lattice_bc_fail():
 
 def test_lattice_info():
     lat = Lattice(1, nsc=[3, 3, 3])
-    with pytest.warns(sisl.SislInfo) as record:
+    with pytest.warns(sisl.SislWarning) as record:
         lat.set_boundary_condition(b=Lattice.BC.DIRICHLET)
         lat.set_boundary_condition(c=Lattice.BC.PERIODIC)
         assert len(record) == 1

--- a/src/sisl/io/cube.py
+++ b/src/sisl/io/cube.py
@@ -32,11 +32,11 @@ class cubeSile(Sile):
     )
     def write_lattice(
         self,
-        lattice,
-        fmt="15.10e",
+        lattice: Lattice,
+        fmt: str = "15.10e",
         size=None,
         origin=None,
-        unit="Bohr",
+        unit: str = "Bohr",
         *args,
         **kwargs,
     ):
@@ -44,15 +44,15 @@ class cubeSile(Sile):
 
         Parameters
         ----------
-        lattice : Lattice
+        lattice :
             lattice to be written
-        fmt : str, optional
+        fmt :
             floating point format for stored values
         size : (3, ), optional
             shape of the stored grid (``[1, 1, 1]``)
         origin : (3, ), optional
             origin of the cell (``[0, 0, 0]``)
-        unit: str, optional
+        unit:
             what length unit should the cube file data be written in
         """
         sile_raise_write(self)
@@ -83,11 +83,11 @@ class cubeSile(Sile):
     @sile_fh_open()
     def write_geometry(
         self,
-        geometry,
-        fmt="15.10e",
+        geometry: Geometry,
+        fmt: str = "15.10e",
         size=None,
         origin=None,
-        unit="Bohr",
+        unit: str = "Bohr",
         *args,
         **kwargs,
     ):
@@ -95,15 +95,15 @@ class cubeSile(Sile):
 
         Parameters
         ----------
-        geometry : Geometry
+        geometry :
             geometry to be written
-        fmt : str, optional
+        fmt :
             floating point format for stored values
         size : (3, ), optional
             shape of the stored grid (``[1, 1, 1]``)
         origin : (3, ), optional
             origin of the cell (``[0, 0, 0]``)
-        unit: str, optional
+        unit:
             what length unit should the cube file data be written in
         """
         sile_raise_write(self)
@@ -140,24 +140,32 @@ class cubeSile(Sile):
             )
 
     @sile_fh_open()
-    def write_grid(self, grid, fmt=".5e", imag=False, unit="Bohr", *args, **kwargs):
+    def write_grid(
+        self,
+        grid: Grid,
+        fmt: str = ".5e",
+        imag: bool = False,
+        unit: str = "Bohr",
+        *args,
+        **kwargs,
+    ):
         """Write `Grid` to the contained file
 
         Parameters
         ----------
-        grid : Grid
+        grid :
            the grid to be written in the CUBE file
-        fmt : str, optional
+        fmt :
            format used for precision output
-        imag : bool, optional
+        imag :
            write only imaginary part of the grid, default to only writing the
            real part.
-        buffersize : int, optional
-           size of the buffer while writing the data, (6144)
-        unit: str, optional
+        unit:
             what length unit should the cube file data be written in.
             The grid data is assumed to be unit-less, this unit only refers
             to the lattice vectors and atomic coordinates.
+        buffersize : int, optional
+           size of the buffer while writing the data, (6144)
         """
         # Check that we can write to the file
         sile_raise_write(self)
@@ -220,7 +228,7 @@ class cubeSile(Sile):
         return header
 
     @sile_fh_open()
-    def read_lattice(self, na=False):
+    def read_lattice(self, na: bool = False):
         """Returns `Lattice` object from the CUBE file
 
         Parameters

--- a/src/sisl/io/siesta/bands.py
+++ b/src/sisl/io/siesta/bands.py
@@ -23,7 +23,7 @@ class bandsSileSiesta(SileSiesta):
         return float(self.readline())
 
     @sile_fh_open()
-    def read_data(self, as_dataarray=False):
+    def read_data(self, as_dataarray: bool = False):
         """Returns data associated with the bands file
 
         The energy levels are shifted with respect to the Fermi-level.

--- a/src/sisl/io/siesta/fa.py
+++ b/src/sisl/io/siesta/fa.py
@@ -28,7 +28,7 @@ class faSileSiesta(SileSiesta):
         return f
 
     @sile_fh_open()
-    def write_force(self, f, fmt=".9e"):
+    def write_force(self, f, fmt: str = ".9e"):
         """Write forces to file
 
         Parameters

--- a/src/sisl/io/siesta/fc.py
+++ b/src/sisl/io/siesta/fc.py
@@ -1,6 +1,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from typing import Optional
+
 import numpy as np
 
 from sisl._internal import set_module
@@ -18,7 +20,9 @@ class fcSileSiesta(SileSiesta):
     """Force constant file"""
 
     @sile_fh_open()
-    def read_force(self, displacement=None, na=None):
+    def read_force(
+        self, displacement: Optional[float] = None, na: Optional[int] = None
+    ):
         """Reads all displacement forces by multiplying with the displacement value
 
         Since the force constant file does not contain the non-displaced configuration
@@ -33,12 +37,12 @@ class fcSileSiesta(SileSiesta):
 
         Parameters
         ----------
-        displacement : float, optional
+        displacement :
            the used displacement in the calculation, since Siesta 4.1-b4 this value
            is written in the FC file and hence not required.
            If prior Siesta versions are used and this is not supplied the 0.04 Bohr displacement
            will be assumed.
-        na : int, optional
+        na :
            number of atoms in geometry (for returning correct number of atoms), since Siesta 4.1-b4
            this value is written in the FC file and hence not required.
            If prior Siesta versions are used then the file is expected to only contain 1-atom displacement.
@@ -67,12 +71,12 @@ class fcSileSiesta(SileSiesta):
         return self.read_force_constant(na) * displacement.reshape(1, 3, 2, 1, 1)
 
     @sile_fh_open()
-    def read_force_constant(self, na=None):
+    def read_force_constant(self, na: Optional[int] = None):
         """Reads the force-constant stored in the FC file
 
         Parameters
         ----------
-        na : int, optional
+        na :
            number of atoms in the unit-cell, if not specified it will guess on only
            one atom displacement.
 

--- a/src/sisl/io/siesta/kp.py
+++ b/src/sisl/io/siesta/kp.py
@@ -1,10 +1,14 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from typing import Optional, Union
+
 import numpy as np
 
+from sisl import Lattice, LatticeChild
 from sisl._internal import set_module
 from sisl.messages import deprecate_argument
+from sisl.physics.brillouinzone import BrillouinZone
 from sisl.unit.siesta import unit_convert
 
 from ..sile import add_sile, sile_fh_open, sile_raise_write
@@ -13,6 +17,8 @@ from .sile import SileSiesta
 __all__ = ["kpSileSiesta", "rkpSileSiesta"]
 
 Bohr2Ang = unit_convert("Bohr", "Ang")
+
+TLattice = Optional[Union[Lattice, LatticeChild]]
 
 
 @set_module("sisl.io.siesta")
@@ -23,12 +29,12 @@ class kpSileSiesta(SileSiesta):
     @deprecate_argument(
         "sc", "lattice", "use lattice= instead of sc=", from_version="0.15"
     )
-    def read_data(self, lattice=None):
+    def read_data(self, lattice: TLattice = None):
         """Returns K-points from the file (note that these are in reciprocal units)
 
         Parameters
         ----------
-        lattice : LatticeChild, optional
+        lattice :
            if supplied the returned k-points will be in reduced coordinates
 
         Returns
@@ -53,7 +59,7 @@ class kpSileSiesta(SileSiesta):
         return np.dot(k, lattice.cell.T / (2 * np.pi)), w
 
     @sile_fh_open()
-    def write_data(self, k, weight, fmt=".9e"):
+    def write_data(self, k, weight, fmt: str = ".9e"):
         """Writes K-points to file
 
         Parameters
@@ -78,7 +84,7 @@ class kpSileSiesta(SileSiesta):
     @deprecate_argument(
         "sc", "lattice", "use lattice= instead of sc=", from_version="0.15"
     )
-    def read_brillouinzone(self, lattice):
+    def read_brillouinzone(self, lattice: TLattice):
         """Returns K-points from the file (note that these are in reciprocal units)
 
         Parameters
@@ -99,7 +105,7 @@ class kpSileSiesta(SileSiesta):
         return bz
 
     @sile_fh_open()
-    def write_brillouinzone(self, bz, fmt=".9e"):
+    def write_brillouinzone(self, bz: BrillouinZone, fmt: str = ".9e"):
         """Writes BrillouinZone-points to file
 
         Parameters
@@ -146,7 +152,7 @@ class rkpSileSiesta(kpSileSiesta):
     @deprecate_argument(
         "sc", "lattice", "use lattice= instead of sc=", from_version="0.15"
     )
-    def read_brillouinzone(self, lattice):
+    def read_brillouinzone(self, lattice: TLattice):
         """Returns K-points from the file
 
         Parameters
@@ -167,7 +173,7 @@ class rkpSileSiesta(kpSileSiesta):
         return bz
 
     @sile_fh_open()
-    def write_brillouinzone(self, bz, fmt=".9e"):
+    def write_brillouinzone(self, bz: BrillouinZone, fmt: str = ".9e"):
         """Writes BrillouinZone-points to file
 
         Parameters

--- a/src/sisl/io/siesta/pdos.py
+++ b/src/sisl/io/siesta/pdos.py
@@ -53,7 +53,7 @@ class pdosSileSiesta(SileSiesta):
         return Ef
 
     @sile_fh_open(True)
-    def read_data(self, as_dataarray=False):
+    def read_data(self, as_dataarray: bool = False):
         r"""Returns data associated with the PDOS file
 
         For spin-polarized calculations the returned values are up/down, orbitals, energy.
@@ -390,7 +390,7 @@ will store the spin x/y components of all atoms in spin_x_all.dat/spin_y_all.dat
             "-E",
             action=ERange,
             help="""Denote the sub-section of energies that are extracted: "-1:0,1:2" [eV]
-                       
+
                        This flag takes effect on all energy-resolved quantities and is reset whenever --plot or --out is called""",
         )
 

--- a/src/sisl/io/siesta/struct.py
+++ b/src/sisl/io/siesta/struct.py
@@ -21,15 +21,15 @@ class structSileSiesta(SileSiesta):
     """Geometry file"""
 
     @sile_fh_open()
-    def write_geometry(self, geometry, fmt=".9f"):
+    def write_geometry(self, geometry: Geometry, fmt: str = ".9f"):
         """Writes the geometry to the contained file
 
         Parameters
         ----------
-        geometry : Geometry
-           geometry to write in the XV file
-        fmt : str, optional
-           the precision used for writing the XV file
+        geometry :
+           geometry to write in the STRUCT file
+        fmt :
+           the precision used for writing the coordinates in the file
         """
         # Check that we can write to the file
         sile_raise_write(self)
@@ -51,7 +51,7 @@ class structSileSiesta(SileSiesta):
                 self._write(fmt_str.format(ips + 1, a.Z, *fxyz[ia]))
 
     @sile_fh_open()
-    def read_lattice(self):
+    def read_lattice(self) -> Lattice:
         """Returns `Lattice` object from the STRUCT file"""
 
         cell = np.empty([3, 3], np.float64)
@@ -61,7 +61,7 @@ class structSileSiesta(SileSiesta):
         return Lattice(cell)
 
     @sile_fh_open()
-    def read_geometry(self, species_Z=False):
+    def read_geometry(self, species_Z: bool = False) -> Geometry:
         """Returns a `Geometry` object from the STRUCT file
 
         Parameters

--- a/src/sisl/io/siesta/xv.py
+++ b/src/sisl/io/siesta/xv.py
@@ -21,14 +21,14 @@ class xvSileSiesta(SileSiesta):
     """Geometry file"""
 
     @sile_fh_open()
-    def write_geometry(self, geometry, fmt=".9f", velocity=None):
+    def write_geometry(self, geometry: Geometry, fmt: str = ".9f", velocity=None):
         """Writes the geometry to the contained file
 
         Parameters
         ----------
-        geometry : Geometry
+        geometry :
            geometry to write in the XV file
-        fmt : str, optional
+        fmt :
            the precision used for writing the XV file
         velocity : numpy.ndarray, optional
            velocities to write in the XV file (will be zero if not specified).
@@ -68,7 +68,7 @@ class xvSileSiesta(SileSiesta):
                 self._write(fmt_str.format(ips + 1, a.Z, *tmp))
 
     @sile_fh_open()
-    def read_lattice(self):
+    def read_lattice(self) -> Lattice:
         """Returns `Lattice` object from the XV file"""
 
         cell = np.empty([3, 3], np.float64)
@@ -79,15 +79,17 @@ class xvSileSiesta(SileSiesta):
         return Lattice(cell)
 
     @sile_fh_open()
-    def read_geometry(self, velocity=False, species_Z=False):
+    def read_geometry(
+        self, velocity: bool = False, species_Z: bool = False
+    ) -> Geometry:
         """Returns a `Geometry` object from the XV file
 
         Parameters
         ----------
-        species_Z : bool, optional
+        species_Z :
            if ``True`` the atomic numbers are the species indices (useful when
            reading the ChemicalSpeciesLabel block simultaneously).
-        velocity : bool, optional
+        velocity :
            also return the velocities in the file
 
         Returns

--- a/src/sisl/io/tests/test_object.py
+++ b/src/sisl/io/tests/test_object.py
@@ -22,6 +22,7 @@ from sisl.io import *
 from sisl.io.siesta.binaries import _gfSileSiesta
 from sisl.io.tbtrans._cdf import *
 from sisl.io.vasp import chgSileVASP
+from sisl.io.xsf import xsfSile
 
 pytestmark = pytest.mark.io
 _dir = osp.join("sisl", "io")
@@ -275,7 +276,7 @@ class TestObject:
         L.set_nsc([1, 1, 1])
         f = sisl_tmp("test_read_write_geom.win", _dir)
         # These files does not store the atomic species
-        if issubclass(sile, (_ncSileTBtrans, deltancSileTBtrans)):
+        if issubclass(sile, (xsfSile, _ncSileTBtrans, deltancSileTBtrans)):
             return
         if sys.platform.startswith("win") and issubclass(sile, chgSileVASP):
             pytest.xfail(
@@ -308,7 +309,7 @@ class TestObject:
         L.set_nsc([1, 1, 1])
         f = sisl_tmp("test_read_write_geom.win", _dir)
         # These files does not store the atomic species
-        if issubclass(sile, (_ncSileTBtrans, deltancSileTBtrans)):
+        if issubclass(sile, (xsfSile, _ncSileTBtrans, deltancSileTBtrans)):
             return
         if sys.platform.startswith("win") and issubclass(sile, chgSileVASP):
             pytest.xfail(

--- a/src/sisl/io/xyz.py
+++ b/src/sisl/io/xyz.py
@@ -4,6 +4,8 @@
 """
 Sile object for reading/writing XYZ files
 """
+from typing import Optional
+
 import numpy as np
 
 import sisl._array as _a
@@ -23,7 +25,7 @@ __all__ = ["xyzSile"]
 class xyzSile(Sile):
     """XYZ file object"""
 
-    def _parse_lattice(self, header, xyz, lattice):
+    def _parse_lattice(self, header: str, xyz, lattice: Optional[Lattice]):
         """Internal helper routine for extracting the lattice"""
         if lattice is not None:
             return lattice
@@ -42,6 +44,7 @@ class xyzSile(Sile):
                     bc.append(BoundaryCondition.PERIODIC)
                 else:
                     bc.append(BoundaryCondition.UNKNOWN)
+
         if "boundary_condition" in header:
             bc = []
             for b in header.pop("boundary_condition").split():
@@ -62,7 +65,9 @@ class xyzSile(Sile):
         return Lattice(cell, nsc=nsc, origin=origin, boundary_condition=bc)
 
     @sile_fh_open()
-    def write_geometry(self, geometry, fmt=".8f", comment=None):
+    def write_geometry(
+        self, geometry: Geometry, fmt: str = ".8f", comment: Optional[str] = None
+    ):
         """Writes the geometry to the contained file
 
         Parameters
@@ -124,7 +129,7 @@ class xyzSile(Sile):
     @deprecate_argument(
         "sc", "lattice", "use lattice= instead of sc=", from_version="0.15"
     )
-    def read_geometry(self, atoms=None, lattice=None):
+    def read_geometry(self, atoms=None, lattice: Optional[Lattice] = None):
         """Returns Geometry object from the XYZ file
 
         Parameters


### PR DESCRIPTION
Added lots of typehints in the code, primarily in the io code base.

Changed the way the siesta.stdout siles handle data. They now rely on the SileSlicer and thus can be sliced upon calling. It makes the code a little simpler but also highligted some problems.

In particular the problem arise when the return function needs to do different things depending on whether the file is done reading, or not.

The defaults for stdoutSileSiesta has changed to read the next entry in the file. This is in contrast to the way it was. It will require users to adapt!
the reason for this can be found in the discussion in #586.

This streamlines the usage across the different parts of the IO handling.

@pfebrer I would be interested in your view on whether we could adapt these changes to the `read_scf` method, i.e. slicing would act on MD indices.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #x
 - [x] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` [24.2.0] at top-level
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`
