### PR TITLE
Resolve Issue #716

### DIFF
--- a/docs/api/io/wannier90.rst
+++ b/docs/api/io/wannier90.rst
@@ -9,6 +9,9 @@ Wannier90
    :toctree: generated/
 
    winSileWannier90 - input file
+   tbSileWannier90 - Hamiltonian and Position operator information
+   hrSileWannier90 - Hamiltonian information
+   xyzSileWannier90 - Wannier charge center information
 
 
 .. autosummary::

--- a/docs/api/io/wannier90.rst
+++ b/docs/api/io/wannier90.rst
@@ -11,7 +11,7 @@ Wannier90
    winSileWannier90 - input file
    tbSileWannier90 - Hamiltonian and Position operator information
    hrSileWannier90 - Hamiltonian information
-   xyzSileWannier90 - Wannier charge center information
+   centresSileWannier90 - Wannier charge center information
 
 
 .. autosummary::
@@ -20,5 +20,3 @@ Wannier90
 
    SileWannier90
    SileBinWannier90
-
-

--- a/src/sisl/io/tests/test_object.py
+++ b/src/sisl/io/tests/test_object.py
@@ -22,6 +22,7 @@ from sisl.io import *
 from sisl.io.siesta.binaries import _gfSileSiesta
 from sisl.io.tbtrans._cdf import *
 from sisl.io.vasp import chgSileVASP
+from sisl.io.wannier90 import winSileWannier90
 from sisl.io.xsf import xsfSile
 
 pytestmark = pytest.mark.io
@@ -348,7 +349,7 @@ class TestObject:
         G.set_nsc([1, 1, 1])
         f = sisl_tmp("test_read_write_geom.win", _dir)
 
-        if issubclass(sile, (_ncSileTBtrans, deltancSileTBtrans)):
+        if issubclass(sile, (_ncSileTBtrans, deltancSileTBtrans, winSileWannier90)):
             pytest.skip(
                 "does not have a proper writing of the atomic species (no direct comparison available)"
             )

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -23,7 +23,7 @@ from ..sile import *
 from .sile import SileWannier90
 from ..xyz import xyzSile
 
-__all__ = ["winSileWannier90"]
+__all__ = ["winSileWannier90", "tbSileWannier90", "hrSileWannier90", "xyzSileWannier90"]
 
 
 def _construct_hamiltonian(geometry: Geometry, Hsc):
@@ -528,3 +528,6 @@ class hrSileWannier90(hamSileWannier90):
 
 
 add_sile("win", winSileWannier90, gzip=True)
+add_sile("_tb.dat", tbSileWannier90, gzip=True)
+add_sile("_hr.dat", hrSileWannier90, gzip=True)
+add_sile("_centres.xyz", xyzSileWannier90, gzip=True)

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -314,6 +314,10 @@ class winSileWannier90(SileWannier90):
             # to ensure we get the correct orbital positions
             kwargs["geometry"] = self.read_geometry()
 
+        if "lattice" not in kwargs:
+            # to ensure we get the correct orbital positions
+            kwargs["lattice"] = self.read_lattice()
+
         kwargs["cutoff"] = cutoff
 
         for f in order:
@@ -392,7 +396,7 @@ class tbSileWannier90(hamSileWannier90):
         #  Lattice vectors [Ang]
         cell = _a.zerosf((3, 3))
         for i in range(3):
-            cell[i] = map(float, self.readline().split())
+            cell[i] = list(map(float, self.readline().split()))
 
         # Number of orbitals
         no = int(self.readline())
@@ -482,7 +486,8 @@ class hrSileWannier90(hamSileWannier90):
         # Number of orbitals
         no = int(self.readline())
         if geometry is None:
