### PR TITLE
Add `read_gtensor` and `read_hyperfine_coupling` to `txtSileORCA`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ we hit release version 1.0.0.
 
 ### Added
 - "Hz", "MHz", "GHz", "THz", and "invcm" as valid energy units, #725
+- added `read_gtensor` and `read_hyperfine_coupling` to `txtSileORCA`, #722
 - enabled `AtomsArgument` and `OrbitalsArgument` to accept `bool` for *all* or *none*
 - enabled `winSileWannier90.read_hamiltonian` to read the ``_tb.dat`` files
 - `atoms` argument to `DensityMatrix.spin_align` to align a subset of atoms

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,6 +1,21 @@
 %comment{This file was created with betterbib v4.3.11.}
 
 
+@article{Sengupta2023,
+  author    = {Sengupta, Sanghita and Frederiksen, Thomas and Giedke, Geza},
+  title     = {Hyperfine interactions in open-shell planar $s{p}^{2}$-carbon nanostructures},
+  journal   = {Phys. Rev. B},
+  year      = {2023},
+  volume    = {107},
+  pages     = {224433},
+  month     = {Jun},
+  doi       = {10.1103/PhysRevB.107.224433},
+  issue     = {22},
+  numpages  = {19},
+  publisher = {American Physical Society},
+  url       = {https://link.aps.org/doi/10.1103/PhysRevB.107.224433},
+}
+
 @article{TopInvTut,
  author = {Blanco de Paz, Mar{\'\i}a and Devescovi, Chiara and Giedke, Geza and Saenz, Juan Jos\'e and Vergniory, Maia G. and Bradlyn, Barry and Bercioux, Dario and Garc{\'\i}a-Etxarri, Aitzol},
  doi = {10.1002/qute.201900117},

--- a/src/sisl/_core/geometry.py
+++ b/src/sisl/_core/geometry.py
@@ -3451,11 +3451,11 @@ class Geometry(
 
         Parameters
         ----------
-        lattice : Lattice or LatticeChild
+        lattice : LatticeLike
             the supercell in which this geometry should be expanded into.
         periodic :
             explicitly define the periodic directions, by default the periodic
-            directions are only where ``self.nsc > 1``.
+            directions are only where ``self.nsc > 1 & self.pbc``.
         tol :
             length tolerance for the fractional coordinates to be on a duplicate site (in Ang).
             This allows atoms within `tol` of the cell boundaries to be taken as *inside* the
@@ -3472,8 +3472,9 @@ class Geometry(
         numpy.ndarray
            integer supercell offsets for `ia` atoms
         """
+        lattice = Lattice.new(lattice)
         if periodic is None:
-            periodic = self.nsc > 1
+            periodic = np.logical_and(self.pbc, self.nsc > 1)
         else:
             periodic = list(periodic)
 

--- a/src/sisl/io/orca/tests/test_txt.py
+++ b/src/sisl/io/orca/tests/test_txt.py
@@ -87,3 +87,52 @@ def test_info_no(sisl_files):
     f = sisl_files(_dir, "molecule3_property.txt")
     out = txtSileORCA(f)
     assert out.info.no == 284
+
+
+def test_gtensor(sisl_files):
+    # file without g-tensor
+    f = sisl_files(_dir, "molecule_property.txt")
+    out = txtSileORCA(f)
+    assert out.read_gtensor() is None
+
+    # file with g-tensor
+    f = sisl_files(_dir, "molecule3_property.txt")
+    out = txtSileORCA(f)
+    G = out.read_gtensor()
+
+    assert G.multiplicity == 2
+    assert G.tensor[0, 0] == 2.002750
+    assert G.vectors[0, 1] == -0.009799
+    for i in range(3):
+        v = G.vectors[i]
+        assert v.dot(v) == pytest.approx(1)
+    assert G.eigenvalues[0] == 2.002127
+
+
+def test_hyperfine_coupling(sisl_files):
+    # file without hyperfine_coupling tensors
+    f = sisl_files(_dir, "molecule_property.txt")
+    out = txtSileORCA(f)
+    assert out.read_hyperfine_coupling() is None
+
+    # file with hyperfine_coupling tensors
+    f = sisl_files(_dir, "molecule3_property.txt")
+    out = txtSileORCA(f)
+    A = out.read_hyperfine_coupling()
+    assert len(A) == 22
+    assert A[0].iso == -23.380794
+    assert A[1].ia == 1
+    assert A[1].sa == "C"
+    assert A[1].isotope == 13
+    assert A[1].spin == 0.5
+    assert A[1].prefactor == 134.190303
+    assert A[1].tensor[0, 1] == -0.320129
+    assert A[1].tensor[2, 2] == 68.556557
+    assert A[1].vectors[1, 0] == 0.407884
+    for i in range(3):
+        v = A[1].vectors[i]
+        assert v.dot(v) == pytest.approx(1)
+    assert A[1].eigenvalues[1] == 5.523380
+    assert A[1].iso == 26.247902
+    assert A[12].sa == "C"
+    assert A[13].sa == "H"

--- a/src/sisl/io/orca/txt.py
+++ b/src/sisl/io/orca/txt.py
@@ -147,5 +147,119 @@ class txtSileORCA(SileORCA):
 
         return Geometry(xyz, atoms)
 
+    @sile_fh_open()
+    def read_gtensor(self):
+        """Reads electronic g-tensor data from the EPRNMR_GTensor block
+        in the ORCA property txt file
+
+        Returns
+        -------
+        PropertyDict : Electronic g-tensor
+        """
+        G = PropertyDict()
+        f, line = self.step_to("EPRNMR_GTensor", allow_reread=False)
+        if not f:
+            return None
+        for i in range(5):  # step 5 lines ahead
+            v = self.readline()
+        G["multiplicity"] = int(v.split()[-1])
+        self.readline()
+        self.readline()
+        tensor = np.empty([3, 3], np.float64)
+        for i in range(3):
+            v = self.readline().split()
+            tensor[i] = v[1:4]
+        G["tensor"] = tensor  # raw (total) tensor
+        self.readline()  # skip g tensor line
+        self.readline()  # skip header
+        vectors = np.empty([3, 3], np.float64)
+        for i in range(3):
+            v = self.readline().split()
+            vectors[i] = v[1:4]
+        G["vectors"] = vectors  # g-tensor eigenvectors
+        self.readline()  # skip eigenvalue line
+        self.readline()  # skip header
+        v = self.readline().split()
+        G["eigenvalues"] = np.array(v[1:4], np.float64)
+
+        return G
+
+    @sile_fh_open()
+    def read_hyperfine_coupling(self):
+        """Reads hyperfine couplings from the EPRNMR_ATensor block
+        in the ORCA property txt file
+
+        For a nucleus :math:`k`, the hyperfine interaction is usually
+        written in terms of the symmetric :math:`3\times 3` hyperfine
+        tensor :math:`A_k` such that
+
+        .. math::
+
+           H_\text{hfi} = \boldsymbol{S} \cdot A_k \boldsymbol{I}_k
+
+        where :math:`\boldsymbol{S}_k` and :math:`\boldsymbol{I}_k`
+        represent the electron and nuclear spin operators, respectively.
+
+        For a study of hyperfine coupling in nanographenes using ORCA
+        see :cite:`Sengupta2023`.
+
+        Note
+        ----
+        The hyperfine tensors are given in units of MHz.
+
+        Returns
+        -------
+        PropertyDict or list of PropertyDict : Hyperfine coupling data (in MHz)
+        """
+        f, line = self.step_to("EPRNMR_ATensor", allow_reread=False)
+        if not f:
+            return None
+
+        def read_A():
+            A = PropertyDict()
+            # Read the EPRNMR_ATensor block
+            f, line = self.step_to("Nucleus:", allow_reread=False)
+            if not f:
+                return None
+            v = line.split()
+            A["ia"] = int(v[1])
+            A["sa"] = v[2]
+            v = self.readline().split()
+            A["isotope"] = int(v[-1])
+            v = self.readline().split()
+            A["spin"] = float(v[-1])
+            v = self.readline().split()
+            A["prefactor"] = float(v[-1])
+            self.readline()  # skip Raw line
+            self.readline()  # skip header
+            tensor = np.empty([3, 3], np.float64)
+            for i in range(3):
+                v = self.readline().split()
+                tensor[i] = v[1:4]
+            A["tensor"] = tensor  # raw A_total tensor
+            self.readline()  # skip eigenvector line
+            self.readline()  # skip header
+            vectors = np.empty([3, 3], np.float64)
+            for i in range(3):
+                v = self.readline().split()
+                vectors[i] = v[1:4]
+            A["vectors"] = vectors
+            self.readline()  # skip eigenvalue line
+            self.readline()  # skip header
+            v = self.readline().split()
+            A["eigenvalues"] = np.array(v[1:4], np.float64)  # eigenvalues of A_total
+            v = self.readline().split()
+            A["iso"] = float(v[1])  # Fermi contact A_FC
+            return A
+
+        for i in range(4):
+            line = self.readline()
+        stored_nuclei = int(line.split()[-1])
+
+        if stored_nuclei == 1:
+            return read_A()
+
+        return [read_A() for k in range(stored_nuclei)]
+
 
 add_sile("txt", txtSileORCA, gzip=True)


### PR DESCRIPTION
This PR enables easy reading of the electronic g-tensor and the hyperfine tensors from ORCA.

 - [x] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` [24.2.0] at top-level
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`
