### PR TITLE
Fix for reading spinful CHG/CHGCAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ we hit release version 1.0.0.
 - A new `AtomicMatrixPlot` to plot sparse matrices, #668
 
 ### Fixed
+- fixed `chgSileVASP.read_grid` for spinful calculations
 - `txtSileOrca.info.no` used a wrong regex, added a test
 - raises error when requesting isosurface for complex valued grids, #709
 - some attributes associated with `Sile.info.*` will now warn instead of raising information

--- a/src/sisl/io/vasp/chg.py
+++ b/src/sisl/io/vasp/chg.py
@@ -66,13 +66,19 @@ class chgSileVASP(carSileVASP):
         vals = []
         vext = vals.extend
 
+        is_chgcar = True
         i = 0
         while i < n * max_index:
-            vext(rl().split())
+            line = rl().split()
+            # CHG: 10 columns, CHGCAR: 5 columns
+            if is_chgcar and len(line) > 5:
+                # we have a data line with more than 5 columns, must be a CHG file
+                is_chgcar = False
+            vext(line)
             i = len(vals)
 
             if i % n == 0 and i < n * max_index:
-                if self.base_file.startswith("CHGCAR"):
+                if is_chgcar:
                     # Read over augmentation occupancies
                     line = rl()
                     while "augmentation" in line:

--- a/src/sisl/io/vasp/chg.py
+++ b/src/sisl/io/vasp/chg.py
@@ -72,11 +72,15 @@ class chgSileVASP(carSileVASP):
             i = len(vals)
 
             if i % n == 0 and i < n * max_index:
-                # Each time a new spin-index is present, we need to read the coordinates
-                j = 0
-                while j < geom.na:
-                    j += len(rl().split())
-
+                if self.base_file.startswith("CHGCAR"):
+                    # Read over augmentation occupancies
+                    line = rl()
+                    while "augmentation" in line:
+                        occ = int(line.split()[-1])
+                        j = 0
+                        while j < occ:
+                            j += len(rl().split())
+                        line = rl()
                 # one line of nx, ny, nz
                 rl()
 

--- a/src/sisl/io/vasp/tests/test_chg.py
+++ b/src/sisl/io/vasp/tests/test_chg.py
@@ -42,51 +42,46 @@ def test_graphene_chgcar_index_float(sisl_files):
     assert grid.grid.sum() / 2 == pytest.approx(gridh.grid.sum())
 
 
-def test_nitric_oxide_chg(sisl_files):
-    for spin in "unpol", "pol", "soi":
-        f = sisl_files(_dir, f"nitric_oxide/{spin}", "CHG.gz")
-        grid = chgSileVASP(f).read_grid()
-        gridf32 = chgSileVASP(f).read_grid(dtype=np.float32)
-        geom = chgSileVASP(f).read_geometry()
-
-        assert grid.grid.sum() * grid.dvolume == pytest.approx(11)
-        assert gridf32.grid.sum() * gridf32.dvolume == pytest.approx(11)
-        assert geom == grid.geometry
+@pytest.fixture(scope="module", params=["unpol", "pol", "soi"])
+def spin_conf(request):
+    return request.param
 
 
-def test_nitric_oxide_chgcar(sisl_files):
-    for spin in "unpol", "pol", "soi":
-        f = sisl_files(_dir, f"nitric_oxide/{spin}", "CHGCAR.gz")
-        grid = chgSileVASP(f).read_grid()
-        gridf32 = chgSileVASP(f).read_grid(dtype=np.float32)
-        geom = chgSileVASP(f).read_geometry()
-
-        assert grid.grid.sum() * grid.dvolume == pytest.approx(11)
-        assert gridf32.grid.sum() * gridf32.dvolume == pytest.approx(11)
-        assert geom == grid.geometry
+@pytest.fixture(scope="module", params=["CHG", "CHGCAR"])
+def chg_type(request):
+    return request.param
 
 
-def test_nitric_oxide_pol(sisl_files):
-    for fn in "CHG.gz", "CHGCAR.gz":
-        f = sisl_files(_dir, f"nitric_oxide/pol", fn)
-        grid = chgSileVASP(f).read_grid(1)
-        gridf32 = chgSileVASP(f).read_grid(1, dtype=np.float32)
-        geom = chgSileVASP(f).read_geometry()
+def test_nitric_oxide_chg(sisl_files, spin_conf, chg_type):
+    f = sisl_files(_dir, f"nitric_oxide/{spin_conf}", chg_type + ".gz")
+    grid = chgSileVASP(f).read_grid()
+    gridf32 = chgSileVASP(f).read_grid(dtype=np.float32)
+    geom = chgSileVASP(f).read_geometry()
 
