### PR TITLE
Legend grouping in bands plots

### DIFF
--- a/docs/visualization/viz_module/showcase/BandsPlot.ipynb
+++ b/docs/visualization/viz_module/showcase/BandsPlot.ipynb
@@ -153,6 +153,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Individual bands in legend\n",
+    "--------------------------\n",
+    "\n",
+    "Usually, showing all bands individually in the legend would be too messy. However, you might want to do it so that you can interactively hide show certain bands. If that is the case, you can set `group_legend` to `False`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bands_plot.update_inputs(group_legend=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bands_plot = bands_plot.update_inputs(group_legend=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Bands styling\n",
     "\n",
     "If all you want is to change the color and width of the bands, there's one simple solution: use the `bands_style` input to tweak the line styles.\n",
@@ -594,7 +622,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/src/sisl/viz/figure/matplotlib.py
+++ b/src/sisl/viz/figure/matplotlib.py
@@ -248,6 +248,7 @@ class MatplotlibFigure(Figure):
         line={},
         marker={},
         text=None,
+        showlegend=True,
         row=None,
         col=None,
         _axes=None,
@@ -257,6 +258,10 @@ class MatplotlibFigure(Figure):
         marker_color = marker.get("color")
 
         axes = _axes or self._get_subplot_axes(row=row, col=col)