-            geometry = Geometry([0.0, 0.0, 0.0], lattice=Lattice([[0.0, 0.0, 0.0]] * 3))
+            lattice = kwargs.pop("lattice", Lattice(_a.zerosf((3, 3))))
+            geometry = Geometry([0.0, 0.0, 0.0] * no, lattice=lattice)
         elif no != geometry.no:
             raise ValueError(
                 f"{self.__class__.__name__}"

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -277,7 +277,6 @@ class winSileWannier90(SileWannier90):
         ws = 1.0 / _a.arrayd(ws)
         return ws
 
-
     def _r_hamiltonian_tb(self, *args, **kwargs):
         """Read Hamiltonian from the <>_tb.dat file"""
         f = self.dir_file(self._seed + "_tb.dat")
@@ -314,7 +313,7 @@ class winSileWannier90(SileWannier90):
         if "geometry" not in kwargs:
             # to ensure we get the correct orbital positions
             kwargs["geometry"] = self.read_geometry()
-        
+
         kwargs["cutoff"] = cutoff
 
         for f in order:
@@ -330,8 +329,9 @@ class winSileWannier90(SileWannier90):
         newkw.update(kwargs)
         return self.read_geometry().ArgumentParser(p, *args, **newkw)
 
+
 class xyzSileWannier90(SileWannier90):
-        
+
     @sile_fh_open()
     def read_geometry(self, lattice):
         """Defered routine"""
@@ -355,8 +355,9 @@ class xyzSileWannier90(SileWannier90):
 
         return Geometry(xyz[:na, :], atoms="H", lattice=lattice)
 
+
 class hamSileWannier90(SileWannier90):
-    
+
     def _r_wigner_seitz_weights(self):
         # Number of Wigner-Seitz degeneracy points
         npts = int(self.readline())
@@ -370,12 +371,14 @@ class hamSileWannier90(SileWannier90):
 
         ws = 1.0 / _a.arrayd(ws)
         return ws
+
+
 class tbSileWannier90(hamSileWannier90):
 
     @sile_fh_open()
     def read_geometry(self):
-        """Reads a geometry information from the _tb.dat file. 
-        
+        """Reads a geometry information from the _tb.dat file.
+
         Wannier centres are not stored in the file, so we use dummy coordinates
         instead.
         """
@@ -387,14 +390,14 @@ class tbSileWannier90(hamSileWannier90):
         self.readline()
 
         #  Lattice vectors [Ang]
-        cell = _a.zerosf((3,3))
+        cell = _a.zerosf((3, 3))
         for i in range(3):
             cell[i] = map(float, self.readline().split())
-            
+
         # Number of orbitals
         no = int(self.readline())
 
-        return Geometry([0., 0., 0.]*no, lattice=Lattice(cell))
+        return Geometry([0.0, 0.0, 0.0] * no, lattice=Lattice(cell))
 
     @sile_fh_open()
     def read_hamiltonian(self, geometry=None, dtype=np.float64, **kwargs):
@@ -462,6 +465,7 @@ class tbSileWannier90(hamSileWannier90):
 
         return _construct_hamiltonian(geometry, Hsc)
 
+
 class hrSileWannier90(hamSileWannier90):
 
     @sile_fh_open()
@@ -478,7 +482,7 @@ class hrSileWannier90(hamSileWannier90):
         # Number of orbitals
         no = int(self.readline())
         if geometry is None:
-            geometry = Geometry([0., 0., 0.], lattice=Lattice([[0.,0.,0.]]*3))
+            geometry = Geometry([0.0, 0.0, 0.0], lattice=Lattice([[0.0, 0.0, 0.0]] * 3))
         elif no != geometry.no:
             raise ValueError(
                 f"{self.__class__.__name__}"
@@ -523,7 +527,6 @@ class hrSileWannier90(hamSileWannier90):
                 Hsc[tuple(isc)][r - 1, c - 1] = h
 
         return _construct_hamiltonian(geometry, Hsc)
-
 
 
 add_sile("win", winSileWannier90, gzip=True)

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -22,7 +22,12 @@ from ..sile import *
 # Import sile objects
 from .sile import SileWannier90
 
-__all__ = ["winSileWannier90", "tbSileWannier90", "hrSileWannier90", "xyzSileWannier90"]
+__all__ = [
+    "winSileWannier90",
+    "tbSileWannier90",
+    "hrSileWannier90",
+    "centresSileWannier90",
+]
 
 
 def _construct_hamiltonian(geometry: Geometry, Hsc):
@@ -145,7 +150,7 @@ class winSileWannier90(SileWannier90):
         f = self.dir_file(self._seed + "_centres.xyz")
         geometry = None
         if f.exists():
-            geometry = xyzSileWannier90(f).read_geometry(*args, **kwargs)
+            geometry = centresSileWannier90(f).read_geometry(*args, **kwargs)
         return geometry
 
     @sile_fh_open()
@@ -360,7 +365,7 @@ class winSileWannier90(SileWannier90):
         return self.read_geometry().ArgumentParser(p, *args, **newkw)
 
 
-class xyzSileWannier90(SileWannier90):
+class centresSileWannier90(SileWannier90):
 
     @sile_fh_open(True)
     def read_geometry(self, lattice):
@@ -605,4 +610,4 @@ class hrSileWannier90(hamSileWannier90):
 add_sile("win", winSileWannier90, gzip=True)
 add_sile("_tb.dat", tbSileWannier90, gzip=True)
 add_sile("_hr.dat", hrSileWannier90, gzip=True)
-add_sile("_centres.xyz", xyzSileWannier90, gzip=True)
+add_sile("_centres.xyz", centresSileWannier90, gzip=True)

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -213,7 +213,8 @@ class winSileWannier90(SileWannier90):
         """
 
         # Read in the super-cell
-        kwargs["lattice"] = self.read_lattice()
+        if "lattice" not in kwargs:
+            kwargs["lattice"] = self.read_lattice()
 
         order = kwargs.pop("order", ["centres"])
         for f in order:

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -12,7 +12,7 @@ import scipy.sparse as sps
 from scipy.sparse import lil_matrix
 
 import sisl._array as _a
-from sisl import Geometry, Lattice, Atom
+from sisl import Geometry, Lattice
 from sisl.messages import deprecate_argument
 from sisl.physics import Hamiltonian
 from sisl.unit import unit_convert
@@ -21,7 +21,6 @@ from ..sile import *
 
 # Import sile objects
 from .sile import SileWannier90
-from ..xyz import xyzSile
 
 __all__ = ["winSileWannier90", "tbSileWannier90", "hrSileWannier90", "xyzSileWannier90"]
 

--- a/src/sisl/io/wannier90/tests/test_seedname.py
+++ b/src/sisl/io/wannier90/tests/test_seedname.py
@@ -32,7 +32,7 @@ end
                 unit
             )
         )