-        assert grid.grid.sum() * grid.dvolume == pytest.approx(1, rel=1e-3)
-        assert gridf32.grid.sum() * gridf32.dvolume == pytest.approx(1, rel=1e-3)
-        assert geom == grid.geometry
+    assert grid.grid.sum() * grid.dvolume == pytest.approx(11)
+    assert gridf32.grid.sum() * gridf32.dvolume == pytest.approx(11)
+    assert geom == grid.geometry
 
 
-def test_nitric_oxide_soi(sisl_files):
-    for fn in "CHG.gz", "CHGCAR.gz":
-        f = sisl_files(_dir, f"nitric_oxide/soi", fn)
-        s, sf32 = 0, 0
-        for i in range(1, 4):
-            grid = chgSileVASP(f).read_grid(i)
-            gridf32 = chgSileVASP(f).read_grid(i, dtype=np.float32)
-            s += (grid.grid.sum() * grid.dvolume) ** 2
-            sf32 += (gridf32.grid.sum() * gridf32.dvolume) ** 2
+def test_nitric_oxide_pol(sisl_files, chg_type):
+    f = sisl_files(_dir, "nitric_oxide/pol", chg_type + ".gz")
+    grid = chgSileVASP(f).read_grid(1)
+    gridf32 = chgSileVASP(f).read_grid(1, dtype=np.float32)
+    geom = chgSileVASP(f).read_geometry()
 
-        assert s == pytest.approx(1, rel=1e-3)
-        assert sf32 == pytest.approx(1, rel=1e-3)
+    assert grid.grid.sum() * grid.dvolume == pytest.approx(1, rel=1e-3)
+    assert gridf32.grid.sum() * gridf32.dvolume == pytest.approx(1, rel=1e-3)
+    assert geom == grid.geometry
+
+
+def test_nitric_oxide_soi(sisl_files, chg_type):
+    f = sisl_files(_dir, "nitric_oxide/soi", chg_type + ".gz")
+    s, sf32 = 0, 0
+    for i in range(1, 4):
+        grid = chgSileVASP(f).read_grid(i)
+        gridf32 = chgSileVASP(f).read_grid(i, dtype=np.float32)
+        s += (grid.grid.sum() * grid.dvolume) ** 2
+        sf32 += (gridf32.grid.sum() * gridf32.dvolume) ** 2
+
+    assert s == pytest.approx(1, rel=1e-3)
+    assert sf32 == pytest.approx(1, rel=1e-3)

--- a/src/sisl/io/vasp/tests/test_chg.py
+++ b/src/sisl/io/vasp/tests/test_chg.py
@@ -12,25 +12,22 @@ pytestmark = [pytest.mark.io, pytest.mark.vasp]
 _dir = osp.join("sisl", "io", "vasp")
 
 
