### PR TITLE
trying to remove numpy 2 (as a temporary work-around)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ keywords = [
 
 dependencies = [
     # TODO work-arounds for windows installations
-    "numpy>=1.20 ; sys_platform == 'win32' and python_version <= '3.9'",
-    "numpy>=1.21.5 ; sys_platform == 'win32' and python_version >= '3.10'",
-    "numpy>=1.20 ; sys_platform != 'win32'",
+    "numpy>=1.20,<2 ; sys_platform == 'win32' and python_version <= '3.9'",
+    "numpy>=1.21.5,<2 ; sys_platform == 'win32' and python_version >= '3.10'",
+    "numpy>=1.20,<2 ; sys_platform != 'win32'",
     "scipy>=1.5",
     # I can't get it to work on py311 with older versions
     "pyparsing>=2.2.1",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
This is a temporary work-around until we build against numpy 2