### PR TITLE
Some polishing of `sisl.nodes`

### DIFF
--- a/src/sisl/nodes/file_nodes.py
+++ b/src/sisl/nodes/file_nodes.py
@@ -177,5 +177,6 @@ class FileNode(Node):
         if "path" in inputs:
             self._update_observer()
 
-    def function(self, path: str) -> Path:
+    @staticmethod
+    def function(path: str) -> Path:
         return Path(path)

--- a/src/sisl/nodes/registry.py
+++ b/src/sisl/nodes/registry.py
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+class NodeClassRegistry:
+    """Keeps track of the node classes that are defined.
+
+    This simple class just stores the classes in a list,
+    but allows other registries to "subscribe" to it. This means
+    that when a new class is added to the registry it will
+    also be registered in the subscribed registries.
+
+    In this way, a user can implement custom behavior to register
+    classes. This can be useful for example to build search indexes.
+    """
+
+    def __init__(self):
+        self.all_classes = []
+
+        self._subscribed = []
+
+    def register(self, node_cls):
+        self.all_classes.append(node_cls)
+        for sub in self._subscribed:
+            sub.register(node_cls)
+
+    def subscribe(self, registry):
+        for cls in self.all_classes:
+            registry.register(cls)
+
+        self._subscribed.append(registry)
+
+    def unsubscribe(self, registry):
+        self._subscribed.remove(registry)
+
+
+# Define the global main registry
+REGISTRY = NodeClassRegistry()

--- a/src/sisl/nodes/tests/test_context.py
+++ b/src/sisl/nodes/tests/test_context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import pytest
 
+from sisl import SislWarning
 from sisl.nodes import Node, Workflow
 from sisl.nodes.context import temporal_context
 
@@ -54,10 +55,12 @@ def test_workflow(nodes_lazy):
     def sum_node(a, b):
         return a + b
 
-    @Workflow.from_func
-    def my_workflow(a, b, c):
-        first_sum = sum_node(a, b)
-        return sum_node(first_sum, c)
+    with pytest.warns(SislWarning):
+
+        @Workflow.from_func
+        def my_workflow(a, b, c):
+            first_sum = sum_node(a, b)
+            return sum_node(first_sum, c)
 
     with temporal_context(context=Node.context, lazy=nodes_lazy):
         # It shouldn't matter whether nodes have lazy computation on or off for the working of the workflow

--- a/src/sisl/nodes/tests/test_registry.py
+++ b/src/sisl/nodes/tests/test_registry.py
@@ -1,0 +1,36 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from sisl.nodes.node import Node
+from sisl.nodes.registry import REGISTRY, NodeClassRegistry
+
+
+def test_registry():
+
+    assert isinstance(REGISTRY, NodeClassRegistry)
+
+    sub_registry = NodeClassRegistry()
+
+    REGISTRY.subscribe(sub_registry)
+
+    assert len(sub_registry.all_classes) == len(REGISTRY.all_classes)
+
+    class TestNode(Node):
+
+        @staticmethod
+        def function():
+            return 1
+
+    assert REGISTRY.all_classes[-1] is TestNode
+    assert sub_registry.all_classes[-1] is TestNode
+
+    REGISTRY.unsubscribe(sub_registry)
+
+    class TestNode2(Node):
+
+        @staticmethod
+        def function():
+            return 2
+
+    assert REGISTRY.all_classes[-1] is TestNode2
+    assert sub_registry.all_classes[-1] is TestNode

--- a/src/sisl/nodes/tests/test_workflow.py
+++ b/src/sisl/nodes/tests/test_workflow.py
@@ -7,6 +7,7 @@ from typing import Type
 
 import pytest
 
+from sisl import SislWarning
 from sisl.nodes import Node, Workflow
 from sisl.nodes.node import ConstantNode
 from sisl.nodes.utils import traverse_tree_forward
@@ -26,28 +27,33 @@ def triple_sum(request) -> Type[Workflow]:
         return a + b
 
     if request.param == "from_func":
-        # A triple sum
-        @Workflow.from_func
-        def triple_sum(a, b, c):
-            first_sum = my_sum(a, b)
-            return my_sum(first_sum, c)
-
-        triple_sum._sum_key = "my_sum"
-    elif request.param == "explicit_class":
-
-        class triple_sum(Workflow):
-            @staticmethod
-            def function(a, b, c):
+        with pytest.warns(SislWarning):
+            # A triple sum
+            @Workflow.from_func
+            def triple_sum(a, b, c):
                 first_sum = my_sum(a, b)
                 return my_sum(first_sum, c)
 
         triple_sum._sum_key = "my_sum"
