### PR TITLE
Add support for sisl in nodify's GUI

### DIFF
--- a/src/sisl/__init__.py
+++ b/src/sisl/__init__.py
@@ -166,6 +166,8 @@ Lattice.to.register("Sile", Lattice.to._dispatchs[str])
 # sisl.geom.graphene
 from . import geom
 
+from ._nodify import on_nodify as __nodify__
+
 # Set all the placeholders for the plot attribute
 # of sisl classes
 from ._lazy_viz import set_viz_placeholders

--- a/src/sisl/_nodify.py
+++ b/src/sisl/_nodify.py
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from typing import List
+
+import sisl
+
+
+def on_nodify():
+    from nodify.server.session import register_file_plot_handler
+
+    def _get_plot_options(file_name: str) -> List[str]:
+        try:
+            plot_handler = sisl.get_sile(file_name).plot
+        except:
+            return []
+
+        options = list(plot_handler._dispatchs.keys())
+
+        return options
+
+    def _plot_file(file_name: str, method: str):
+        plot_handler = sisl.get_sile(file_name).plot
+        print(plot_handler)
+        if method is None:
+            plot = plot_handler()
+        else:
+            plot = getattr(plot_handler, method)()
+
+        try:
+            plot.get()
+        except:
+            pass
+
+        return plot
+
+    register_file_plot_handler("sisl", _get_plot_options, _plot_file)


### PR DESCRIPTION
The idea is that `sisl-gui` (https://github.com/pfebrer/sisl-gui) will disappear in favour of a GUI that is general for `nodify`. This GUI can be launched in the terminal with 
```
nodify-gui
```
once `nodify` is installed.

Then, the only thing sisl-specific (for now) are the options that sisl provides for plotting files. These are registered once `sisl` is nodified, because `sisl.__nodify__()` will be called.

Then, to use sisl functionality on `nodify`'s GUI one only needs to pass sisl on the list of modules:

```
nodify-gui sisl
```

This will result in what previously was `sisl-gui`.
