### PR TITLE
fixed pbc usage across sisl, fixes #764

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ we hit release version 1.0.0.
 - A new `AtomicMatrixPlot` to plot sparse matrices, #668
 
 ### Fixed
+- xsf files now only respect `lattice.pbc` for determining PBC, #764
 - fixed `CHGCAR` spin-polarized density reads, #754
 - dispatch methods now searches the mro for best matches, #721
 - all `eps` arguments has changed to `atol`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ we hit release version 1.0.0.
 
 ### Added
 - ability to retain sub-classes through `<class>.new` calls
+- added `Listify` to ensure arguments behaves as *iterables*
+- setter for `Lattice.pbc` to specify it through an array
+- `Lattice.volumef` to calculate a subset volume based on axes
 - added `write_grid` to Siesta binary grid files
 - added the `goldene` 2D lattice, a `hexagonal` Gold 2D structure
 - added the `hexagonal` 2D lattice, close-packed FCC(111) surface
@@ -48,6 +51,9 @@ we hit release version 1.0.0.
 - A new `AtomicMatrixPlot` to plot sparse matrices, #668
 
 ### Fixed
+- lots of `Lattice` methods did not consistently copy over BC
+- `BrillouinZone.volume` fixed to actually return BZ volume
+  use `Lattice.volume` for getting the lattice volume.
 - xsf files now only respect `lattice.pbc` for determining PBC, #764
 - fixed `CHGCAR` spin-polarized density reads, #754
 - dispatch methods now searches the mro for best matches, #721
@@ -86,7 +92,8 @@ we hit release version 1.0.0.
 - removed `Selector` and `TimeSelector`, they were never used internally
 
 ### Changed
-- changed `Eigenmode.displacement` return shape, please read the documentation
+- deprecated `periodic` to `axes` argument in `BrillouinZone.volume`
+- changed `Eigenmode.displacement` shape, please read the documentation
 - bumped minimal Python version to 3.9, #640
 - documentation build system on RTD is updated, #745
 - `gauge` arguments now accept 'cell' and 'orbital' in replacements for 'R' and 'r', respectively

--- a/docs/api/utilities.misc.rst
+++ b/docs/api/utilities.misc.rst
@@ -26,6 +26,8 @@ Miscellaneous routines
 
    str_spec
    direction - abc/012 -> 012
+   Listify
+   listify
    angle - radian to degree
    iter_shape
    math_eval

--- a/src/sisl/_core/lattice.py
+++ b/src/sisl/_core/lattice.py
@@ -26,7 +26,7 @@ from sisl.messages import SislError, deprecate, deprecate_argument, deprecation,
 from sisl.shape.prism4 import Cuboid
 from sisl.typing import CellAxes, CellAxis
 from sisl.utils.mathematics import fnorm
-from sisl.utils.misc import direction
+from sisl.utils.misc import direction, listify
 
 from ._lattice import cell_invert, cell_reciprocal
 
