### PR TITLE
fixed #700 by reverting 7cf88f1a5

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,5 +1,4 @@
-# We use some functionality in 1.13 (np.unique)
-numpy>=1.13
+numpy>=1.19.5
 scipy>=1.5
 pyparsing>=1.5.7
 xarray>=0.10

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,7 @@ Required dependencies
 Running sisl requires these versions:
 
 - `Python`_ 3.8 or above
-- `numpy`_ (1.13 or later)
+- `numpy`_ (1.19.5 or later)
 - `scipy`_ (1.5 or later)
 - `pyparsing`_ (1.5.7 or later)
 - `xarray`_ (0.10.0 or later)
@@ -213,4 +213,3 @@ A basic procedure would be:
 
    git clone https://github.com/zerothi/sisl-files.git
    SISL_FILES_TESTS=$(pwd)/sisl-files/tests pytest --pyargs sisl
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     # TODO work-arounds for windows installations
     "numpy>=1.19.5 ; sys_platform == 'win32' and python_version <= '3.9'",
     "numpy>=1.21.5 ; sys_platform == 'win32' and python_version >= '3.10'",
-    "numpy>=1.13 ; sys_platform != 'win32'",
+    "numpy>=1.19.5 ; sys_platform != 'win32'",
     "scipy>=1.5",
     "pyparsing>=1.5.7",
     "xarray>=0.10",

--- a/src/sisl/_core/tests/test_sparse.py
+++ b/src/sisl/_core/tests/test_sparse.py
@@ -1036,10 +1036,9 @@ def test_op3():
         j = range(i * 4, i * 4 + 3)
         S[0, j] = i
 
-    for op in ["add", "sub", "mul", "pow"]:
+    for op in ("add", "sub", "mul", "pow"):
         func = getattr(S, f"__{op}__")
         s = func(1)
-        # 1 will promote to whatever numpy will cast it to
         assert s.dtype == np.int32
         s = func(1.0)
         assert s.dtype == np.float64
@@ -1048,7 +1047,7 @@ def test_op3():
             assert s.dtype == np.complex128
 
     S = S.copy(dtype=np.float64)
-    for op in ["add", "sub", "mul", "pow"]:
+    for op in ("add", "sub", "mul", "pow"):
         func = getattr(S, f"__{op}__")
         s = func(1)
         assert s.dtype == np.float64
@@ -1059,7 +1058,7 @@ def test_op3():
             assert s.dtype == np.complex128
 
     S = S.copy(dtype=np.complex128)
-    for op in ["add", "sub", "mul", "pow"]:
+    for op in ("add", "sub", "mul", "pow"):
         func = getattr(S, f"__{op}__")
         s = func(1)
         assert s.dtype == np.complex128

--- a/src/sisl/physics/densitymatrix.py
+++ b/src/sisl/physics/densitymatrix.py
@@ -692,17 +692,6 @@ class _densitymatrix(SparseOrbitalBZSpin):
         eta : bool, optional
            show a progressbar on stdout
         """
-        try:
-            # Once unique has the axis keyword, we know we can safely
-            # use it in this routine
-            # Otherwise we raise an ImportError
-            unique([[0, 1], [2, 3]], axis=0)
-        except Exception:
-            raise NotImplementedError(
-                f"{self.__class__.__name__}.density requires numpy >= 1.13, either update "
-                "numpy or do not use this function!"
-            )
-
         geometry = self.geometry
         # Check that the atomic coordinates, really are all within the intrinsic supercell.
         # If not, it may mean that the DM does not conform to the primary unit-cell paradigm
@@ -953,7 +942,6 @@ class _densitymatrix(SparseOrbitalBZSpin):
             idx[idx[:, 2] < 0, 2] = 0
             idx[shape[2] <= idx[:, 2], 2] = shape[2] - 1
 
-            # Remove duplicates, requires numpy >= 1.13
             idx = unique(idx, axis=0)
             if len(idx) == 0:
                 eta.update()

--- a/src/sisl/physics/state.py
+++ b/src/sisl/physics/state.py
@@ -1119,8 +1119,6 @@ coefficients assigned to each state
                 if matrix:
                     ret = (v,)
                 else:
-                    # numpy >= 1.9 returns a read-only view of the data,
-                    # so take a copy to ensure editable state
                     ret = (np.diagonal(v, axis1=1, axis2=2).copy(),)
 
             else:


### PR DESCRIPTION
In 7cf88f1a5243541d9d86fae42c34b518a0cb02ed the introduction of ufunc.resolve_types was done.
However, this is not a viable approach when dealing with older numpy versions.
Instead we now fully rely on the return value of the ufunc. This should bypass any dtype argument handling and hopefully work with many versions of numpy.

This bumps numpy to 1.19.5. It should not really be a problem, since that is already quite old.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [X] Closes #700 
 - [x] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` [24.2.0] at top-level
 - [x] Documentation for functionality in `docs/`
 - [ ] Changes documented in `CHANGELOG.md`
