### PR TITLE
Pre-commit hook to add license

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,13 @@ repos:
       stages: [commit]
       language: system
       entry: jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace
+#License header
+- repo: https://github.com/Lucas-C/pre-commit-hooks
+  rev: v1.5.5
+  hooks:
+    - id: insert-license
+      files: \.py$
+      args:
+        - --license-filepath
+        - LICENSE_header
+        - --no-extra-eol

--- a/LICENSE_header
+++ b/LICENSE_header
@@ -1,0 +1,3 @@
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
Added a pre-commit hook that makes sure the license header is at the beggining of the file.

The hook needs a file containing the header, which I named `LICENSE_header`, but can be renamed to anything else.
