### PR TITLE
Allow dash to be set in bands plots.

### DIFF
--- a/src/sisl/viz/figure/matplotlib.py
+++ b/src/sisl/viz/figure/matplotlib.py
@@ -233,6 +233,13 @@ class MatplotlibFigure(Figure):
     def show(self, *args, **kwargs):
         return self.figure.show(*args, **kwargs)
 
+    def _plotly_dash_to_matplotlib(self, dash: str) -> str:
+        """Converts a plotly line_dash specification to a matplotlib linestyle."""
+        return {
+            "dash": "dashed",
+            "dot": "dotted",
+        }.get(dash, dash)
+
     def draw_line(
         self,
         x,
@@ -256,6 +263,7 @@ class MatplotlibFigure(Figure):
             y,
             color=line.get("color"),
             linewidth=line.get("width", 1),
+            linestyle=self._plotly_dash_to_matplotlib(line.get("dash", "solid")),
             marker=marker_format,
             markersize=marker.get("size"),
             markerfacecolor=marker_color,
@@ -310,6 +318,7 @@ class MatplotlibFigure(Figure):
         # Set the values used for colormapping
         lc.set_array(line.get("color"))
         lc.set_linewidth(line.get("width", 1))
+        lc.set_linestyle(self._plotly_dash_to_matplotlib(line.get("dash", "solid")))
 
         axes = _axes or self._get_subplot_axes(row=row, col=col)
 
@@ -337,6 +346,7 @@ class MatplotlibFigure(Figure):
 
         # Set the values used for colormapping
         lc.set_linewidth(line.get("width", 1))
+        lc.set_linestyle(self._plotly_dash_to_matplotlib(line.get("dash", "solid")))
 
         axes = _axes or self._get_subplot_axes(row=row, col=col)
 

--- a/src/sisl/viz/plots/bands.py
+++ b/src/sisl/viz/plots/bands.py
@@ -29,7 +29,12 @@ def bands_plot(
     E_axis: Literal["x", "y"] = "y",
     bands_range: Optional[Tuple[int, int]] = None,
     spin: Optional[Literal[0, 1]] = None,
-    bands_style: StyleSpec = {"color": "black", "width": 1, "opacity": 1},
+    bands_style: StyleSpec = {
+        "color": "black",
+        "width": 1,
+        "opacity": 1,
+        "dash": "solid",
+    },
     spindown_style: StyleSpec = {"color": "blue", "width": 1},
     colorscale: Optional[str] = None,
     gap: bool = False,

--- a/src/sisl/viz/processors/bands.py
+++ b/src/sisl/viz/processors/bands.py
@@ -128,7 +128,7 @@ def style_bands(
                 )
     else:
         style_arrays = {}
-        for key in ["color", "width", "opacity"]:
+        for key in ["color", "width", "opacity", "dash"]:
             style_arrays[key] = xr.DataArray(bands_style[key])
 
     # Merge the style arrays with the bands dataset and return the styled dataset


### PR DESCRIPTION
This commit also makes line dash work for the matplotlib backend

One can now use the`"dash"` key in `bands_style`, as in all other line style specifications in the viz module:

```python
sisl.get_sile("file.bands").plot(bands_style={"dash": "dot"})
```

![newplot (73)](https://github.com/zerothi/sisl/assets/42074085/893e6ddf-9faf-44c3-972f-7853f092d68d)


