### PR TITLE
Added trace of M*overlap

### DIFF
--- a/src/sisl/_core/sparse_geometry.py
+++ b/src/sisl/_core/sparse_geometry.py
@@ -1077,6 +1077,13 @@ class _SparseGeometry(NDArrayOperatorsMixin):
 
         return p
 
+    def trace_with_S(self):
+        """Trace of the multiplication of the sparse matrix with the overlap matrix."""
+        if self.orthogonal:
+            return self._csr.diagonal().sum(axis=0)
+        else:
+            return (self._csr.data[:, :-1] * self._csr.data[:, [-1]]).sum(axis=0)
+
     # numpy dispatch methods (same priority as SparseCSR!)
     __array_priority__ = 14
 


### PR DESCRIPTION
Adds a method to retrieve the trace of the matrix multiplication of a matrix with its overlap.

E.g. to get the total number of electrons from the DM or the band structure energy from the EDM (I think?).

If you agree that this is useful I can add some tests before merging.