+    elif request.param == "explicit_class":
+
+        with pytest.warns(SislWarning):
+
+            class triple_sum(Workflow):
+                @staticmethod
+                def function(a, b, c):
+                    first_sum = my_sum(a, b)
+                    return my_sum(first_sum, c)
+
+        triple_sum._sum_key = "my_sum"
     elif request.param == "input_operations":
 
-        @Workflow.from_func
-        def triple_sum(a, b, c):
-            first_sum = a + b
-            return first_sum + c
+        with pytest.warns(SislWarning):
+
+            @Workflow.from_func
+            def triple_sum(a, b, c):
+                first_sum = a + b
+                return first_sum + c
 
         triple_sum._sum_key = "UfuncNode"
 
@@ -141,10 +147,12 @@ def test_args_nodes_registered():
     def some_node(*args):
         return args
 
-    @Workflow.from_func
-    def some_workflow():
-        a = some_node(1, 2, 3)
-        return some_node(2, a, 4)
+    with pytest.warns(SislWarning):
+
+        @Workflow.from_func
+        def some_workflow():
+            a = some_node(1, 2, 3)
+            return some_node(2, a, 4)
 
     # Check that the workflow knows about the first instanced node.
     wf = some_workflow()
@@ -155,10 +163,12 @@ def test_kwargs_nodes_registered():
     def some_node(**kwargs):
         return kwargs
 
-    @Workflow.from_func
-    def some_workflow():
-        a = some_node(a=1, b=2, c=3)
-        return some_node(b=2, a=a, c=4)
+    with pytest.warns(SislWarning):
+
+        @Workflow.from_func
+        def some_workflow():
+            a = some_node(a=1, b=2, c=3)
+            return some_node(b=2, a=a, c=4)
 
     # Check that the workflow knows about the first instanced node.
     wf = some_workflow()
@@ -169,10 +179,12 @@ def test_workflow_inside_workflow(triple_sum):
     def multiply(a, b):
         return a * b
 
-    @Workflow.from_func
-    def some_multiplication(a, b, c, d, e, f):
-        """Workflow that computes (a + b + c) * (d + e + f)"""
-        return multiply(triple_sum(a, b, c), triple_sum(d, e, f))
+    with pytest.warns(SislWarning):
+
+        @Workflow.from_func
+        def some_multiplication(a, b, c, d, e, f):
+            """Workflow that computes (a + b + c) * (d + e + f)"""
+            return multiply(triple_sum(a, b, c), triple_sum(d, e, f))
 
     val = some_multiplication(1, 2, 3, 1, 2, 1)
 

--- a/src/sisl/nodes/utils.py
+++ b/src/sisl/nodes/utils.py
@@ -94,6 +94,9 @@ def visit_all_connected(
         traverse_tree_backward((node,), func=visit)
 
 
+_nodified_modules = {}
+
+
 def nodify_module(module: ModuleType, node_class: Type[Node] = Node) -> ModuleType:
     """Returns a copy of a module where all functions are replaced with nodes.
 
@@ -118,6 +121,9 @@ def nodify_module(module: ModuleType, node_class: Type[Node] = Node) -> ModuleTy
     ModuleType
         A new module with all functions replaced with nodes.
     """
+
+    if module in _nodified_modules:
+        return _nodified_modules[module]
 
     # Function that recursively traverses the module and replaces functions with nodes.
     def _nodified_module(
@@ -178,4 +184,8 @@ def nodify_module(module: ModuleType, node_class: Type[Node] = Node) -> ModuleTy
 
         return noded_module
 
-    return _nodified_module(module, visited={}, main_module=module.__name__)
+    nodified_module = _nodified_module(module, visited={}, main_module=module.__name__)
+
+    _nodified_modules[module] = nodified_module
+
+    return nodified_module

--- a/src/sisl/viz/plot.py
+++ b/src/sisl/viz/plot.py
@@ -12,7 +12,19 @@ class Plot(Workflow):
 
     def __getattr__(self, key):
         if key != "nodes":
-            return getattr(self.nodes.output.get(), key)
+            # If an ipython key is requested, get the plot and look
+            # for the key in the plot. This is simply to enhance
+            # interactivity in a python notebook environment.
+            # However, this results in a (maybe undesired) behavior:
+            # The plot is updated when ipython requests it, without any
+            # explicit request to update it. This is how it has worked
+            # from the beggining, so it's probably best to keep it like
+            # this for now.
+            if "ipython" in key:
+                output = self.nodes.output.get()
+            else:
+                output = self.nodes.output._output
+            return getattr(output, key)
         else:
             return super().__getattr__(key)
 


### PR DESCRIPTION
Just some minor changes that I made to `sisl.nodes` while working on the GUI.

- Added a registry to keep track of created node classes
- Changed `getattr` of `Plot` so that plots are not computed undesirably.
- Minor change in `FileNode`
- Keep track of nodified modules so that they can be returned if the module needs is requested to be nodified again.