-    g = winSileWannier90(f).read_geometry()
+    g = winSileWannier90(f).read_geometry(order=["win"])
 
     if len(unit) == 0:
         unit = "ang"
@@ -62,7 +62,7 @@ end
                 unit_sc, unit
             )
         )
-    g = winSileWannier90(f).read_geometry()
+    g = winSileWannier90(f).read_geometry(order=["win"])
 
     if len(unit) == 0:
         unit = "ang"
@@ -82,7 +82,7 @@ def test_seedname_write_read(sisl_tmp, sisl_system, frac):
     sile = winSileWannier90(f, "w")
     sile.write_geometry(sisl_system.g, frac=frac)
 
-    g = winSileWannier90(f).read_geometry()
+    g = winSileWannier90(f).read_geometry(order=["win"])
     assert np.allclose(g.cell, sisl_system.g.cell)
     assert np.allclose(g.xyz, sisl_system.g.xyz)
 


### PR DESCRIPTION
This should resolve #716.

In this PR, I 
- changes the default behavior in which geometry is read: the geometry is only read from the `<>.win` file if explicitly requested.
- split the functionality of the `winSileWannier90` into different siles: `xyzSileWannier90`, `tbSileWannier90`, `hrSileWannier90`.
-
@zerothi, could you have a look at this and see if it matches what you had imagined?

