### PR TITLE
Added specific functions to create animations and subplots

### DIFF
--- a/docs/api/viz/index.rst
+++ b/docs/api/viz/index.rst
@@ -37,4 +37,6 @@ Utilities to build custom plots
 
     get_figure
     merge_plots
+    subplots
+    animation
     Figure

--- a/docs/visualization/viz_module/combining-plots/Intro to combining plots.ipynb
+++ b/docs/visualization/viz_module/combining-plots/Intro to combining plots.ipynb
@@ -232,6 +232,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-info\">\n",
+    "    \n",
+    "Note\n",
+    "    \n",
+    "There is also the `sisl.viz.subplots` function, which might be more convenient to use in a notebook because its help message is more helpful.\n",
+    "    \n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Merging merged plots\n",
     "-------------------\n",
     "\n",
@@ -317,6 +330,19 @@
    "outputs": [],
    "source": [
     "merge_plots(*pdos_plots, composite_method=\"animation\", frame_names=ks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "    \n",
+    "Note\n",
+    "    \n",
+    "There is also the `sisl.viz.animation` function, which might be more convenient to use in a notebook because its help message is more helpful.\n",
+    "    \n",
+    "</div>"
    ]
   }
  ],

--- a/src/sisl/viz/figure/plotly.py
+++ b/src/sisl/viz/figure/plotly.py
@@ -311,6 +311,7 @@ class PlotlyFigure(Figure):
                         **action["kwargs"].get("meta", {}),
                         "i_plot": i,
                     }
+                sanitized_section_actions.append(action)
 
             yield sanitized_section_actions
 

--- a/src/sisl/viz/plots/__init__.py
+++ b/src/sisl/viz/plots/__init__.py
@@ -11,5 +11,5 @@ from .bands import BandsPlot, FatbandsPlot, bands_plot, fatbands_plot
 from .geometry import GeometryPlot, SitesPlot, geometry_plot, sites_plot
 from .grid import GridPlot, WavefunctionPlot, grid_plot, wavefunction_plot
 from .matrix import AtomicMatrixPlot, atomic_matrix_plot
-from .merged import merge_plots
+from .merged import animation, merge_plots, subplots
 from .pdos import PdosPlot, pdos_plot

--- a/src/sisl/viz/plots/merged.py
+++ b/src/sisl/viz/plots/merged.py
@@ -35,10 +35,109 @@ def merge_plots(
         which controls the arrangement ("rows", "cols" or "square").
     """
 
+    def _san_plot(plot):
+        if isinstance(plot, Plot) and plot._nupdates == 0:
+            plot.get()
+        return plot
+
     plot_actions = combined(
-        *[fig.plot_actions for fig in figures],
+        *[_san_plot(fig).plot_actions for fig in figures],
         composite_method=composite_method,
         **kwargs,
     )
 
     return get_figure(plot_actions=plot_actions, backend=backend)
+
+
+def subplots(
+    *figures: Figure,
+    rows: Optional[int] = None,
+    cols: Optional[int] = None,
+    arrange: Literal["rows", "cols", "square"] = "rows",
+    backend: Literal["plotly", "matplotlib", "py3dmol", "blender"] = "plotly",
+    **kwargs,
+) -> Figure:
+    """Combines multiple plots into a single figure using subplots.
+
+    Parameters
+    ----------
+    *figures : Figure
+        The figures (or plots) to combine.
+    rows : int, optional
+        The number of rows in the subplots grid.
+        If not specified, it will be inferred automatically based on the number of columns and the number of plots.
+        If neither `rows` nor `cols` are specified,
+        the `arrange` parameter will be used to determine the number of rows and columns.
+    cols : int, optional
+        The number of columns in the subplots grid.
+        If not specified, it will be inferred automatically based on the number of rows and the number of plots.
+        If neither `rows` nor `cols` are specified,
+        the `arrange` parameter will be used to determine the number of rows and columns.
+    arrange : {"rows", "cols", "square"}, optional
+        Determines number of rows and columns if neither ``rows`` nor ``cols`` are specified.
+        If ``arrange`` is "rows", the number of rows will be equal to the number of plots.
+        If ``arrange`` is "cols", the number of columns will be equal to the number of plots.
+        If ``arrange`` is "square", the number of rows and columns will be equal to the square root of the number of plots,
+    backend : {"plotly", "matplotlib", "py3dmol", "blender"}, optional
+        The backend to use for the merged figure.
+    **kwargs
+        Additional arguments that will be passed to the `_init_figure_*` method of the Figure class.
+        The arguments accepted here are basically backend specific, but for subplots all backends should
+        support `rows` and `cols` to specify the number of rows and columns of the subplots, and `arrange`
+        which controls the arrangement ("rows", "cols" or "square").
+
+    See Also
+    --------
+    merge_plots : The function that is called to merge the plots.
+    """
+
+    return merge_plots(
+        *figures,
+        composite_method="subplots",
+        backend=backend,
+        arrange=arrange,
+        rows=rows,
+        cols=cols,
+        **kwargs,
+    )
+
+
+def animation(
+    *figures: Figure,
+    frame_duration: float = 500,
+    interpolated_frames: int = 5,
+    backend: Literal["plotly", "matplotlib", "py3dmol", "blender"] = "plotly",
+    **kwargs,
+) -> Figure:
+    """Combines multiple plots into a single figure using an animation.
+
+    Parameters
+    ----------
+    *figures : Figure
+        The figures (or plots) to combine.
+    frame_duration : float, optional
+        Number of milliseconds each frame should be displayed.
+    interpolated_frames : int, optional
+        Number of interpolated frames to add between each frame.
+        This only works with the blender backend.
+    backend : {"plotly", "matplotlib", "py3dmol", "blender"}, optional
+        The backend to use for the merged figure.
+    **kwargs
+        Additional arguments that will be passed to the `_init_figure_*` method of the Figure class.
+        The arguments accepted here are basically backend specific, but for subplots all backends should
+        support `rows` and `cols` to specify the number of rows and columns of the subplots, and `arrange`
+        which controls the arrangement ("rows", "cols" or "square").
+
+    See Also
+    --------
+    merge_plots : The function that is called to merge the plots.
+    """
+
+    return merge_plots(
+        *figures,
+        frame_duration=frame_duration,
+        interpolated_frames=interpolated_frames,
+        composite_method="animation",
+        backend=backend,
+        **kwargs,
+    )


### PR DESCRIPTION
Before this, the only option to merge plots was `sisl.viz.merge_plots`. Since this function only accepted the composite method and `*args, **kwargs`, it was difficult for users to know which arguments they could pass for a particular composite method.

This PR adds two additional functions: `sisl.viz.subplots` and `sisl.viz.animation`. They do exactly the same but have more useful signatures for the specific method.

E.g.:

```python
import sisl

graphene = sisl.geom.graphene(bond=1.4)
plot = graphene.plot(axes="xy")

sisl.viz.subplots(plot, plot, cols=2)
# Equivalent to 
# sisl.viz.merge_plots(plot, plot, composite_method="subplots", cols=2)
```

![newplot (62)](https://github.com/zerothi/sisl/assets/42074085/c76eaf4a-11cb-47e1-81a7-e299b62b9178)

