### PR TITLE
Remove 'run' argument from pytest.xfail calls

### DIFF
--- a/src/sisl/conftest.py
+++ b/src/sisl/conftest.py
@@ -122,7 +122,6 @@ def sisl_files():
         def _path(*files):
             pytest.xfail(
                 reason=f"Environment SISL_FILES_TESTS not pointing to a valid directory.",
-                run=False,
             )
 
         return _path
@@ -135,7 +134,6 @@ def sisl_files():
         # But it isn't an actual fail since it hasn't runned...
         pytest.xfail(
             reason=f"Environment SISL_FILES_TESTS may point to a wrong path(?); file {p} not found",
-            run=False,
         )
 
     return _path


### PR DESCRIPTION
I encountered the following error when, trying to run pytest with missing/misplaced `sisl-files`.

```python    def _path(*files):
        p = sisl_files_tests.joinpath(*files)
        if p.exists():
            return p
        # I expect this test to fail due to the wrong environment.
        # But it isn't an actual fail since it hasn't runned...
>       pytest.xfail(
            reason=f"Environment SISL_FILES_TESTS may point to a wrong path(?); file {p} not found",
            run=False,
        )
E       TypeError: xfail() got an unexpected keyword argument 'run'
```

Maybe it is just my version of `pytest` (8.1.1), but it only seems to accept a single argument (`reason`).

Removing the second argument. Fixed the error and the test proceed as expected (reporting `xfail` and continuing with the rest).

P.S: I couldn't find the `run` keyword argument documented in the pytest documentation either. 

