### PR TITLE
Plot update on getting attributes

### DIFF
--- a/src/sisl/viz/figure/figure.py
+++ b/src/sisl/viz/figure/figure.py
@@ -68,6 +68,17 @@ class Figure:
 
         return fig
 
+    @classmethod
+    def fig_has_attr(cls, key: str) -> bool:
+        """Whether the figure that this class generates has a given attribute.
+
+        Parameters
+        -----------
+        key
+            the attribute to check for.
+        """
+        return False
+
     @staticmethod
     def _sanitize_plot_actions(plot_actions):
         def _flatten(plot_actions, out, level=0, root_i=0):

--- a/src/sisl/viz/figure/matplotlib.py
+++ b/src/sisl/viz/figure/matplotlib.py
@@ -195,9 +195,16 @@ class MatplotlibFigure(Figure):
 
             yield sanitized_section_actions
 
+    @classmethod
+    def fig_has_attr(cls, key: str) -> bool:
+        return hasattr(plt.Axes, key) or hasattr(plt.Figure, key)
+
     def __getattr__(self, key):
         if key != "axes":
-            return getattr(self.axes, key)
+            if hasattr(self.axes, key):
+                return getattr(self.axes, key)
+            elif key != "figure" and hasattr(self.figure, key):
+                return getattr(self.figure, key)
         raise AttributeError(key)
 
     def clear(self, layout=False):

--- a/src/sisl/viz/figure/plotly.py
+++ b/src/sisl/viz/figure/plotly.py
@@ -402,6 +402,11 @@ class PlotlyFigure(Figure):
 
         self.update_layout(sliders=[slider], updatemenus=updatemenus)
 
+    @classmethod
+    def fig_has_attr(cls, key: str) -> bool:
+        print(key, hasattr(go.Figure, key))
+        return hasattr(go.Figure, key)
+
     def __getattr__(self, key):
         if key != "figure":
             return getattr(self.figure, key)


### PR DESCRIPTION
With this PR plots are updated if one attempts to retreive an attribute that we know will be present in the figure.

This is to make things like `plot.show()` even when no plot has been computed yet. It was not intuitive for users that you had to `plot.get().show()`. This has the side effect that `plot.show()` will now update the plot.This means that the way of acting on the plot without updating it now is by getting the `_output` attribute. E.g. to show the current (possibly outdated) plot:

```python
plot._output.show()
```

It fixes the broken docs.