+
+        # Matplotlib doesn't show lines on the legend if their name starts
+        # with an underscore, so prepend the name with "_" if showlegend is False.
+        name = name if showlegend else f"_{name}"
 
         return axes.plot(
             x,
@@ -279,6 +284,7 @@ class MatplotlibFigure(Figure):
         line={},
         marker={},
         text=None,
+        showlegend=True,
         row=None,
         col=None,
         _axes=None,
@@ -288,6 +294,10 @@ class MatplotlibFigure(Figure):
         # https://matplotlib.org/stable/gallery/lines_bars_and_markers/multicolored_line.html
 
         color = line.get("color")
+
+        # Matplotlib doesn't show lines on the legend if their name starts
+        # with an underscore, so prepend the name with "_" if showlegend is False.
+        name = name if showlegend else f"_{name}"
 
         if not np.issubdtype(np.array(color).dtype, np.number):
             return self.draw_multicolor_scatter(
@@ -358,6 +368,7 @@ class MatplotlibFigure(Figure):
         y,
         line={},
         name=None,
+        showlegend=True,
         dependent_axis=None,
         row=None,
         col=None,
@@ -370,6 +381,10 @@ class MatplotlibFigure(Figure):
         spacing = width / 2
 
         axes = _axes or self._get_subplot_axes(row=row, col=col)
+
+        # Matplotlib doesn't show lines on the legend if their name starts
+        # with an underscore, so prepend the name with "_" if showlegend is False.
+        name = name if showlegend else f"_{name}"
 
         if dependent_axis in ("y", None):
             axes.fill_between(
@@ -392,6 +407,7 @@ class MatplotlibFigure(Figure):
         marker={},
         text=None,
         zorder=2,
+        showlegend=True,
         row=None,
         col=None,
         _axes=None,
@@ -399,6 +415,11 @@ class MatplotlibFigure(Figure):
         **kwargs,
     ):
         axes = _axes or self._get_subplot_axes(row=row, col=col)
+
+        # Matplotlib doesn't show lines on the legend if their name starts
+        # with an underscore, so prepend the name with "_" if showlegend is False.
+        name = name if showlegend else f"_{name}"
+
         try:
             return axes.scatter(
                 x,

--- a/src/sisl/viz/figure/plotly.py
+++ b/src/sisl/viz/figure/plotly.py
@@ -643,10 +643,10 @@ class PlotlyFigure(Figure):
                 size=sp_size,
                 color=sp_color,
                 opacity=sp_opacity,
-                name=f"{name}_{i}",
+                name=name,
                 legendgroup=name,
                 showlegend=showlegend,
-                meta=meta,
+                meta={**meta, f"{name}_i": i},
             )
             showlegend = False
 

--- a/src/sisl/viz/plots/pdos.py
+++ b/src/sisl/viz/plots/pdos.py
@@ -84,6 +84,7 @@ def pdos_plot(
         x=x,
         y=y,
         width="size",
+        name="group",
         what=line_mode,
         dependent_axis=dependent_axis,
     )

--- a/src/sisl/viz/processors/bands.py
+++ b/src/sisl/viz/processors/bands.py
@@ -77,20 +77,25 @@ def style_bands(
     bands_data: xr.Dataset,
     bands_style: dict = {"color": "black", "width": 1},
     spindown_style: dict = {"color": "blue", "width": 1},
+    group_legend: bool = True,
 ) -> xr.Dataset:
     """Returns the bands dataset, with the style information added to it.
 
     Parameters
     ------------
-    bands_data: xr.Dataset
+    bands_data:
         The dataset containing bands energy information.
-    bands_style: dict
+    bands_style:
         Dictionary containing the style information for the bands.
-    spindown_style: dict
+    spindown_style:
         Dictionary containing the style information for the spindown bands.
         Any style that is not present in this dictionary will be taken from
         the "bands_style" dictionary.
+    group_legend:
+        Whether the bands will be grouped in the legend. This will determine
+        how the names of each band are set
     """
+
     # If the user provided a styler function, apply it.
     if bands_style.get("styler") is not None:
         if callable(bands_style["styler"]):
@@ -112,7 +117,7 @@ def style_bands(
     if "spin" in bands_data.dims:
         spindown_style = {**bands_style, **spindown_style}
         style_arrays = {}
-        for key in ["color", "width", "opacity"]:
+        for key in ["color", "width", "opacity", "dash"]:
             if isinstance(bands_style[key], xr.DataArray):
                 if not isinstance(spindown_style[key], xr.DataArray):
                     down_style = bands_style[key].copy(deep=True)
@@ -126,10 +131,36 @@ def style_bands(
                 style_arrays[key] = xr.DataArray(
                     [bands_style[key], spindown_style[key]], dims=["spin"]
                 )
+
+        # Determine the names of the bands
+        if group_legend:
+            style_arrays["line_name"] = xr.DataArray(
+                ["Spin up Bands", "Spin down Bands"], dims=["spin"]
+            )
+        else:
+            names = []
+            for s in bands_data.spin:
+                spin_string = "UP" if s == 0 else "DOWN"
+                for iband in bands_data.band.values:
+                    names.append(f"{spin_string}_{iband}")
+
+            style_arrays["line_name"] = xr.DataArray(
+                np.array(names).reshape(2, -1),
+                coords=[
+                    ("spin", bands_data.spin.values),
+                    ("band", bands_data.band.values),
+                ],
+            )
     else:
         style_arrays = {}
         for key in ["color", "width", "opacity", "dash"]:
             style_arrays[key] = xr.DataArray(bands_style[key])
+
+        # Determine the names of the bands
+        if group_legend:
+            style_arrays["line_name"] = xr.DataArray("Bands")
+        else:
+            style_arrays["line_name"] = bands_data.band
 
     # Merge the style arrays with the bands dataset and return the styled dataset
     return bands_data.assign(style_arrays)

--- a/src/sisl/viz/processors/xarray.py
+++ b/src/sisl/viz/processors/xarray.py
@@ -12,9 +12,6 @@ import numpy as np
 import xarray as xr
 from xarray import DataArray, Dataset
 
-from sisl import Geometry
-from sisl.messages import SislError
-
 
 class XarrayData:
     @singledispatchmethod


### PR DESCRIPTION
This PR solves two problems:

- Legend grouping of fatbands in matplotlib. Since the "fatband" of each band is drawn as a separate line, the matplotlib backend used to show multiple legend items. Now this is solved by only showing one item:

- The bands where shown individually on the legend, which often made for a very useless legend. Now all bands are shown as one item in the legend by default. This can be tuned with the `group_legend` (in bands plots) and `bands_group_legend` (in fatbands plots) arguments.


```python
import sisl

# First, we create the geometry
BN = sisl.geom.graphene(atoms=["B", "N"])

# Create a hamiltonian with different on-site terms
H = sisl.Hamiltonian(BN)

H[0, 0] = 2
H[1, 1] = -2

H[0, 1] = -2.7
H[1, 0] = -2.7

H[0, 1, (-1, 0)] = -2.7
H[0, 1, (0, -1)] = -2.7
H[1, 0, (1, 0)] = -2.7
H[1, 0, (0, 1)] = -2.7

band = sisl.BandStructure(
    H,
    [[0.0, 0.0], [2.0 / 3, 1.0 / 3], [1.0 / 2, 1.0 / 2], [1.0, 1.0]],
    301,
    [r"Gamma", "K", "M", r"Gamma"],
)

fatbands = band.plot.fatbands(backend="matplotlib")
fatbands.split_groups(name="$species")
fatbands.axes.legend()
```

![Screenshot from 2024-06-05 01-18-31](https://github.com/zerothi/sisl/assets/42074085/df6859b4-cb47-489d-94be-79d9a2e84e93)

Reverting legend grouping for bands:

```python
fatbands.update_inputs(bands_group_legend=False).legend()
```

![Screenshot from 2024-06-05 01-23-49](https://github.com/zerothi/sisl/assets/42074085/5d762464-8795-45f4-9836-99a31aa99422)


