### PR TITLE
Reading spin densities from CHGCAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ we hit release version 1.0.0.
 - A new `AtomicMatrixPlot` to plot sparse matrices, #668
 
 ### Fixed
+- fixed `CHGCAR` spin-polarized density reads, #754
 - dispatch methods now searches the mro for best matches, #721
 - all `eps` arguments has changed to `atol`
 - methods with `axis` arguments now accepts the str equivalent 0==a

--- a/src/sisl/io/vasp/chg.py
+++ b/src/sisl/io/vasp/chg.py
@@ -32,15 +32,28 @@ class chgSileVASP(carSileVASP):
         Parameters
         ----------
         index : int or array_like, optional
-           the index of the grid to read. For a spin-polarized VASP calculation 0 and 1 are
-           allowed, UP/DOWN. For non-collinear 0, 1, 2 or 3 is allowed which equals,
+           the index of the grid to read.
+           For spin-polarized calculations, 0 and 1 refer to the charge (spin-up plus spin-down) and
+           magnetitization (spin-up minus spin-down), respectively.
+           For non-collinear calculations, 0 refers to the charge while 1, 2 and 3 to
+           the magnetization in the :math:`\sigma_1`, :math:`\sigma_2`, and :math:`\sigma_3` directions, respectively.
            TOTAL, x, y, z charge density with the Cartesian directions equal to the charge
-           magnetization. For array-like they refer to the fractional
-           contributions for each corresponding index.
+           magnetization.
+           For array-like they refer to the fractional contributions for each corresponding index.
         dtype : numpy.dtype, optional
            grid stored dtype
         spin : optional
            same as `index` argument. `spin` argument has precedence.
+
+        Examples
+        --------
+        Read the spin polarization from a spin-polarized CHGCAR file
+
+        >>> fh = sisl.get_sile('CHGCAR')
+        >>> charge = fh.read_grid()
+        >>> spin = fh.read_grid(1)
+        >>> up_density = fh.read_grid([0.5, 0.5])
+        >>> assert np.allclose((charge + spin).grid, up_density.grid)
 
         Returns
         -------

--- a/src/sisl/io/vasp/chg.py
+++ b/src/sisl/io/vasp/chg.py
@@ -53,7 +53,7 @@ class chgSileVASP(carSileVASP):
         >>> charge = fh.read_grid()
         >>> spin = fh.read_grid(1)
         >>> up_density = fh.read_grid([0.5, 0.5])
-        >>> assert np.allclose((charge + spin).grid, up_density.grid)
+        >>> assert np.allclose((charge + spin).grid / 2, up_density.grid)
 
         Returns
         -------

--- a/src/sisl/io/vasp/chg.py
+++ b/src/sisl/io/vasp/chg.py
@@ -27,7 +27,7 @@ class chgSileVASP(carSileVASP):
 
     @sile_fh_open(True)
     def read_grid(self, index=0, dtype=np.float64, **kwargs) -> Grid:
-        """Reads the charge density from the file and returns with a grid (plus geometry)
+        r"""Reads the charge density from the file and returns with a grid (plus geometry)
 
         Parameters
         ----------
@@ -36,7 +36,7 @@ class chgSileVASP(carSileVASP):
            For spin-polarized calculations, 0 and 1 refer to the charge (spin-up plus spin-down) and
            magnetitization (spin-up minus spin-down), respectively.
            For non-collinear calculations, 0 refers to the charge while 1, 2 and 3 to
-           the magnetization in the :math:`\sigma_1`, :math:`\sigma_2`, and :math:`\sigma_3` directions, respectively.
+           the magnetization in the :math:`\sigma_x`, :math:`\sigma_y`, and :math:`\sigma_z` directions, respectively.
            TOTAL, x, y, z charge density with the Cartesian directions equal to the charge
            magnetization.
            For array-like they refer to the fractional contributions for each corresponding index.
@@ -54,6 +54,8 @@ class chgSileVASP(carSileVASP):
         >>> spin = fh.read_grid(1)
         >>> up_density = fh.read_grid([0.5, 0.5])
         >>> assert np.allclose((charge + spin).grid / 2, up_density.grid)
+        >>> down_density = fh.read_grid([0.5, -0.5])
+        >>> assert np.allclose((charge - spin).grid / 2, down_density.grid)
 
         Returns
         -------

--- a/src/sisl/io/vasp/chg.py
+++ b/src/sisl/io/vasp/chg.py
@@ -95,7 +95,7 @@ class chgSileVASP(carSileVASP):
                     while j < geom.na:
                         j += len(rl().split())
                 # one line of nx, ny, nz
-                assert len(rl().split()) == 3
+                assert np.allclose(list(map(int, rl().split())), [nx, ny, nz])
 
         # Cut size before proceeding (otherwise it *may* fail)
         vals = np.array(vals).astype(dtype, copy=False)

--- a/src/sisl/io/vasp/chg.py
+++ b/src/sisl/io/vasp/chg.py
@@ -90,8 +90,12 @@ class chgSileVASP(carSileVASP):
                         while j < occ:
                             j += len(rl().split())
                         line = rl()
