### PR TITLE
Remove deprecated `bc` argument to `Grid`

### DIFF
--- a/src/sisl/io/siesta/siesta_grid.py
+++ b/src/sisl/io/siesta/siesta_grid.py
@@ -126,9 +126,9 @@ class gridncSileSiesta(SileCDFSiesta):
             v = self._variable(name)
 
         # Create the grid, Siesta uses periodic, always
+        lattice.set_boundary_condition(Grid.PERIODIC)
         grid = Grid(
             [nz, ny, nx],
-            bc=Grid.PERIODIC,
             lattice=lattice,
             dtype=v.dtype,
             geometry=kwargs.get("geometry", None),

--- a/src/sisl/io/siesta/siesta_nc.py
+++ b/src/sisl/io/siesta/siesta_nc.py
@@ -382,7 +382,8 @@ class ncSileSiesta(SileCDFSiesta):
         v = g.variables[name]
 
         # Create the grid, Siesta uses periodic, always
-        grid = Grid([nz, ny, nx], bc=Grid.PERIODIC, geometry=geom, dtype=v.dtype)
+        geom.lattice.set_boundary_condition(Grid.PERIODIC)
+        grid = Grid([nz, ny, nx], geometry=geom, dtype=v.dtype)
 
         # Unit-conversion
         BohrC2AngC = Bohr2Ang**3

--- a/src/sisl/io/siesta/transiesta_grid.py
+++ b/src/sisl/io/siesta/transiesta_grid.py
@@ -44,7 +44,8 @@ class tsvncSileSiesta(gridncSileSiesta):
         v = self._variable("V")
 
         # Create the grid, Siesta uses periodic, always
-        grid = Grid([nc, nb, na], bc=Grid.PERIODIC, lattice=lattice, dtype=v.dtype)
+        lattice.set_boundary_condition(Grid.PERIODIC)
+        grid = Grid([nc, nb, na], lattice=lattice, dtype=v.dtype)
 
         grid.grid[:, :, :] = v[:, :, :] * _Ry2eV
 


### PR DESCRIPTION
The code issues a deprecation warning about the (internal) use of `bc` to `Grid`, because boundary conditions now belong to `Lattice`. This PR fixes this.