@@ -151,16 +151,64 @@ class Lattice(
         """Length of each lattice vector"""
         return fnorm(self.cell)
 
+    def lengthf(self, axes: CellAxes = (0, 1, 2)) -> ndarray:
+        """Length of specific lattice vectors (as a function)
+        Parameters
+        ----------
+        axes:
+            only calculate the volume based on a subset of axes
+
+        Examples
+        --------
+        Only get lengths of two lattice vectors:
+
+        >>> lat = Lattice(1)
+        >>> lat.lengthf([0, 1])
+        """
+        axes = map(direction, listify(axes)) | listify
+        return fnorm(self.cell[axes])
+
     @property
     def volume(self) -> float:
         """Volume of cell"""
-        return abs(dot3(self.cell[0], cross3(self.cell[1], self.cell[2])))
+        return self.volumef((0, 1, 2))
+
+    def volumef(self, axes: CellAxes = (0, 1, 2)) -> float:
+        """Volume of cell (as a function)
+
+        Default to the 3D volume.
+        For `axes` with only 2 elements, it corresponds to an area.
+        For `axes` with only 1 element, it corresponds to a length.
+
+        Parameters
+        ----------
+        axes:
+            only calculate the volume based on a subset of axes
+
+        Examples
+        --------
+        Only get the volume of the periodic directions:
+
+        >>> lat = Lattice(1)
+        >>> lat.pbc = (True, False, True)
+        >>> lat.volumef(lat.pbc.nonzero()[0])
+        """
+        axes = map(direction, listify(axes)) | listify
+
+        cell = self.cell
+        if len(axes) == 3:
+            return abs(dot3(cell[axes[0]], cross3(cell[axes[1]], cell[axes[2]])))
+        if len(axes) == 2:
+            return fnorm(cross3(cell[axes[0]], cell[axes[1]]))
+        if len(axes) == 1:
+            return fnorm(cell[axes])
+        return 0.0
 
     def area(self, axis1: CellAxis, axis2: CellAxis) -> float:
         """Calculate the area spanned by the two axis `ax0` and `ax1`"""
         axis1 = direction(axis1)
         axis2 = direction(axis2)
-        return (cross3(self.cell[axis1], self.cell[axis2]) ** 2).sum() ** 0.5
+        return fnorm(cross3(self.cell[axis1], self.cell[axis2]))
 
     @property
     def boundary_condition(self) -> np.ndarray:
@@ -185,9 +233,18 @@ class Lattice(
         # set_boundary_condition does not allow to have PERIODIC and non-PERIODIC
         # along the same lattice vector. So checking one should suffice
         assert len(pbc) == 3
+
+        PERIODIC = BoundaryCondition.PERIODIC
         for axis, bc in enumerate(pbc):
+
+            # Simply skip those that are not T|F
+            if not isinstance(bc, bool):
+                continue
+
             if bc:
-                self._bc[axis] = BoundaryCondition.PERIODIC
+                self._bc[axis] = PERIODIC
+            elif self._bc[axis, 0] == PERIODIC:
+                self._bc[axis] = BoundaryCondition.UNKNOWN
 
     @property
     def origin(self) -> ndarray:
@@ -544,13 +601,9 @@ class Lattice(
         # Reduce to total repetitions
         ireps = np.amax(ix, axis=0) - np.amin(ix, axis=0) + 1
 
-        # Only repeat the axis requested
-        if isinstance(axes, Integral):
-            axes = [axes]
-
         # Reduce the non-set axis
         if not axes is None:
-            axes = list(map(direction, axes))
+            axes = map(direction, listify(axes))
             for ax in (0, 1, 2):
                 if ax not in axes:
                     ireps[ax] = 1
@@ -618,6 +671,7 @@ class Lattice(
         """
         axis1 = direction(axis1)
         axis2 = direction(axis2)
+
         cell = self.cell
         n = cross3(cell[axis1], cell[axis2])
         # Normalize
@@ -695,9 +749,7 @@ class Lattice(
         numpy.ndarray
              cell-vectors with prescribed length, same order as `axes`
         """
-        if isinstance(axes, Integral):
-            axes = [axes]
-        axes = list(map(direction, axes))
+        axes = map(direction, listify(axes)) | listify
 
         length = _a.asarray(length).ravel()
         if len(length) != len(axes):
@@ -708,6 +760,7 @@ class Lattice(
                     f"{self.__class__.__name__}.cell2length length parameter should be a single "
                     "float, or an array of values according to axes argument."
                 )
+
         return self.cell[axes] * (length / self.length[axes]).reshape(-1, 1)
 
     def offset(self, isc=None) -> Tuple[float, float, float]:
@@ -973,9 +1026,8 @@ class Lattice(
         axes :
            only check the specified axes (default to all)
         """
-        if isinstance(axes, Integral):
-            axes = [axes]
-        axis = list(map(direction, axes))
+        axis = map(direction, listify(axes))
+
         # Convert to unit-vector cell
         for i in axis:
             a = self.cell[i] / fnorm(self.cell[i])

--- a/src/sisl/_core/lattice.py
+++ b/src/sisl/_core/lattice.py
@@ -179,6 +179,16 @@ class Lattice(
         # along the same lattice vector. So checking one should suffice
         return self._bc[:, 0] == BoundaryCondition.PERIODIC
 
+    @pbc.setter
+    def pbc(self, pbc) -> None:
+        """Boolean array to specify whether the boundary conditions are periodic`"""
+        # set_boundary_condition does not allow to have PERIODIC and non-PERIODIC
+        # along the same lattice vector. So checking one should suffice
+        assert len(pbc) == 3
+        for axis, bc in enumerate(pbc):
+            if bc:
+                self._bc[axis] = BoundaryCondition.PERIODIC
+
     @property
     def origin(self) -> ndarray:
         """Origin for the cell"""

--- a/src/sisl/_core/sparse_geometry.py
+++ b/src/sisl/_core/sparse_geometry.py
@@ -182,7 +182,7 @@ class _SparseGeometry(NDArrayOperatorsMixin):
         """
         # Sanitize the axes argument
         if axes is None:
-            axes = (self.lattice.nsc > 1).nonzero()[0]
+            axes = self.lattice.pbc.nonzero()[0]
 
         elif isinstance(axes, bool):
             if axes:

--- a/src/sisl/_core/tests/test_geometry.py
+++ b/src/sisl/_core/tests/test_geometry.py
@@ -906,7 +906,7 @@ class TestGeometry:
                 assert np.allclose(d[j], di[j])
                 assert np.allclose(isc[j], isci[j])
 
-    def test_within_inf1(self, setup):
+    def test_within_inf_small_translated(self, setup):
         g = setup.g.translate([0.05] * 3)
         lattice_3x3 = g.lattice.tile(3, 0).tile(3, 1)
         assert len(g.within_inf(lattice_3x3)[0]) == len(g) * 3**2
@@ -930,7 +930,7 @@ class TestGeometry:
         assert np.any(isc[:, 0] != 0)
         assert np.all(isc[:, 1] == 0)
 
-    def test_within_inf2(self, setup):
+    def test_within_inf_molecule(self, setup):
         g = setup.mol.translate([0.05] * 3)
         lattice = Lattice(1.5)
         for o in range(10):
@@ -942,10 +942,9 @@ class TestGeometry:
 
     def test_within_inf_duplicates(self, setup):
         g = setup.g.copy()
+        g.lattice.pbc = [True, True, False]
         lattice_3x3 = g.lattice.tile(3, 0).tile(3, 1)
-        assert (
-            len(g.within_inf(lattice_3x3)[0]) == len(g) * 3**2 + 7
-        )  # 3 per vector and 1 in the upper right corner
+        assert len(g.within_inf(lattice_3x3)[0]) == 25
 
     def test_close_sizes(self, setup):
         point = 0

--- a/src/sisl/_core/tests/test_lattice.py
+++ b/src/sisl/_core/tests/test_lattice.py
@@ -606,3 +606,15 @@ def test_lattice_info():
         lat.set_boundary_condition(b=Lattice.BC.DIRICHLET)
         lat.set_boundary_condition(c=Lattice.BC.PERIODIC)
         assert len(record) == 1
+
+
+def test_lattice_pbc_setter():
+    lat = Lattice(1, nsc=[3, 3, 3])
+    assert np.all(lat.pbc)
+    pbc = [True, False, True]
+    lat.pbc = pbc
+    assert np.all(lat.pbc == pbc)
+    # check that None won't change anything
+    pbc = [False, None, None]
+    lat.pbc = pbc
+    assert np.all(lat.pbc == [False, False, True])

--- a/src/sisl/io/tests/test_xsf.py
+++ b/src/sisl/io/tests/test_xsf.py
@@ -24,6 +24,28 @@ def test_default(sisl_tmp):
     assert grid.geometry is None
 
 
+@pytest.mark.parametrize(
+    "pbc",
+    [
+        (True, True, True),
+        (True, True, False),
+        (True, False, False),
+        (False, False, False),
+    ],
+)
+def test_pbc(sisl_tmp, pbc):
+    f = sisl_tmp("GRID_default.xsf", _dir)
+    geom = Geometry(
+        np.random.rand(10, 3),
+        np.random.randint(1, 70, 10),
+        lattice=[10, 10, 10, 45, 60, 90],
+    )
+    geom.lattice.pbc = pbc
+    geom.write(f)
+    geom2 = geom.read(f)
+    assert all(geom.pbc == geom2.pbc)
+
+
 def test_default_size(sisl_tmp):
     f = sisl_tmp("GRID_default_size.xsf", _dir)
     grid = Grid(0.2, lattice=2.0)

--- a/src/sisl/io/xsf.py
+++ b/src/sisl/io/xsf.py
@@ -122,11 +122,12 @@ class xsfSile(Sile):
             "# File created by: sisl {}\n#\n".format(strftime("%Y-%m-%d", gmtime()))
         )
 
-        if all(lattice.nsc == 1):
+        pbc = lattice.pbc
+        if pbc.sum() == 0:
             self._write_once("MOLECULE\n#\n")
-        elif all(lattice.nsc[:2] > 1):
+        elif all(pbc == (True, True, False)):
             self._write_once("SLAB\n#\n")
-        elif lattice.nsc[0] > 1:
+        elif all(pbc == (True, False, False)):
             self._write_once("POLYMER\n#\n")
         else:
             self._write_once("CRYSTAL\n#\n")

--- a/src/sisl/physics/brillouinzone.py
+++ b/src/sisl/physics/brillouinzone.py
@@ -422,17 +422,17 @@ class BrillouinZone:
            the dimensionality of the volume
         """
         # default periodic array
-        if periodic is None:
-            periodic = self.parent.pbc.nonzero()[0]
+        if axes is None:
+            axes = self.parent.pbc.nonzero()[0]
 
-        dim = len(periodic)
+        dim = len(axes)
         vol = 0.0
         if dim == 3:
             vol = self.parent.volume
         elif dim == 2:
-            vol = self.parent.area(*periodic)
+            vol = self.parent.area(*axes)
         elif dim == 1:
-            vol = self.parent.length[periodic[0]]
+            vol = self.parent.length[axes[0]]
 
         if ret_dim:
             return vol, dim

--- a/src/sisl/physics/brillouinzone.py
+++ b/src/sisl/physics/brillouinzone.py
@@ -389,7 +389,14 @@ class BrillouinZone:
 
         return BrillouinZone(parent, np.concatenate(k), np.concatenate(w))
 
-    def volume(self, ret_dim: bool = False, periodic=None):
+    @deprecate_argument(
+        "periodic",
+        "axes",
+        "argument 'periodic' has been deprecated in favor of 'axes', please update your code.",
+        "0.15",
+        "0.16",
+    )
+    def volume(self, ret_dim: bool = False, axes: Optional[AnyAxes] = None):
         """Calculate the volume of the full Brillouin zone of the parent
 
         This will return the volume depending on the dimensions of the system.
@@ -400,11 +407,11 @@ class BrillouinZone:
 
         Parameters
         ----------
-        ret_dim:
+        ret_dim :
            also return the dimensionality of the system
-        periodic : array_like of int, optional
+        axes :
            estimate the volume using only the directions indexed by this array.
-           The default value is `(self.parent.nsc > 1).nonzero()[0]`.
+           The default value is ``self.parent.pbc.nonzero()[0]``.
 
         Returns
         -------
@@ -416,7 +423,7 @@ class BrillouinZone:
         """
         # default periodic array
         if periodic is None:
-            periodic = (self.parent.nsc > 1).nonzero()[0]
+            periodic = self.parent.pbc.nonzero()[0]
 
         dim = len(periodic)
         vol = 0.0

--- a/src/sisl/physics/tests/test_brillouinzone.py
+++ b/src/sisl/physics/tests/test_brillouinzone.py
@@ -1,4 +1,4 @@
-# Source Code Form is subject to the terms of the Mozilla Public
+# This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
@@ -71,13 +71,18 @@ class TestBrillouinZone:
 
     def test_volume_self(self):
         bz = BrillouinZone(1.0)
-        assert bz.volume(True)[1] == 0
-        bz = BrillouinZone(Lattice(1, nsc=[3, 1, 1]))
+        bz.parent.pbc = (False, False, False)
+        v, dim = bz.volume(True)
+        assert dim == 0
+        assert v == pytest.approx(0)
+        bz.parent.pbc = (True, False, False)
         assert bz.volume(True)[1] == 1
-        bz = BrillouinZone(Lattice(1, nsc=[3, 3, 1]))
+        bz.parent.pbc = (True, True, False)
         assert bz.volume(True)[1] == 2
-        bz = BrillouinZone(Lattice(1, nsc=[3, 3, 3]))
-        assert bz.volume(True)[1] == 3
+        bz.parent.pbc = (True, True, True)
+        v, dim = bz.volume(True)
+        assert dim == 3
+        assert v == pytest.approx((2 * np.pi) ** 3)
 
     def test_volume_direct(self):
         bz = BrillouinZone(1.0)

--- a/src/sisl/utils/misc.py
+++ b/src/sisl/utils/misc.py
@@ -10,11 +10,12 @@ import inspect
 import operator as op
 import re
 import sys
+from collections.abc import Callable, Iterable, Iterator
 from math import pi
 from numbers import Integral
-from typing import Union
+from typing import Any, Union
 
-__all__ = ["merge_instances", "str_spec", "direction", "angle"]
+__all__ = ["merge_instances", "str_spec", "direction", "listify", "angle"]
 __all__ += ["iter_shape", "math_eval", "allow_kwargs"]
 __all__ += ["import_attr", "lazy_import"]
 __all__ += ["PropertyDict", "NotNonePropertyDict"]
@@ -218,6 +219,71 @@ def str_spec(name):
 
     lname = name[:-1].split("{")
     return "{".join(lname[:-1]), lname[-1]
+
+
+IterableAny = Iterator[Any]
+IterableInstantiation = Callable[..., IterableAny]
+
+
+class Listify:
+    """Convert arguments to an iterable-like (any iterable, default to `list`)
+
+    It provides also an easy mechanism for "piping" content to
+    a function call (for better readability).
+
+    Parameters
+    ----------
+    cls:
+        the default list-like object to cast it to
+
+    Examples
+    --------
+    >>> listify = Listify()
+    >>> 1 | listify
+    [1]
+    >>> Listify(tuple)(1)
+    (1,)
+
+    It can greatly improve readability with `map` constructs:
+    >>> map(lambda x, [1]) | listify
+    [1]
+
+    Notes
+    -----
+    If using this to convert to `tuple` instances ``Iterfy(tuple)``,
+    please do note the problems of using a tuple as indices for
+    `numpy.ndarray` objects.
+    """
+
+    __slots__ = ("_cls",)
+
+    # Ensures that numpy function calls won't happen!
+    # Just a higher priority than *any* numpy arrays and subclasses.
+    __array_priority__ = 1000000
+
+    def __init__(self, cls: IterableInstantiation = list):
+        self._cls = cls
+
+    def __call__(
+        self, arg: Any, cls: Optional[IterableInstantiation] = None
+    ) -> IterableAny:
+        if cls is None:
+            cls = self._cls
+        if isinstance(arg, Iterable):
+            if isinstance(arg, cls):
+                return arg
+            return cls(arg)
+        return cls([arg])
+
+    def __ror__(self, arg: Any) -> IterableAny:
+        """Allow piping of function calls"""
+        return self(arg)
+
+    def __getattr__(self, attr):
+        raise RuntimeError(f"{self.__class__.__name__} can not be used with {attr}.")
+
+
+listify = Listify()
 
 
 # Transform a string to a Cartesian direction

--- a/src/sisl/utils/misc.py
+++ b/src/sisl/utils/misc.py
@@ -250,9 +250,11 @@ class Listify:
 
     Notes
     -----
-    If using this to convert to `tuple` instances ``Iterfy(tuple)``,
+    If using this to convert to `tuple` instances ``Listify(tuple)``,
     please do note the problems of using a tuple as indices for
     `numpy.ndarray` objects.
+
+    This is partly inspired by `pip <https://pypi.org/project/pipe/>`_.
     """
 
     __slots__ = ("_cls",)
@@ -276,7 +278,7 @@ class Listify:
         return cls([arg])
 
     def __ror__(self, arg: Any) -> IterableAny:
-        """Allow piping of function calls"""
+        """Allow piping of function calls (on the right side)"""
         return self(arg)
 
     def __getattr__(self, attr):

--- a/src/sisl/utils/tests/test_misc.py
+++ b/src/sisl/utils/tests/test_misc.py
@@ -101,6 +101,20 @@ def test_str_spec1():
     assert a[1] == "bar"
 
 
+def test_listify():
+    assert isinstance(listify([1, 2]), list)
+    assert isinstance(1 | listify, list)
+    a = np.ones(2)
+    assert isinstance(listify(a), list)
+    assert isinstance(a | listify, list)
+
+
+def test_listify_as_index():
+    idx = 1 | listify
+    a = np.arange(2)
+    assert a[idx] == 1
+
+
 def test_merge_instances1():
     class A:
         pass


### PR DESCRIPTION
Now pbc usage has been moved across the
code base (I hope everything is managed).
I have added a setter for pbc to enable
fast setting pbc. It will silently ignore
any dimensions not specified.
This may be used as a shorthand for
lattice.set_boundary_condition(...)

@pfebrer could you please review this? I hope it fixes the issue!

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #764 
 - [x] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` [24.2.0] at top-level
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`