-def test_graphene_chg(sisl_files):
-    f = sisl_files(_dir, "graphene", "CHG")
-    grid = chgSileVASP(f).read_grid()
-    gridf32 = chgSileVASP(f).read_grid(dtype=np.float32)
+@pytest.fixture(scope="module", params=["CHG", "CHGCAR"])
+def chg_type(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=[np.float64, np.float32])
+def np_dtype(request):
+    return request.param
+
+
+def test_graphene_chg(sisl_files, chg_type, np_dtype):
+    f = sisl_files(_dir, "graphene", chg_type)
+    grid = chgSileVASP(f).read_grid(dtype=np_dtype)
     geom = chgSileVASP(f).read_geometry()
 
     assert grid.grid.sum() * grid.dvolume == pytest.approx(8)
-    assert gridf32.grid.sum() * gridf32.dvolume == pytest.approx(8)
-    assert geom == grid.geometry
-
-
-def test_graphene_chgcar(sisl_files):
-    f = sisl_files(_dir, "graphene", "CHGCAR")
-    grid = chgSileVASP(f).read_grid()
-    gridf32 = chgSileVASP(f).read_grid(index=0, dtype=np.float32)
-    geom = chgSileVASP(f).read_geometry()
-
-    assert grid.grid.sum() * grid.dvolume == pytest.approx(8)
-    assert gridf32.grid.sum() * gridf32.dvolume == pytest.approx(8)
     assert geom == grid.geometry
 
 
@@ -47,41 +44,29 @@ def spin_conf(request):
     return request.param
 
 
-@pytest.fixture(scope="module", params=["CHG", "CHGCAR"])
-def chg_type(request):
-    return request.param
-
-
-def test_nitric_oxide_chg(sisl_files, spin_conf, chg_type):
+def test_nitric_oxide_chg(sisl_files, spin_conf, chg_type, np_dtype):
     f = sisl_files(_dir, f"nitric_oxide/{spin_conf}", chg_type + ".gz")
-    grid = chgSileVASP(f).read_grid()
-    gridf32 = chgSileVASP(f).read_grid(dtype=np.float32)
+    grid = chgSileVASP(f).read_grid(dtype=np_dtype)
     geom = chgSileVASP(f).read_geometry()
 
     assert grid.grid.sum() * grid.dvolume == pytest.approx(11)
-    assert gridf32.grid.sum() * gridf32.dvolume == pytest.approx(11)
     assert geom == grid.geometry
 
 
-def test_nitric_oxide_pol(sisl_files, chg_type):
+def test_nitric_oxide_pol(sisl_files, chg_type, np_dtype):
     f = sisl_files(_dir, "nitric_oxide/pol", chg_type + ".gz")
-    grid = chgSileVASP(f).read_grid(1)
-    gridf32 = chgSileVASP(f).read_grid(1, dtype=np.float32)
+    grid = chgSileVASP(f).read_grid(1, dtype=np_dtype)
     geom = chgSileVASP(f).read_geometry()
 
     assert grid.grid.sum() * grid.dvolume == pytest.approx(1, rel=1e-3)
-    assert gridf32.grid.sum() * gridf32.dvolume == pytest.approx(1, rel=1e-3)
     assert geom == grid.geometry
 
 
-def test_nitric_oxide_soi(sisl_files, chg_type):
+def test_nitric_oxide_soi(sisl_files, chg_type, np_dtype):
     f = sisl_files(_dir, "nitric_oxide/soi", chg_type + ".gz")
-    s, sf32 = 0, 0
+    s = 0,
     for i in range(1, 4):
-        grid = chgSileVASP(f).read_grid(i)
-        gridf32 = chgSileVASP(f).read_grid(i, dtype=np.float32)
+        grid = chgSileVASP(f).read_grid(i, dtype=np_dtype)
         s += (grid.grid.sum() * grid.dvolume) ** 2
-        sf32 += (gridf32.grid.sum() * gridf32.dvolume) ** 2
 
     assert s == pytest.approx(1, rel=1e-3)
-    assert sf32 == pytest.approx(1, rel=1e-3)

