### PR TITLE
CI also run on minimal installation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,6 +66,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.9', '3.12']
+        full: [true]
+        include:
+          # Run a minimal dependency check for 3.9
+          # This is not per-see a minimal dependency check.
+          # However, it checks that sisl can run without viz
+          # and those dependencies.
+          - python-version: '3.9'
+            full: false
 
     steps:
     - name: Checkout sisl
@@ -73,9 +81,9 @@ jobs:
       with:
         ref: '${{ github.event.inputs.branch }}'
         # The files submodule is required for tests purposes
-        submodules: true
+        submodules: ${{ matrix.full }}
         # the 'files' submodule uses lfs
-        lfs: true
+        lfs: ${{ matrix.full }}
 
     - name: Print-out commit information
       run: |
@@ -99,7 +107,11 @@ jobs:
         SKBUILD_CMAKE_ARGS: -DWITH_COVERAGE:bool=true;-DWITH_LINE_DIRECTIVES:bool=true
       run: |
         python -m pip install --progress-bar=off --upgrade pip
-        CC=gcc FC=gfortran python -m pip install --progress-bar=off -vvv .[test,viz]
+        if [[ "${{ matrix.full }}" == "true" ]]; then
+          CC=gcc FC=gfortran python -m pip install --progress-bar=off -vvv .[test,viz]
+        else
+          CC=gcc FC=gfortran python -m pip install --progress-bar=off -vvv .
+        fi
 
     - name: Running sisl import test
       run: |

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -152,7 +152,7 @@ jobs:
           sleep 10
           version=${GITHUB_REF#refs/*/v}
           version=${version#refs/*/}
-          python -m pip install --progress-bar=off --find-links dist --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ sisl[test]==${version}
+          python -m pip install --progress-bar=off --find-links dist --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ sisl[test,viz]==${version}
 
       - name: Test the installation
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,14 +185,6 @@ test = [
     "pytest-cov",
     "pytest-env",
     "pytest-faulthandler",
-    "netCDF4",
-    "tqdm>=4.36.0",
-    "dill >= 0.3.2",
-    "pathos",
-    "scikit-image",
-    "matplotlib",
-    "plotly",
-    "ase"
 ]
 
 docs = [


### PR DESCRIPTION
A test run without viz and other things is now added. This should test the branch when a user
simply does pip install sisl.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #x
 - [ ] Added tests for new/changed functions?
 - [ ] Ran `isort .` and `black .` [24.2.0] at top-level
 - [ ] Documentation for functionality in `docs/`
 - [ ] Changes documented in `CHANGELOG.md`
