### PR TITLE
fixed reading geometries from fdf + XV + STRUCT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ we hit release version 1.0.0.
 - A new `AtomicMatrixPlot` to plot sparse matrices, #668
 
 ### Fixed
+- reading XV/STRUCT files from fdf siles could cause problems, #778
 - `Geometry.[ao][us]c2[su]c` methods now retains the input shapes (unless `unique=True`)
 - lots of `Lattice` methods did not consistently copy over BC
 - `BrillouinZone.volume` fixed to actually return BZ volume
@@ -90,6 +91,8 @@ we hit release version 1.0.0.
   be done for assigning matrix elements (it fills with 0's).
 
 ### Removed
+- `xvSileSiesta.read_geometry(species_as_Z)`, deprecated in favor of `atoms=`
+- `structSileSiesta.read_geometry(species_as_Z)`, deprecated in favor of `atoms=`
 - `Atom.radii` is removed, `Atom.radius` is the correct invocation
 - `sisl.plot` is removed (`sisl.viz` is replacing it!)
 - `cell` argument for `Geometry.translate/move` (it never worked)

--- a/src/sisl/_core/atom.py
+++ b/src/sisl/_core/atom.py
@@ -1927,7 +1927,7 @@ class Atoms:
         # Update orbital counts...
         self._update_orbitals()
 
-    def replace_atom(self, atom_from, atom_to):
+    def replace_atom(self, atom_from: Atom, atom_to: Atom):
         """Replace all atoms equivalent to `atom_from` with `atom_to` (in-place)
 
         I.e. this is the preferred way of adapting all atoms of a specific type

--- a/src/sisl/io/siesta/_help.py
+++ b/src/sisl/io/siesta/_help.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 
 import sisl._array as _a
-from sisl import Atoms, AtomUnknown, Geometry, SislError
+from sisl import SislError
 from sisl.messages import warn
 
 try:
@@ -21,7 +21,6 @@ except ImportError:
 __all__ = ["_csr_from_siesta", "_csr_from_sc_off"]
 __all__ += ["_csr_to_siesta", "_csr_to_sc_off"]
 __all__ += ["_mat_spin_convert", "_fc_correct"]
-__all__ += ["_fill_basis_empty", "_replace_basis"]
 
 
 def _ensure_diagonal(csr):
@@ -159,67 +158,6 @@ def _geom2hsx(geometry):
             l.append([-1 for orb in atom])
             zeta.append([1 for orb in atom])
     return (label, Z, no), (n, l, zeta)
-
-
-def _fill_basis_empty(sp: np.ndarray, basis: List[Atom], start_Z=1000) -> Atoms:
-    """Adds atoms in `basis` with ``AtomUnknown(start_Z + species_idx)``
-
-    This is useful when one does not have the required atom in the basis,
-    but one knows that the species are existing.
-
-    Parameters
-    ----------
-    basis:
-        the basis to insert *empty* atoms into
-    sp:
-        the array of species indices
-    start_Z:
-        the offset used in AtomUnknown
-    """
-    # Retrieve the first atom object
-    # This is important to initialize the Atoms object with the
-    # correct species index
-    idx = (sp == 0).nonzero()[0]
-    if len(idx) == 0:
-        atom = AtomUnknown(start_Z)
-    else:
-        atom = basis[idx[0]]
-
-    atoms = Atoms(atom, na=len(sp))
-
-    for isp in range(1, sp.max() + 1):
-        idx = (sp == isp).nonzero()[0]
-        if len(idx) == 0:
-            atoms[idx] = AtomUnknown(start_Z + isp)
-        else:
-            atoms[idx] = basis[idx[0]]
-
-    return atoms
-
-
-def _replace_basis(basis: Atoms, ref_basis: Union[Atoms, Geometry]) -> None:
-    """Replace the `basis` with the atoms in `ref_basis`"""
-    if isinstance(ref_basis, Geometry):
-        ref_basis = ref_basis.atoms
-    only_basis = len(basis) != len(ref_basis)
-
-    # Try and replace stuff
-    # We *must* assume that the species are aligned
-    for (atom_in, in_idx), (atom_ref, ref_idx) in zip(
-        basis.iter(True), ref_basis.iter(True)
-    ):
-        # Check if the indices are the same
-        if len(in_idx) > 0 and (np.allclose(in_idx, ref_idx) or only_basis):
-            if atom_in.Z == atom_ref.Z:
-                # replace
-                basis.replace_atom(atom_in, atom_ref)
-        elif len(in_idx) == 0 and (len(ref_idx) == 0 or only_basis):
-            # replace because it is a missing
-            basis.replace_atom(atom_in, atom_ref)
-        elif not only_basis:
-            warn(
-                f"Trying to replace atom {atom_in!r} with {atom_ref!r}, but they don't share the same atoms in the geometry."
-            )
 
 
 def _fc_correct(fc, trans_inv=True, sum0=True, hermitian=True):

--- a/src/sisl/io/siesta/fdf.py
+++ b/src/sisl/io/siesta/fdf.py
@@ -47,7 +47,6 @@ from ..sile import (
     sile_fh_open,
     sile_raise_write,
 )
-from ._help import _fill_basis_empty
 from .bands import bandsSileSiesta
 from .basis import ionncSileSiesta, ionxmlSileSiesta
 from .binaries import (
@@ -1446,10 +1445,11 @@ class fdfSileSiesta(SileSiesta):
         return None
 
     def _r_geometry_species(self):
-        atoms_species = self.get("AtomicCoordinatesAndAtomicSpecies")
-        if atoms_species:
-            atoms_species = _a.fromiteri(map(lambda x: x.split()[3], atoms_species)) - 1
-        return atoms_species
+        species = self.get("AtomicCoordinatesAndAtomicSpecies", default=[])
+        if species:
+            na = self.get("NumberOfAtoms", default=len(species))
+            species = _a.fromiteri(map(lambda x: x.split()[3], species[:na])) - 1
+        return species
 
     def _r_geometry_xv(self, *args, **kwargs):
         """Returns `Geometry` object from the XV file"""
@@ -1914,9 +1914,9 @@ class fdfSileSiesta(SileSiesta):
             atoms[idx] = Atom(**atom)
 
         # retrieve the atomic species (from the AtomicCoordinatesAndSpecies block)
-        atoms_species = self._r_geometry_species()
-        if len(atoms_species) > 0:
-            return _fill_basis_empty(atoms_species, atoms)
+        species = self._r_geometry_species()
+        if len(species) > 0:
+            return _fill_basis_empty(species, atoms)
 
         warn(
             f"{self!r} does not contain the AtomicCoordinatesAndAtomicSpecies block, basis set definition may not contain all atoms."

--- a/src/sisl/io/siesta/fdf.py
+++ b/src/sisl/io/siesta/fdf.py
@@ -1583,9 +1583,11 @@ class fdfSileSiesta(SileSiesta):
             warn(
                 "Block ChemicalSpeciesLabel does not exist, cannot determine the basis (all will be their species indices)."
             )
+            # the following call will then make use of this object
+            atoms = species
 
         # Default atoms are the species indices... Basically unknown
-        atoms = _fill_basis_empty(species, atoms or species)
+        atoms = _fill_basis_empty(species, atoms)
 
         if isinstance(origin, str):
             opt = origin
@@ -1916,7 +1918,7 @@ class fdfSileSiesta(SileSiesta):
         # retrieve the atomic species (from the AtomicCoordinatesAndSpecies block)
         species = self._r_geometry_species()
         if len(species) > 0:
-            return _fill_basis_empty(species, atoms)
+            return _fill_basis_empty(species, Atoms(atoms))
 
         warn(
             f"{self!r} does not contain the AtomicCoordinatesAndAtomicSpecies block, basis set definition may not contain all atoms."

--- a/src/sisl/io/siesta/fdf.py
+++ b/src/sisl/io/siesta/fdf.py
@@ -47,7 +47,7 @@ from ..sile import (
     sile_fh_open,
     sile_raise_write,
 )
-from ._help import _replace_with_species
+from ._help import _fill_basis_empty
 from .bands import bandsSileSiesta
 from .basis import ionncSileSiesta, ionxmlSileSiesta
 from .binaries import (
@@ -1448,7 +1448,7 @@ class fdfSileSiesta(SileSiesta):
     def _r_geometry_species(self):
         atoms_species = self.get("AtomicCoordinatesAndAtomicSpecies")
         if atoms_species:
-            atoms_species = map(lambda x: int(x.split()[3]) - 1, atoms_species)
+            atoms_species = _a.fromiteri(map(lambda x: x.split()[3], atoms_species)) - 1
         return atoms_species
 
     def _r_geometry_xv(self, *args, **kwargs):
@@ -1458,11 +1458,7 @@ class fdfSileSiesta(SileSiesta):
         _track_file(self._r_geometry_xv, f)
         if f.is_file():
             basis = self.read_basis()
-            if basis is None:
-                geom = xvSileSiesta(f).read_geometry(species_as_Z=False)
-            else:
-                geom = xvSileSiesta(f).read_geometry(species_as_Z=True)
-                _replace_with_species(geom.atoms, basis)
+            geom = xvSileSiesta(f).read_geometry(atoms=basis)
             nsc = self.read_lattice_nsc()
             geom.set_nsc(nsc)
         return geom
@@ -1475,11 +1471,7 @@ class fdfSileSiesta(SileSiesta):
             _track_file(self._r_geometry_struct, f)
             if f.is_file():
                 basis = self.read_basis()
-                if basis is None:
-                    geom = structSileSiesta(f).read_geometry(species_as_Z=False)
-                else:
-                    geom = structSileSiesta(f).read_geometry(species_as_Z=True)
-                    _replace_with_species(geom.atoms, basis)
+                geom = structSileSiesta(f).read_geometry(atoms=basis)
                 nsc = self.read_lattice_nsc()
                 geom.set_nsc(nsc)
                 break
@@ -1589,18 +1581,11 @@ class fdfSileSiesta(SileSiesta):
         atoms = self.read_basis()
         if atoms is None:
             warn(
-                "Block ChemicalSpeciesLabel does not exist, cannot determine the basis (all Hydrogen)."
+                "Block ChemicalSpeciesLabel does not exist, cannot determine the basis (all will be their species indices)."
             )
 
-            # Default atom (hydrogen)
-            atoms = Atom(1)
-
-        # the above reading of basis sets will always
-        # ensure a correct basis set with correct number of atoms.
-        # After all the number of atoms in the basis set is decided
-        # by the AtomicCoordinatesAndAtomicSpecies block (which is found just
-        # above).
-        atoms = Atoms(atoms[:na], na=len(xyz))
+        # Default atoms are the species indices... Basically unknown
+        atoms = _fill_basis_empty(species, atoms or species)
 
         if isinstance(origin, str):
             opt = origin
@@ -1855,7 +1840,7 @@ class fdfSileSiesta(SileSiesta):
             return None
 
         atoms_species = self._r_geometry_species()
-        if atoms_species:
+        if len(atoms_species) > 0:
             return Atoms([atoms[spc] for spc in atoms_species])
         warn(
             f"{self!r} does not contain the AtomicCoordinatesAndAtomicSpecies block, basis set definition may not contain all atoms."
@@ -1930,8 +1915,8 @@ class fdfSileSiesta(SileSiesta):
 
         # retrieve the atomic species (from the AtomicCoordinatesAndSpecies block)
         atoms_species = self._r_geometry_species()
-        if atoms_species:
-            return Atoms([atoms[spc] for spc in atoms_species])
+        if len(atoms_species) > 0:
+            return _fill_basis_empty(atoms_species, atoms)
 
         warn(
             f"{self!r} does not contain the AtomicCoordinatesAndAtomicSpecies block, basis set definition may not contain all atoms."

--- a/src/sisl/io/siesta/struct.py
+++ b/src/sisl/io/siesta/struct.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from sisl import Atom, AtomGhost, Atoms, AtomUnknown, Geometry, Lattice
+from sisl import Atom, AtomGhost, Atoms, Geometry, Lattice
 from sisl._internal import set_module
 from sisl.messages import deprecate_argument
 from sisl.unit.siesta import unit_convert
 
+from .._help import _fill_basis_empty, _replace_basis
 from ..sile import add_sile, sile_fh_open, sile_raise_write
-from ._help import _fill_basis_empty, _replace_basis
 from .sile import SileSiesta
 
 __all__ = ["structSileSiesta"]

--- a/src/sisl/io/siesta/tests/test_fdf.py
+++ b/src/sisl/io/siesta/tests/test_fdf.py
@@ -713,3 +713,31 @@ AtomicCoordinatesFormat Ang
     assert geom.na == 2
     assert np.allclose(geom.atoms.Z, [8, 79])
     assert np.allclose(geom.atoms.species, [1, 0])
+
+    with open(f, "w") as fh:
+        fh.write(
+            """
+%block ChemicalSpeciesLabel
+    1   79  Au
+    2    8   O
+%endblock ChemicalSpeciesLabel
+
+LatticeConstant    1.000 Ang
+%block LatticeVectors
+    4  0  0
+    0  10 0
+    0  0  10
+%endblock LatticeVectors
+AtomicCoordinatesFormat Ang
+%block AtomicCoordinatesAndAtomicSpecies
+    0 0 0  2
+    2 0 0  1
+    0 0 0  2
+%endblock AtomicCoordinatesAndAtomicSpecies
+                """
+        )
+
+    geom = fdfSileSiesta(f).read_geometry()
+    assert geom.na == 3
+    assert np.allclose(geom.atoms.Z, [8, 79, 8])
+    assert np.allclose(geom.atoms.species, [1, 0, 1])

--- a/src/sisl/io/siesta/tests/test_xv.py
+++ b/src/sisl/io/siesta/tests/test_xv.py
@@ -8,7 +8,7 @@ import os.path as osp
 import numpy as np
 import pytest
 
-from sisl import Atom, AtomUnknown, Geometry
+from sisl import Atom, Atoms, AtomUnknown, Geometry
 from sisl.io.siesta.xv import *
 
 pytestmark = [pytest.mark.io, pytest.mark.siesta]
@@ -106,3 +106,54 @@ def test_xv_missing_atoms(sisl_tmp):
     atom = AtomUnknown(1000 + 2)
     assert geom.atoms.atom[2].Z == atom.Z
     assert isinstance(geom.atoms.atom[2], atom.__class__)
+
+
+def test_xv_missing_atoms_end(sisl_tmp):
+    # test for #778
+    f = sisl_tmp("missing_end.XV", _dir)
+    with open(f, "w") as fh:
+        fh.write(
+            """\
+1. 0. 0.  0. 0. 0.
+0. 1. 0.  0. 0. 0.
+0. 0. 2.  0. 0. 0.
+6
+2 6 0. 1. 0.  0. 0. 0.
+1 2 0. 1. 0.  0. 0. 0.
+1 2 0. 1. 0.  0. 0. 0.
+3 3 0. 1. 0.  0. 0. 0.
+3 3 0. 1. 0.  0. 0. 0.
+2 6 0. 1. 0.  0. 0. 0.
+"""
+        )
+    atoms = Atoms([2, 6, 3, 5])
+    geom = xvSileSiesta(f).read_geometry(atoms=atoms)
+    assert len(geom) == 6
+    assert len(geom.atoms.atom) == 4
+    assert np.allclose(geom.atoms.species, [1, 0, 0, 2, 2, 1])
+
+
+def test_xv_missing_atoms_species(sisl_tmp):
+    # test for #778
+    f = sisl_tmp("missing_species.XV", _dir)
+    with open(f, "w") as fh:
+        fh.write(
+            """\
+1. 0. 0.  0. 0. 0.
+0. 1. 0.  0. 0. 0.
+0. 0. 2.  0. 0. 0.
+6
+2 1 0. 1. 0.  0. 0. 0.
+1 1 0. 1. 0.  0. 0. 0.
+1 1 0. 1. 0.  0. 0. 0.
+3 1 0. 1. 0.  0. 0. 0.
+3 1 0. 1. 0.  0. 0. 0.
+2 1 0. 1. 0.  0. 0. 0.
+"""
+        )
+
+    atoms = Atoms([Atom(1, tag=tag) for tag in "ABCD"])
+    geom = xvSileSiesta(f).read_geometry(atoms=atoms)
+    assert len(geom) == 6
+    assert len(geom.atoms.atom) == 4
+    assert np.allclose(geom.atoms.species, [1, 0, 0, 2, 2, 1])

--- a/src/sisl/io/siesta/xv.py
+++ b/src/sisl/io/siesta/xv.py
@@ -11,6 +11,7 @@ from sisl.messages import deprecate_argument
 from sisl.unit.siesta import unit_convert
 
 from ..sile import SileError, add_sile, sile_fh_open, sile_raise_write
+from ._help import _fill_basis_empty, _replace_basis
 from .sile import SileSiesta
 
 __all__ = ["xvSileSiesta"]
@@ -92,22 +93,34 @@ class xvSileSiesta(SileSiesta):
     @deprecate_argument(
         "species_Z",
         "species_as_Z",
-        "use species_as_Z= instead of species_Z=",
+        "species_ arguments (species_Z and species_as_Z) are deprecated in favor of atoms=",
+        "0.15",
+        "0.16",
+    )
+    @deprecate_argument(
+        "species_as_Z",
+        None,
+        "species_as_Z= is deprecated, please pass an Atoms object with the basis information as atoms=",
         "0.15",
         "0.16",
     )
     def read_geometry(
-        self, ret_velocity: bool = False, species_as_Z: bool = False
+        self,
+        ret_velocity: bool = False,
+        atoms: Optional[Atoms, Geometry] = None,
+        species_as_Z: bool = False,
     ) -> Geometry:
         """Returns a `Geometry` object from the XV file
 
         Parameters
         ----------
         ret_velocity :
-           also return the velocities in the file
+            also return the velocities in the file
+        atoms :
+            an object containing the basis information, is useful to overwrite
+            the atoms object contained in the geometry.
         species_as_Z :
-           if ``True`` the atomic numbers are the species indices (useful when
-           reading the ChemicalSpeciesLabel block simultaneously).
+            Deprecated, it does nothing!
 
         Returns
         -------
@@ -129,10 +142,7 @@ class xvSileSiesta(SileSiesta):
             sp[ia] = int(line[0])
             Z = int(line[1])
 
-            if species_as_Z:
-                atms[ia] = Atom(sp[ia])
-            else:
-                atms[ia] = Atom(Z)
+            atms[ia] = Atom(Z)
 
             xyz[ia, :] = line[2:5]
             vel[ia, :] = line[5:8]
@@ -141,19 +151,15 @@ class xvSileSiesta(SileSiesta):
         vel *= Bohr2Ang
 
         # Ensure correct sorting
-        max_s = sp.max()
-        sp -= 1
-        # Ensure we can remove the atom after having aligned them
-        atms2 = Atoms(AtomUnknown(1000), na=na)
-        for i in range(max_s):
-            idx = (sp[:] == i).nonzero()[0]
-            if len(idx) == 0:
-                # Always ensure we have "something" for the unoccupied places
-                atms2[idx] = AtomUnknown(1000 + i)
-            else:
-                atms2[idx] = atms[idx[0]]
+        # This is important when users creates geometries with
+        # basis information for atoms that are not present.
+        # E.g. a graphene flake with a H basis information as the first species
+        atms2 = _fill_basis_empty(sp - 1, atms)
 
-        geom = Geometry(xyz, atms2.reduce(), lattice=lattice)
+        if atoms is not None:
+            _replace_basis(atms2, atoms)
+
+        geom = Geometry(xyz, atms2, lattice=lattice)
         if ret_velocity:
             return geom, vel
         return geom

--- a/src/sisl/io/siesta/xv.py
+++ b/src/sisl/io/siesta/xv.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from sisl import Atom, AtomGhost, Atoms, AtomUnknown, Geometry, Lattice
+from sisl import Atom, AtomGhost, Atoms, Geometry, Lattice
 from sisl._internal import set_module
 from sisl.messages import deprecate_argument
 from sisl.unit.siesta import unit_convert
 
+from .._help import _fill_basis_empty, _replace_basis
 from ..sile import SileError, add_sile, sile_fh_open, sile_raise_write
-from ._help import _fill_basis_empty, _replace_basis
 from .sile import SileSiesta
 
 __all__ = ["xvSileSiesta"]
@@ -154,10 +154,12 @@ class xvSileSiesta(SileSiesta):
         # This is important when users creates geometries with
         # basis information for atoms that are not present.
         # E.g. a graphene flake with a H basis information as the first species
-        atms2 = _fill_basis_empty(sp - 1, atms)
 
         if atoms is not None:
+            atms2 = _fill_basis_empty(sp - 1, atoms)
             _replace_basis(atms2, atoms)
+        else:
+            atms2 = _fill_basis_empty(sp - 1, atms)
 
         geom = Geometry(xyz, atms2, lattice=lattice)
         if ret_velocity:


### PR DESCRIPTION
The different geometries reading mechanisms
where kind-of broken for various constalletations
in the XV+fdf+struct files.

The species_as_Z was basicaly never going to
works since there was no mechanism to counter
it.

Instead the XV and STRUCT siles now handle
basis from the perspective of being passed
an atoms argument, from which it will
fill in stuff based on data.
If the atoms is a *pure* basis object (only
correct species indices).
Then it will replace without checking stuff.
If it has the same length as the geometry
it will check Z and whether indices are
the same. This *can* potentially lead
to errors if there is only 1 atom of each
species, but on the other hand the species
order should then handle the indices correctly.

There was also cases in fdf, XV and STRUCT reads
that could potentially lead to reducing the basis. We should generally try to avoid this since
there may be good reasons for having *empty* basis.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #778 
 - [x] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` [24.2.0] at top-level
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`


Replaces #778