--- a/src/sisl/io/vasp/tests/test_chg.py
+++ b/src/sisl/io/vasp/tests/test_chg.py
@@ -40,3 +40,53 @@ def test_graphene_chgcar_index_float(sisl_files):
     gridh = chgSileVASP(f).read_grid(index=[0.5])
 
     assert grid.grid.sum() / 2 == pytest.approx(gridh.grid.sum())
+
+
+def test_nitric_oxide_chg(sisl_files):
+    for spin in "unpol", "pol", "soi":
+        f = sisl_files(_dir, f"nitric_oxide/{spin}", "CHG.gz")
+        grid = chgSileVASP(f).read_grid()
+        gridf32 = chgSileVASP(f).read_grid(dtype=np.float32)
+        geom = chgSileVASP(f).read_geometry()
+
+        assert grid.grid.sum() * grid.dvolume == pytest.approx(11)
+        assert gridf32.grid.sum() * gridf32.dvolume == pytest.approx(11)
+        assert geom == grid.geometry
+
+
+def test_nitric_oxide_chgcar(sisl_files):
+    for spin in "unpol", "pol", "soi":
+        f = sisl_files(_dir, f"nitric_oxide/{spin}", "CHGCAR.gz")
+        grid = chgSileVASP(f).read_grid()
+        gridf32 = chgSileVASP(f).read_grid(dtype=np.float32)
+        geom = chgSileVASP(f).read_geometry()
+
+        assert grid.grid.sum() * grid.dvolume == pytest.approx(11)
+        assert gridf32.grid.sum() * gridf32.dvolume == pytest.approx(11)
+        assert geom == grid.geometry
+
+
+def test_nitric_oxide_pol(sisl_files):
+    for fn in "CHG.gz", "CHGCAR.gz":
+        f = sisl_files(_dir, f"nitric_oxide/pol", fn)
+        grid = chgSileVASP(f).read_grid(1)
+        gridf32 = chgSileVASP(f).read_grid(1, dtype=np.float32)
+        geom = chgSileVASP(f).read_geometry()
+
+        assert grid.grid.sum() * grid.dvolume == pytest.approx(1, rel=1e-3)
+        assert gridf32.grid.sum() * gridf32.dvolume == pytest.approx(1, rel=1e-3)
+        assert geom == grid.geometry
+
+
+def test_nitric_oxide_soi(sisl_files):
+    for fn in "CHG.gz", "CHGCAR.gz":
+        f = sisl_files(_dir, f"nitric_oxide/soi", fn)
+        s, sf32 = 0, 0
+        for i in range(1, 4):
+            grid = chgSileVASP(f).read_grid(i)
+            gridf32 = chgSileVASP(f).read_grid(i, dtype=np.float32)
+            s += (grid.grid.sum() * grid.dvolume) ** 2
+            sf32 += (gridf32.grid.sum() * gridf32.dvolume) ** 2
+
+        assert s == pytest.approx(1, rel=1e-3)
+        assert sf32 == pytest.approx(1, rel=1e-3)

--- a/src/sisl/io/vasp/tests/test_chg.py
+++ b/src/sisl/io/vasp/tests/test_chg.py
@@ -64,7 +64,7 @@ def test_nitric_oxide_pol(sisl_files, chg_type, np_dtype):
 
 def test_nitric_oxide_soi(sisl_files, chg_type, np_dtype):
     f = sisl_files(_dir, "nitric_oxide/soi", chg_type + ".gz")
-    s = 0,
+    s = 0
     for i in range(1, 4):
         grid = chgSileVASP(f).read_grid(i, dtype=np_dtype)
         s += (grid.grid.sum() * grid.dvolume) ** 2


### PR DESCRIPTION
I encountered a problem when reading spinful `CHG` and `CHGCAR` files. I'm unsure if the file formats could have changed, but as far as I can see, in VASP version 5.4.4 only the latter format contains "augmentation occupancies" blocks.

I also added a couple of new tests with a nitric oxide molecule in the cell.

 - [ ] Closes #x
 - [x] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` [24.2.0] at top-level
 - [ ] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`
