### PR TITLE
made State.inner a very flexible matrix product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ we hit release version 1.0.0.
 ## [0.15.0] - YYYY-MM-DD
 
 ### Added
+- improved `atom` projections of states, #750
 - improved typing system
 - `units` to `read_*` for some `Sile`s, #726
 - enabled reading the Hamiltonian from the Wannier90 _tb.dat file, #727

--- a/src/sisl/_core/tests/test_geometry.py
+++ b/src/sisl/_core/tests/test_geometry.py
@@ -1852,3 +1852,17 @@ def test_as_supercell_fcc():
 def test_sc_warn():
     with pytest.warns(SislDeprecation):
         lattice = sisl_geom.graphene().sc
+
+
+def test_geometry_apply():
+    from functools import partial
+
+    g = sisl_geom.fcc(2**0.5, Atom(1, R=(1.0001, 2)))
+    data = np.random.rand(3, g.no, 4)
+    data_dup = g.apply(data, "sum", lambda x: x, segments="orbitals", axis=1)
+    assert data_dup.shape == data.shape
+    assert np.allclose(data, data_dup)
+
+    data_atom = g.apply(data, "sum", partial(g.a2o, all=True), axis=1)
+    assert data_atom.shape == (3, g.na, 4)
+    assert np.allclose(data_atom[:, 0], data[:, :2].sum(1))

--- a/src/sisl/physics/electron.py
+++ b/src/sisl/physics/electron.py
@@ -1555,7 +1555,7 @@ class _electron_State:
         "0.15",
         "0.16",
     )
-    def norm2(self, projection: Literal["sum", "orbitals", "state", "atoms"] = "sum"):
+    def norm2(self, projection: Literal["sum", "orbitals", "states", "atoms"] = "sum"):
         r"""Return a vector with the norm of each state :math:`\langle\psi|\mathbf S|\psi\rangle`
 
         :math:`\mathbf S` is the overlap matrix (or basis), for orthogonal basis

--- a/src/sisl/physics/state.py
+++ b/src/sisl/physics/state.py
@@ -440,13 +440,14 @@ state coefficients
         "0.15",
         "0.16",
     )
-    def norm2(self, projection: Literal["sum", "atoms", "state"] = "sum"):
+    def norm2(self, projection: Literal["sum", "atoms", "states"] = "sum"):
         r"""Return a vector with the norm of each state :math:`\langle\psi|\psi\rangle`
 
         Parameters
         ----------
         projection :
-           whether to compute the norm per state as a single number, atom-resolved or none quantity
+           whether to compute the norm per state as a single number, atom-resolved or per
+           state dimension.
 
         See Also
         --------
@@ -609,7 +610,7 @@ state coefficients
         self,
         ket=None,
         matrix=None,
-        projection: Literal["diag", "atoms", "state", "none"] = "diag",
+        projection: Literal["diag", "atoms", "states", "matrix"] = "diag",
     ):
         r"""Calculate the inner product as :math:`\mathbf A_{ij} = \langle\psi_i|\mathbf M|\psi'_j\rangle`
 
@@ -627,9 +628,9 @@ state coefficients
             full matrix.
 
             * ``diag`` only return the diagonal of the inner product
+            * ``matrix`` return a matrix of inner products, also the off-diagonals
             * ``atoms`` only do inner products for same states, summed over atoms on the state
-            * ``state`` only do inner products for same states
-            * ``matrix`` return a matrix of inner products, also between different states
+            * ``states`` only do inner products for same states
 
         Notes
         -----
@@ -692,10 +693,11 @@ state coefficients
         projection = {
             # temporary work-around for older codes where project/diag=T|F were allowed
             True: "diag",
-            False: "none",
+            False: "matrix",
             "sum": "diag",  # still allowed here (for bypass options)
             "atoms": "atom",  # plural s allowed
-            "orbitals": "none",  # still allowed here (for bypass options)
+            "states": "state",  # plural s allowed
+            "orbitals": "orbital",  # still allowed here (for bypass options)
         }.get(projection, projection)
 
         if projection in ("diag", "diagonal"):

--- a/src/sisl/physics/state.py
+++ b/src/sisl/physics/state.py
@@ -500,7 +500,7 @@ state coefficients
           order parameter for the IPR
         """
         # This *has* to be a real value C * C^* == real
-        state_abs2 = self.norm2(projection="state").real
+        state_abs2 = self.norm2(projection="states").real
         assert q >= 2, f"{self.__class__.__name__}.ipr requires q>=2"
         # abs2 is already having the exponent 2
         return (state_abs2**q).sum(-1) / state_abs2.sum(-1) ** q
@@ -852,8 +852,8 @@ state coefficients
         --------
         align_phase : rotate states such that their phases align
         """
-        snorm = self.norm2(projection="state").real
-        onorm = other.norm2(projection="state").real
+        snorm = self.norm2(projection="states").real
+        onorm = other.norm2(projection="states").real
 
         # Now find new orderings
         show_warn = False

--- a/src/sisl/physics/tests/test_state.py
+++ b/src/sisl/physics/tests/test_state.py
@@ -259,9 +259,9 @@ def test_state_align_phase():
 
 
 def test_state_ipr():
-    state = State(ortho_matrix(15))
+    state = State(ortho_matrix(10))
     ipr = state.ipr()
-    assert ipr.shape == (15,)
+    assert ipr.shape == (10,)
 
 
 def test_state_align_norm():
@@ -282,7 +282,7 @@ def test_state_align_norm():
 
 
 def test_state_align_norm2():
-    state = ortho_matrix(15)
+    state = ortho_matrix(10)
     state1 = State(state)
     idx = np.arange(len(state))
     np.random.shuffle(idx)


### PR DESCRIPTION
It can now be used to calculate state norms
and is basically the backbone of a lot of the methods now. It can work in 3 different ways:

- diag (diagonal inner state products)
- matrix (off-diagonal inner states)
- atoms|state|orbital (only diagonal inner states but atom resolved and/or orbital resolved.

I don't know if this complicates the usage a great deal. It makes much things simpler.


@tfrederiksen could you have a look here. I don't know if it is too much, or whether the names makes sense.
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #x
 - [x] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` [24.2.0] at top-level
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`
