### PR TITLE
Optimize nsc after reading Hamiltonian from wann90 output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ we hit release version 1.0.0.
 ## [0.15.0] - YYYY-MM-DD
 
 ### Added
+- enabled `winSileWannier90.read_hamiltonian` to read the ``_tb.dat`` files
 - `atoms` argument to `DensityMatrix.spin_align` to align a subset of atoms
   (only diagonal elements between the atoms orbitals)
 - added an efficient neighbor finder, #393

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -363,9 +363,9 @@ class winSileWannier90(SileWannier90):
             Hr = Hr + 1j * Hi
 
         H = Hamiltonian.fromsp(geom, Hr)
-
+        
         # Optimize nsc by searching for the maximum interaction range
-        sc_orbs = list(j for i, j in H.iter_nnz())
+        sc_orbs = list(j for i,j in H.iter_nnz())
         iscs = H.o2isc(np.unique(sc_orbs))
         nsc = 2 * np.max(np.abs(iscs), 0) + 1
         H.set_nsc(nsc)

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -363,9 +363,9 @@ class winSileWannier90(SileWannier90):
             Hr = Hr + 1j * Hi
 
         H = Hamiltonian.fromsp(geom, Hr)
-        
+
         # Optimize nsc by searching for the maximum interaction range
-        sc_orbs = list(j for i,j in H.iter_nnz())
+        sc_orbs = list(j for i, j in H.iter_nnz())
         iscs = H.o2isc(np.unique(sc_orbs))
         nsc = 2 * np.max(np.abs(iscs), 0) + 1
         H.set_nsc(nsc)

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -362,15 +362,7 @@ class winSileWannier90(SileWannier90):
             Hi = Hi.tocsr()
             Hr = Hr + 1j * Hi
 
-        H = Hamiltonian.fromsp(geom, Hr)
-        
-        # Optimize nsc by searching for the maximum interaction range
-        sc_orbs = list(j for i,j in H.iter_nnz())
-        iscs = H.o2isc(np.unique(sc_orbs))
-        nsc = 2 * np.max(np.abs(iscs), 0) + 1
-        H.set_nsc(nsc)
-
-        return H
+        return Hamiltonian.fromsp(geom, Hr)
 
     def read_hamiltonian(self, *args, **kwargs):
         """Read the electronic structure of the Wannier90 output

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -401,7 +401,7 @@ class winSileWannier90(SileWannier90):
 
             # Get Hamiltonian matrix elements
             Hr = Hsc[tuple(isc)]
-            for j in range(no**2):
+            for _ in range(no**2):
                 l = self.readline().split()
 
                 # Get row and column):
@@ -415,7 +415,7 @@ class winSileWannier90(SileWannier90):
                     h = hr
 
                 if abs(h) > cutoff:
-                    Hsc[tuple(isc)][r - 1, c - 1] = h
+                    Hr[r - 1, c - 1] = h
 
         return _construct_hamiltonian(geometry, Hsc)
 

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -362,7 +362,15 @@ class winSileWannier90(SileWannier90):
             Hi = Hi.tocsr()
             Hr = Hr + 1j * Hi
 
-        return Hamiltonian.fromsp(geom, Hr)
+        H = Hamiltonian.fromsp(geom, Hr)
+        
+        # Optimize nsc by searching for the maximum interaction range
+        sc_orbs = list(j for i,j in H.iter_nnz())
+        iscs = H.o2isc(np.unique(sc_orbs))
+        nsc = 2 * np.max(np.abs(iscs), 0) + 1
+        H.set_nsc(nsc)
+
+        return H
 
     def read_hamiltonian(self, *args, **kwargs):
         """Read the electronic structure of the Wannier90 output

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -450,6 +450,8 @@ class winSileWannier90(SileWannier90):
             if H is not None:
                 return H
 
+        return None
+
     def ArgumentParser(self, p=None, *args, **kwargs):
         """Returns the arguments that is available for this Sile"""
         newkw = Geometry._ArgumentParser_args_single()

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -422,7 +422,6 @@ class winSileWannier90(SileWannier90):
         Hsc_r = defaultdict(lambda: lil_matrix((geom.no, geom.no), dtype=np.float64))
         Hsc_i = defaultdict(lambda: lil_matrix((geom.no, geom.no), dtype=np.float64))
 
-        isc = [0, 0, 0]
         # Parse hamiltonian matrix elements
         for iws in np.arange(nrpts):
             l = self.readline() # Skip empty line


### PR DESCRIPTION
Before this change, the `nsc` attribute of the Hamtilonian read from wann90 output, was often unnecessarily large. 

The change made in the PR explicitly checks what the maximum range of interactions is after truncation with a specified cutoff. 

Relying on the built-in 'optimize_nsc' is impossible because the Wannier orbitals do not have a specified orbital range.