### PR TITLE
Ensure __module__ is fine on node class creation

### DIFF
--- a/src/sisl/nodes/node.py
+++ b/src/sisl/nodes/node.py
@@ -244,7 +244,10 @@ class Node(NDArrayOperatorsMixin):
 
     @classmethod
     def from_func(
-        cls, func: Union[Callable, None] = None, context: Union[dict, None] = None
+        cls,
+        func: Union[Callable, None] = None,
+        context: Union[dict, None] = None,
+        module: Optional[str] = None,
     ):
         """Builds a node from a function.
 
@@ -261,7 +264,7 @@ class Node(NDArrayOperatorsMixin):
             will be created.
         """
         if func is None:
-            return lambda func: cls.from_func(func=func, context=context)
+            return lambda func: cls.from_func(func=func, context=context, module=module)
 
         if isinstance(func, type) and issubclass(func, Node):
             return func
@@ -281,6 +284,7 @@ class Node(NDArrayOperatorsMixin):
                 "function": staticmethod(func),
                 "_cls_context": context,
                 "_from_function": True,
+                "__module__": module or func.__module__,
             },
         )
 

--- a/src/sisl/nodes/tests/test_node.py
+++ b/src/sisl/nodes/tests/test_node.py
@@ -27,6 +27,22 @@ def sum_node(request):
     return SumNode
 
 
+def test_node_class_module():
+    def a():
+        pass
+
+    x = Node.from_func(a)
+
+    assert x.__module__ == __name__
+
+    def b():
+        pass
+
+    y = Node.from_func(b, module="other_module")
+
+    assert y.__module__ == "other_module"
+
+
 def test_node_classes_reused():
     def a():
         pass

--- a/src/sisl/nodes/utils.py
+++ b/src/sisl/nodes/utils.py
@@ -162,8 +162,9 @@ def nodify_module(module: ModuleType, node_class: Type[Node] = Node) -> ModuleTy
                 # There are some reasons why a function or class with exotic properties
                 # might not be able to be converted to a node. We do not aim at nodifying them.
                 try:
-                    noded_variable = node_class.from_func(variable)
-                    noded_variable.__module__ = f"nodified_{variable.__module__}"
+                    noded_variable = node_class.from_func(
+                        variable, module=f"nodified_{variable.__module__}"
+                    )
                 except:
                     ...
             elif inspect.ismodule(variable):


### PR DESCRIPTION
Small change to ensure that the `__module__` variable is set as expected on creation of a node class from a function.