### PR TITLE
removed txtSileOrca.no/info.no since it was never present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ we hit release version 1.0.0.
   be done for assigning matrix elements (it fills with 0's).
 
 ### Removed
+- removed `txtSileOrca.info.no` since it was not present in any txt files
 - removed `Selector` and `TimeSelector`, they were never used internally
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ we hit release version 1.0.0.
 - A new `AtomicMatrixPlot` to plot sparse matrices, #668
 
 ### Fixed
+- `txtSileOrca.info.no` used a wrong regex, added a test
 - raises error when requesting isosurface for complex valued grids, #709
 - some attributes associated with `Sile.info.*` will now warn instead of raising information
 - reading matrices from HSX files with *weird* labels, should now work (*fingers-crossed*)
@@ -61,7 +62,6 @@ we hit release version 1.0.0.
   be done for assigning matrix elements (it fills with 0's).
 
 ### Removed
-- removed `txtSileOrca.info.no` since it was not present in any txt files
 - removed `Selector` and `TimeSelector`, they were never used internally
 
 ### Changed

--- a/src/sisl/io/orca/stdout.py
+++ b/src/sisl/io/orca/stdout.py
@@ -27,11 +27,13 @@ class stdoutSileORCA(SileORCA):
             "na",
             r".*Number of atoms",
             lambda attr, match: int(match.string.split()[-1]),
+            not_found="error",
         ),
         _A(
             "no",
             r".*Number of basis functions",
             lambda attr, match: int(match.string.split()[-1]),
+            not_found="error",
         ),
         _A(
             "vdw_correction",

--- a/src/sisl/io/orca/tests/test_txt.py
+++ b/src/sisl/io/orca/tests/test_txt.py
@@ -80,3 +80,9 @@ def test_multiple_calls(sisl_files):
     assert len(G) == 2
     N = out.read_electrons[:]()
     assert len(N) == 2
+
+
+def test_info_no(sisl_files):
+    f = sisl_files(_dir, "molecule3_property.txt")
+    out = txtSileORCA(f)
+    assert out.info.no == 284

--- a/src/sisl/io/orca/tests/test_txt.py
+++ b/src/sisl/io/orca/tests/test_txt.py
@@ -1,5 +1,4 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import os.path as osp
 import sys
@@ -18,7 +17,6 @@ def test_tags(sisl_files):
     f = sisl_files(_dir, "molecule_property.txt")
     out = txtSileORCA(f)
     assert out.info.na == 2
-    assert out.info.no == None
 
 
 def test_read_electrons(sisl_files):

--- a/src/sisl/io/orca/txt.py
+++ b/src/sisl/io/orca/txt.py
@@ -27,6 +27,13 @@ class txtSileORCA(SileORCA):
             "na",
             r".*Number of atoms:",
             lambda attr, match: int(match.string.split()[-1]),
+            not_found="error",
+        ),
+        _A(
+            "no",
+            r".*number of basis functions:",
+            lambda attr, match: int(match.string.split()[-1]),
+            not_found="error",
         ),
         _A(
             "vdw_correction",
@@ -42,6 +49,12 @@ class txtSileORCA(SileORCA):
     def na(self):
         """Number of atoms"""
         return self.info.na
+
+    @property
+    @deprecation("txtSileORCA.no is deprecated in favor of txtSileORCA.info.no", "0.16")
+    def no(self):
+        """Number of orbitals (basis functions)"""
+        return self.info.no
 
     @SileBinder(postprocess=np.array)
     @sile_fh_open()

--- a/src/sisl/io/orca/txt.py
+++ b/src/sisl/io/orca/txt.py
@@ -29,11 +29,6 @@ class txtSileORCA(SileORCA):
             lambda attr, match: int(match.string.split()[-1]),
         ),
         _A(
-            "no",
-            r".*Number of basis functions:",
-            lambda attr, match: int(match.string.split()[-1]),
-        ),
-        _A(
             "vdw_correction",
             r".*\$ VdW_Correction",
             lambda attr, match: True,
@@ -47,12 +42,6 @@ class txtSileORCA(SileORCA):
     def na(self):
         """Number of atoms"""
         return self.info.na
-
-    @property
-    @deprecation("txtSileORCA.no is deprecated in favor of txtSileORCA.info.no", "0.16")
-    def no(self):
-        """Number of orbitals (basis functions)"""
-        return self.info.no
 
     @SileBinder(postprocess=np.array)
     @sile_fh_open()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

@tfrederiksen I checked the tests, in none (of the two examples) are the number of basis functions present, will they ever be?
This PR suggests to remove the attribute if it will never be present?
If this is not the case, then please let me know. :)

- [x] Changes documented in `CHANGELOG.md`