+                    # read over an additional block with geom.na entries???
+                    j = len(line.split())
+                    while j < geom.na:
+                        j += len(rl().split())
                 # one line of nx, ny, nz
-                rl()
+                assert len(rl().split()) == 3
 
         # Cut size before proceeding (otherwise it *may* fail)
         vals = np.array(vals).astype(dtype, copy=False)

--- a/src/sisl/io/vasp/tests/test_chg.py
+++ b/src/sisl/io/vasp/tests/test_chg.py
@@ -62,6 +62,11 @@ def test_nitric_oxide_pol(sisl_files, chg_type, np_dtype):
 
     assert grid.grid.sum() * grid.dvolume == pytest.approx(1, rel=1e-3)
     assert geom == grid.geometry
+    # check against first raw datapoint on grid
+    if chg_type == "CHG":
+        assert grid.grid[0, 0, 0] * grid.volume == pytest.approx(0.33228e-03)
+    elif chg_type == "CHGCAR":
+        assert grid.grid[0, 0, 0] * grid.volume == pytest.approx(0.49880745183e-03)
 
 
 def test_nitric_oxide_soi(sisl_files, chg_type, np_dtype):
@@ -70,5 +75,17 @@ def test_nitric_oxide_soi(sisl_files, chg_type, np_dtype):
     for i in range(1, 4):
         grid = chgSileVASP(f).read_grid(i, dtype=np_dtype)
         s += (grid.grid.sum() * grid.dvolume) ** 2
+        # check against first raw datapoint on grid
+        if chg_type == "CHG":
+            val = [0.12505, 0.26118e-03, 0.26791e-03, 0.27440e-03][i]
+            assert grid.grid[0, 0, 0] * grid.volume == pytest.approx(val)
+        elif chg_type == "CHGCAR":
+            val = [
+                0.12504989341e00,
+                0.26117671499e-03,
+                0.26791165124e-03,
+                0.27440440526e-03,
+            ][i]
+            assert grid.grid[0, 0, 0] * grid.volume == pytest.approx(val)
 
     assert s == pytest.approx(1, rel=1e-3)

--- a/src/sisl/io/vasp/tests/test_chg.py
+++ b/src/sisl/io/vasp/tests/test_chg.py
@@ -68,13 +68,20 @@ def test_nitric_oxide_pol(sisl_files, chg_type, np_dtype):
     elif chg_type == "CHGCAR":
         assert grid.grid[0, 0, 0] * grid.volume == pytest.approx(0.49880745183e-03)
 
+    # construct up-spin density
+    chg = chgSileVASP(f).read_grid(0, dtype=np_dtype)
+    grid.grid += chg.grid
+    grid.grid /= 2
+    up_spin = chgSileVASP(f).read_grid([0.5, 0.5], dtype=np_dtype)
+    assert np.allclose(grid.grid, up_spin.grid)
+
 
 def test_nitric_oxide_soi(sisl_files, chg_type, np_dtype):
     f = sisl_files(_dir, "nitric_oxide/soi", chg_type + ".gz")
-    s = 0
-    for i in range(1, 4):
+    grids = []
+    for i in range(4):
         grid = chgSileVASP(f).read_grid(i, dtype=np_dtype)
-        s += (grid.grid.sum() * grid.dvolume) ** 2
+        grids.append(grid)
         # check against first raw datapoint on grid
         if chg_type == "CHG":
             val = [0.12505, 0.26118e-03, 0.26791e-03, 0.27440e-03][i]
@@ -88,4 +95,14 @@ def test_nitric_oxide_soi(sisl_files, chg_type, np_dtype):
             ][i]
             assert grid.grid[0, 0, 0] * grid.volume == pytest.approx(val)
 
+    s = 0
+    for i in range(1, 4):
+        grid = grids[i]
+        s += (grid.grid.sum() * grid.dvolume) ** 2
     assert s == pytest.approx(1, rel=1e-3)
+
+    # construct up-spin density
+    grid.grid += grids[0].grid
+    grid.grid /= 2
+    up_spin = chgSileVASP(f).read_grid([0.5, 0, 0, 0.5], dtype=np_dtype)
+    assert np.allclose(grid.grid, up_spin.grid)


### PR DESCRIPTION
The spin densities were not correctly read from CHGCAR, because after the augmentation occupancies *an additional block of values* (apparently one per atom) is found on file.

I could not determine what this extra block refers to, as it is not explicitly mentioned in the documentation from the [VASP forum](https://www.vasp.at/wiki/index.php/CHGCAR), which just mentions:
> For magnetic calculations, the CHGCAR file contains additional data blocks for the magnetization. In particular, for spin-polarized calculations ([ISPIN](https://www.vasp.at/wiki/index.php/ISPIN)=2), the first set contains the total charge density (spin up + spin down) and the second one is the magnetization density (spin up - spin down):
> 
> - Structure
> - FFT-grid dimensions
> - Charge density times FFT-grid volume (spin up + spin down)
> - Augmentation occupancies
> - FFT-grid dimensions
> - Magnetization density (spin up - spin down)
> - Augmentation occupancies

This PR resolves this issue and adds some further checks.