### PR TITLE
Allow tuning matplotlib subplots.

### DIFF
--- a/src/sisl/viz/figure/matplotlib.py
+++ b/src/sisl/viz/figure/matplotlib.py
@@ -84,7 +84,7 @@ class MatplotlibFigure(Figure):
         self.axes.update(self._axes_defaults)
 
     def _init_figure_subplots(self, rows, cols, **kwargs):
-        self.figure, self.axes = plt.subplots(rows, cols)
+        self.figure, self.axes = plt.subplots(rows, cols, **kwargs)
 
         # Normalize the axes array to have two dimensions
         if rows == 1 and cols == 1:


### PR DESCRIPTION
Now subplot kwargs are passed directly to `plt.subplots` in the matplotlib backend, and one can therefore pass things like `gridspec_kw`:

```python
import sisl
p = sisl.geom.graphene().plot(axes="xy")
sisl.viz.subplots(p, p, rows=2, gridspec_kw={"height_ratios": [2, 1]}, backend="matplotlib")
```

![Screenshot from 2024-05-29 22-36-13](https://github.com/zerothi/sisl/assets/42074085/7c6281a8-b123-410c-a707-099cbc41c03f)

