### PR TITLE
`units` as parameter in `read_*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ we hit release version 1.0.0.
 ## [0.15.0] - YYYY-MM-DD
 
 ### Added
+- `units` to `read_*` for some `Sile`s, #726
 - "Hz", "MHz", "GHz", "THz", and "invcm" as valid energy units, #725
 - added `read_gtensor` and `read_hyperfine_coupling` to `txtSileORCA`, #722
 - enabled `AtomsArgument` and `OrbitalsArgument` to accept `bool` for *all* or *none*

--- a/src/sisl/io/orca/stdout.py
+++ b/src/sisl/io/orca/stdout.py
@@ -260,12 +260,21 @@ class stdoutSileORCA(SileORCA):
 
     @SileBinder()
     @sile_fh_open()
-    def read_energy(self):
+    def read_energy(self, unit="eV"):
         """Reads the energy blocks
+
+        Parameters
+        ----------
+        unit :
+            what energy unit the data should be returned in
+
+        Note
+        ----
+        Energies written by ORCA have units of Ha.
 
         Returns
         -------
-        PropertyDict or list of PropertyDict : all energy data (in eV) from the "TOTAL SCF ENERGY" and "DFT DISPERSION CORRECTION" blocks
+        PropertyDict or list of PropertyDict : all energy data from the "TOTAL SCF ENERGY" and "DFT DISPERSION CORRECTION" blocks
         """
         f = self.step_to("TOTAL SCF ENERGY", allow_reread=False)[0]
         if not f:
@@ -274,28 +283,28 @@ class stdoutSileORCA(SileORCA):
         self.readline()  # skip ---
         self.readline()  # skip blank line
 
-        Ha2eV = units("Ha", "eV")
+        Ha2unit = units("Ha", unit)
         E = PropertyDict()
 
         line = self.readline()
         while "----" not in line:
             v = line.split()
             if "Total Energy" in line:
-                E["total"] = float(v[-4]) * Ha2eV
+                E["total"] = float(v[-4]) * Ha2unit
             elif "E(X)" in line:
-                E["exchange"] = float(v[-2]) * Ha2eV
+                E["exchange"] = float(v[-2]) * Ha2unit
             elif "E(C)" in line:
-                E["correlation"] = float(v[-2]) * Ha2eV
+                E["correlation"] = float(v[-2]) * Ha2unit
             elif "E(XC)" in line:
-                E["xc"] = float(v[-2]) * Ha2eV
+                E["xc"] = float(v[-2]) * Ha2unit
             elif "DFET-embed. en." in line:
-                E["embedding"] = float(v[-2]) * Ha2eV
+                E["embedding"] = float(v[-2]) * Ha2unit
             line = self.readline()
 
         if self.info.vdw_correction:
             self.step_to("DFT DISPERSION CORRECTION")
             v = self.step_to("Dispersion correction", allow_reread=False)[1].split()
-            E["vdw"] = float(v[-1]) * Ha2eV
+            E["vdw"] = float(v[-1]) * Ha2unit
 
         return E
 

--- a/src/sisl/io/orca/stdout.py
+++ b/src/sisl/io/orca/stdout.py
@@ -5,7 +5,8 @@ import numpy as np
 
 from sisl._internal import set_module
 from sisl.messages import deprecation
-from sisl.unit import units
+from sisl.unit import serialize_units_arg
+from sisl.unit import units as sunits
 from sisl.utils import PropertyDict
 
 from .._multiple import SileBinder
@@ -260,13 +261,13 @@ class stdoutSileORCA(SileORCA):
 
     @SileBinder()
     @sile_fh_open()
-    def read_energy(self, unit="eV"):
+    def read_energy(self, units="eV"):
         """Reads the energy blocks
 
         Parameters
         ----------
-        unit :
-            what energy unit the data should be returned in
+        units :
+            what energy units the data should be returned in
 
         Note
         ----
@@ -283,7 +284,9 @@ class stdoutSileORCA(SileORCA):
         self.readline()  # skip ---
         self.readline()  # skip blank line
 
-        Ha2unit = units("Ha", unit)
+        units = serialize_units_arg(units)
+        Ha2unit = sunits.convert("Ha", units["energy"])
+
         E = PropertyDict()
 
         line = self.readline()

--- a/src/sisl/io/orca/stdout.py
+++ b/src/sisl/io/orca/stdout.py
@@ -265,7 +265,7 @@ class stdoutSileORCA(SileORCA):
 
         Parameters
         ----------
-        units :
+        units : {str, dict, list, tuple}
             selects units in the returned data
 
         Note

--- a/src/sisl/io/orca/stdout.py
+++ b/src/sisl/io/orca/stdout.py
@@ -5,8 +5,7 @@ import numpy as np
 
 from sisl._internal import set_module
 from sisl.messages import deprecation
-from sisl.unit import serialize_units_arg
-from sisl.unit import units as sunits
+from sisl.unit import serialize_units_arg, unit_convert
 from sisl.utils import PropertyDict
 
 from .._multiple import SileBinder
@@ -267,7 +266,7 @@ class stdoutSileORCA(SileORCA):
         Parameters
         ----------
         units :
-            what energy units the data should be returned in
+            selects units in the returned data
 
         Note
         ----
@@ -285,7 +284,7 @@ class stdoutSileORCA(SileORCA):
         self.readline()  # skip blank line
 
         units = serialize_units_arg(units)
-        Ha2unit = sunits.convert("Ha", units["energy"])
+        Ha2unit = unit_convert("Ha", units["energy"])
 
         E = PropertyDict()
 

--- a/src/sisl/io/orca/tests/test_txt.py
+++ b/src/sisl/io/orca/tests/test_txt.py
@@ -113,7 +113,7 @@ def test_hyperfine_coupling(sisl_files):
     # file without hyperfine_coupling tensors
     f = sisl_files(_dir, "nitric_oxide", "molecule_property.txt")
     out = txtSileORCA(f)
-    assert out.read_hyperfine_coupling() is None
+    assert out.read_hyperfine_coupling(unit="MHz") is None
 
     # file with hyperfine_coupling tensors
     f = sisl_files(_dir, "phenalenyl", "molecule_property.txt")

--- a/src/sisl/io/orca/tests/test_txt.py
+++ b/src/sisl/io/orca/tests/test_txt.py
@@ -118,7 +118,7 @@ def test_hyperfine_coupling(sisl_files):
     # file with hyperfine_coupling tensors
     f = sisl_files(_dir, "phenalenyl", "molecule_property.txt")
     out = txtSileORCA(f)
-    A = out.read_hyperfine_coupling()
+    A = out.read_hyperfine_coupling(unit="MHz")
     assert len(A) == 22
     assert A[0].iso == -23.380794
     assert A[1].ia == 1

--- a/src/sisl/io/orca/tests/test_txt.py
+++ b/src/sisl/io/orca/tests/test_txt.py
@@ -113,12 +113,12 @@ def test_hyperfine_coupling(sisl_files):
     # file without hyperfine_coupling tensors
     f = sisl_files(_dir, "nitric_oxide", "molecule_property.txt")
     out = txtSileORCA(f)
-    assert out.read_hyperfine_coupling(unit="MHz") is None
+    assert out.read_hyperfine_coupling(units="MHz") is None
 
     # file with hyperfine_coupling tensors
     f = sisl_files(_dir, "phenalenyl", "molecule_property.txt")
     out = txtSileORCA(f)
-    A = out.read_hyperfine_coupling(unit="MHz")
+    A = out.read_hyperfine_coupling(units="MHz")
     assert len(A) == 22
     assert A[0].iso == -23.380794
     assert A[1].ia == 1
@@ -136,3 +136,19 @@ def test_hyperfine_coupling(sisl_files):
     assert A[1].iso == 26.247902
     assert A[12].sa == "C"
     assert A[13].sa == "H"
+
+
+def test_hyperfine_coupling_units(sisl_files):
+    f = sisl_files(_dir, "phenalenyl", "molecule_property.txt")
+    out = txtSileORCA(f)
+    A = out.read_hyperfine_coupling()
+    B = out.read_hyperfine_coupling(units="eV")
+    C = out.read_hyperfine_coupling(units={"energy": "eV"})
+
+    assert A[0].iso == B[0].iso == C[0].iso
+
+    A = out.read_hyperfine_coupling(units=("MHz", "Ang"))
+    B = out.read_hyperfine_coupling(units={"energy": "MHz"})
+
+    assert A[0].iso == B[0].iso
+    assert A[0].iso != C[0].iso

--- a/src/sisl/io/orca/txt.py
+++ b/src/sisl/io/orca/txt.py
@@ -105,7 +105,7 @@ class txtSileORCA(SileORCA):
         line = self.readline()
         while "----" not in line:
             v = line.split()
-            value = float(v[-1]) * Ha2conv
+            value = float(v[-1]) * Ha2unit
             if v[0] == "Exchange":
                 E["exchange"] = value
             elif v[0] == "Correlation":
@@ -124,7 +124,7 @@ class txtSileORCA(SileORCA):
         line = self.readline()
         if self.info.vdw_correction:
             v = self.step_to("Van der Waals Correction:")[1].split()
-            E["vdw"] = float(v[-1]) * Ha2conv
+            E["vdw"] = float(v[-1]) * Ha2unit
 
         return E
 

--- a/src/sisl/io/orca/txt.py
+++ b/src/sisl/io/orca/txt.py
@@ -80,7 +80,7 @@ class txtSileORCA(SileORCA):
 
         Parameters
         ----------
-        units :
+        units : {str, dict, list, tuple}
             selects units in the returned data
 
         Note
@@ -206,7 +206,7 @@ class txtSileORCA(SileORCA):
 
         Parameters
         ----------
-        units :
+        units : {str, dict, list, tuple}
            selects units in the returned data
 
         For a nucleus :math:`k`, the hyperfine interaction is usually

--- a/src/sisl/io/orca/txt.py
+++ b/src/sisl/io/orca/txt.py
@@ -6,8 +6,7 @@ import numpy as np
 from sisl._core.geometry import Geometry
 from sisl._internal import set_module
 from sisl.messages import deprecation
-from sisl.unit import serialize_units_arg
-from sisl.unit import units as sunits
+from sisl.unit import serialize_units_arg, unit_convert
 from sisl.utils import PropertyDict
 
 from .._multiple import SileBinder
@@ -81,8 +80,8 @@ class txtSileORCA(SileORCA):
 
         Parameters
         ----------
-        unit :
-            what energy unit the data should be returned in
+        units :
+            selects units in the returned data
 
         Note
         ----
@@ -101,7 +100,7 @@ class txtSileORCA(SileORCA):
         self.readline()  # prop. index
 
         units = serialize_units_arg(units)
-        Ha2unit = sunits.convert("Ha", units["energy"])
+        Ha2unit = unit_convert("Ha", units["energy"])
 
         E = PropertyDict()
 
@@ -207,8 +206,8 @@ class txtSileORCA(SileORCA):
 
         Parameters
         ----------
-        unit :
-            what energy unit the data should be returned in
+        units :
+           selects units in the returned data
 
         For a nucleus :math:`k`, the hyperfine interaction is usually
         written in terms of the symmetric :math:`3\times 3` hyperfine
@@ -237,7 +236,7 @@ class txtSileORCA(SileORCA):
             return None
 
         units = serialize_units_arg(units)
-        MHz2unit = sunits.convert("MHz", units["energy"])
+        MHz2unit = unit_convert("MHz", units["energy"])
 
         def read_A():
             A = PropertyDict()

--- a/src/sisl/io/orca/txt.py
+++ b/src/sisl/io/orca/txt.py
@@ -282,7 +282,7 @@ class txtSileORCA(SileORCA):
             )  # eigenvalues of A_total
 
             v = self.readline().split()
-            A["iso"] = float(v[1])  # Fermi contact A_FC
+            A["iso"] = float(v[1]) * MHz2unit  # Fermi contact A_FC
 
             return A
 

--- a/src/sisl/io/orca/txt.py
+++ b/src/sisl/io/orca/txt.py
@@ -6,7 +6,8 @@ import numpy as np
 from sisl._core.geometry import Geometry
 from sisl._internal import set_module
 from sisl.messages import deprecation
-from sisl.unit import units
+from sisl.unit import serialize_units_arg
+from sisl.unit import units as sunits
 from sisl.utils import PropertyDict
 
 from .._multiple import SileBinder
@@ -75,7 +76,7 @@ class txtSileORCA(SileORCA):
 
     @SileBinder()
     @sile_fh_open()
-    def read_energy(self, unit="eV"):
+    def read_energy(self, units="eV"):
         """Reads the energy blocks
 
         Parameters
@@ -99,7 +100,9 @@ class txtSileORCA(SileORCA):
         self.readline()  # geom. index
         self.readline()  # prop. index
 
-        Ha2unit = units("Ha", unit)
+        units = serialize_units_arg(units)
+        Ha2unit = sunits.convert("Ha", units["energy"])
+
         E = PropertyDict()
 
         line = self.readline()
@@ -199,7 +202,7 @@ class txtSileORCA(SileORCA):
         return G
 
     @sile_fh_open()
-    def read_hyperfine_coupling(self, unit="eV"):
+    def read_hyperfine_coupling(self, units="eV"):
         r"""Reads hyperfine couplings from the ``EPRNMR_ATensor`` block
 
         Parameters
@@ -233,7 +236,8 @@ class txtSileORCA(SileORCA):
         if not f:
             return None
 
-        MHz2unit = units.convert("MHz", unit)
+        units = serialize_units_arg(units)
+        MHz2unit = sunits.convert("MHz", units["energy"])
 
         def read_A():
             A = PropertyDict()

--- a/src/sisl/io/vasp/doscar.py
+++ b/src/sisl/io/vasp/doscar.py
@@ -39,7 +39,7 @@ class doscarSileVASP(SileVASP):
 
         Parameters
         ----------
-        units :
+        units : {str, dict, list, tuple}
             selects units in the returned data
 
         Returns

--- a/src/sisl/io/vasp/eigenval.py
+++ b/src/sisl/io/vasp/eigenval.py
@@ -26,7 +26,7 @@ class eigenvalSileVASP(SileVASP):
         ----------
         k : bool, optional
            also return k points and weights
-        units :
+        units : {str, dict, list, tuple}
            selects units in the returned data
 
         Returns

--- a/src/sisl/io/vasp/eigenval.py
+++ b/src/sisl/io/vasp/eigenval.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 from sisl._internal import set_module
+from sisl.unit import serialize_units_arg, unit_convert
 
 from ..sile import add_sile, sile_fh_open
 
@@ -18,13 +19,15 @@ class eigenvalSileVASP(SileVASP):
     """Kohn-Sham eigenvalues"""
 
     @sile_fh_open()
-    def read_data(self, k=False):
+    def read_data(self, k=False, units="eV"):
         r"""Read eigenvalues, as calculated and written by VASP
 
         Parameters
         ----------
         k : bool, optional
            also return k points and weights
+        units :
+           selects units in the returned data
 
         Returns
         -------
@@ -58,6 +61,11 @@ class eigenvalSileVASP(SileVASP):
                 # We currently neglect the populations
                 E = map(float, self.readline().split()[1 : ns + 1])
                 eigs[:, ik, ib] = list(E)
+
+        units = serialize_units_arg(units)
+        eV2unit = unit_convert("eV", units["energy"])
+        eigs *= eV2unit
+
         if k:
             return eigs, kk, w
         return eigs

--- a/src/sisl/io/vasp/locpot.py
+++ b/src/sisl/io/vasp/locpot.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from sisl import Grid
 from sisl._internal import set_module
+from sisl.unit import serialize_units_arg, unit_convert
 
 from .._help import grid_reduce_indices
 from ..sile import add_sile, sile_fh_open
@@ -24,8 +25,8 @@ class locpotSileVASP(carSileVASP):
     """
 
     @sile_fh_open(True)
-    def read_grid(self, index=0, dtype=np.float64, **kwargs):
-        """Reads the potential (in eV) from the file and returns with a grid (plus geometry)
+    def read_grid(self, index=0, dtype=np.float64, units="eV", **kwargs):
+        """Reads the potential from the file and returns with a grid (plus geometry)
 
         Parameters
         ----------
@@ -37,6 +38,8 @@ class locpotSileVASP(carSileVASP):
            contributions for each corresponding index.
         dtype : numpy.dtype, optional
            grid stored dtype
+        units :
+           selects units in the returned data
         spin : optional
            same as `index` argument. `spin` argument has precedence.
 
@@ -47,6 +50,9 @@ class locpotSileVASP(carSileVASP):
         index = kwargs.get("spin", index)
         geom = self.read_geometry()
         V = geom.lattice.volume
+
+        units = serialize_units_arg(units)
+        eV2unit = unit_convert("eV", units["energy"])
 
         # Now we are past the cell and geometry
         # We can now read the size of LOCPOT
@@ -96,7 +102,7 @@ class locpotSileVASP(carSileVASP):
         # Since we populate the grid data afterwards there
         # is no need to create a bigger grid than necessary.
         grid = Grid([1, 1, 1], dtype=dtype, geometry=geom)
-        grid.grid = val
+        grid.grid = val * eV2unit
 
         return grid
 

--- a/src/sisl/io/vasp/locpot.py
+++ b/src/sisl/io/vasp/locpot.py
@@ -38,7 +38,7 @@ class locpotSileVASP(carSileVASP):
            contributions for each corresponding index.
         dtype : numpy.dtype, optional
            grid stored dtype
-        units :
+        units : {str, dict, list, tuple}
            selects units in the returned data
         spin : optional
            same as `index` argument. `spin` argument has precedence.

--- a/src/sisl/io/vasp/outcar.py
+++ b/src/sisl/io/vasp/outcar.py
@@ -93,7 +93,7 @@ class outcarSileVASP(SileVASP):
 
         Parameters
         ----------
-        units :
+        units : {str, dict, list, tuple}
             selects units in the returned data
 
         Notes

--- a/src/sisl/io/vasp/tests/test_doscar.py
+++ b/src/sisl/io/vasp/tests/test_doscar.py
@@ -15,3 +15,7 @@ _dir = osp.join("sisl", "io", "vasp")
 def test_graphene_doscar(sisl_files):
     f = sisl_files(_dir, "graphene", "DOSCAR")
     E, DOS = doscarSileVASP(f).read_data()
+
+    EHa, DOSHa = doscarSileVASP(f).read_data(units=("Ha", "Bohr"))
+    assert not np.allclose(E, EHa)
+    assert not np.allclose(DOS, DOSHa)

--- a/src/sisl/io/vasp/tests/test_eigenval.py
+++ b/src/sisl/io/vasp/tests/test_eigenval.py
@@ -15,3 +15,5 @@ _dir = osp.join("sisl", "io", "vasp")
 def test_read_eigenval(sisl_files):
     f = sisl_files(_dir, "graphene", "EIGENVAL")
     eigs = eigenvalSileVASP(f).read_data()
+    eigsHa = eigenvalSileVASP(f).read_data(units="Ha")
+    assert not np.allclose(eigs, eigsHa)

--- a/src/sisl/io/vasp/tests/test_locpot.py
+++ b/src/sisl/io/vasp/tests/test_locpot.py
@@ -22,6 +22,9 @@ def test_graphene_locpot(sisl_files):
     assert gridf32.dtype == np.float32
     assert geom == gridf32.geometry
 
+    gridHa = locpotSileVASP(f).read_grid(units="Ha")
+    assert not np.allclose(gridf64.grid, gridHa.grid)
+
 
 def test_graphene_locpot_index_float(sisl_files):
     f = sisl_files(_dir, "graphene", "LOCPOT")

--- a/src/sisl/io/vasp/tests/test_outcar.py
+++ b/src/sisl/io/vasp/tests/test_outcar.py
@@ -31,6 +31,9 @@ def test_diamond_outcar_energies(sisl_files):
     assert len(Eall) > 1
     assert f.info.completed()
 
+    EHa = f.read_energy[-1](units="Ha")
+    assert EHa.sigma0 != E.sigma0
+
 
 def test_diamond_outcar_cputime(sisl_files):
     f = sisl_files(_dir, "diamond", "OUTCAR")

--- a/src/sisl/unit/__init__.py
+++ b/src/sisl/unit/__init__.py
@@ -45,4 +45,4 @@ will use the unit definitions in `Siesta`_.
 """
 # Enable the siesta unit-conversion
 from . import siesta
-from .base import unit_convert, unit_default, unit_group, units
+from .base import serialize_units_arg, unit_convert, unit_default, unit_group, units

--- a/src/sisl/unit/base.py
+++ b/src/sisl/unit/base.py
@@ -5,7 +5,7 @@ import pyparsing as pp
 
 from sisl._internal import set_module
 
-__all__ = ["unit_group", "unit_convert", "unit_default", "units"]
+__all__ = ["unit_group", "unit_convert", "unit_default", "units", "serialize_units_arg"]
 
 
 # We do not import anything as it depends on the package.
@@ -424,3 +424,28 @@ class UnitParser:
 
 # Create base sisl unit conversion object
 units = UnitParser(unit_table)
+
+
+@set_module("sisl.unit")
+def serialize_units_arg(units):
+    "Parse units arguments into a dictionary"
+
+    if isinstance(units, str):
+        return {unit_group(units): units}
+
+    elif isinstance(units, (list, tuple)):
+        new_units_arg = {}
+        for u in units:
+            g = unit_group(u)
+            if g not in new_units_arg:
+                # add new quantity to dictionary
+                new_units_arg[g] = u
+            else:
+                raise ValueError(
+                    f"Two units for the same quantity was specified. This is not allowed."
+                )
+        return new_units_arg
+
+    else:
+
+        return units


### PR DESCRIPTION
Although sisl works with `eV` as the default energy unit, users may just use sisl as an interface and keep original units (or some other choice). 

Here a suggestion for ORCA. I could extend to the other interfaces too.