### PR TITLE
Ensure c-order for `Geometry` coordinates

### DIFF
--- a/src/sisl/_core/geometry.py
+++ b/src/sisl/_core/geometry.py
@@ -176,7 +176,7 @@ class Geometry(
     )
     def __init__(self, xyz: ArrayLike, atoms=None, lattice=None, names=None):
         # Create the geometry coordinate, be aware that we do not copy!
-        self.xyz = _a.asarrayd(xyz).reshape(-1, 3)
+        self.xyz = _a.asarrayd(xyz, order="C").reshape(-1, 3)
 
         # Default value
         if atoms is None:


### PR DESCRIPTION
I propose to force c-order of the coordinate array upon creation of a `Geometry`. To my understanding, there is little overhead by always checking (and possibly converting) this.

This closes #748.