### PR TITLE
Clarify out of memory error on density

### DIFF
--- a/src/sisl/physics/densitymatrix.py
+++ b/src/sisl/physics/densitymatrix.py
@@ -814,12 +814,19 @@ class _densitymatrix(SparseOrbitalBZSpin):
             csrDM = csr.tocsr(dim=0)
 
         if method == "pre-compute":
-            # Compute orbital values on the grid
-            psi_values = uc_dm.geometry._orbital_values(grid.shape)
+            try:
+                # Compute orbital values on the grid
+                psi_values = uc_dm.geometry._orbital_values(grid.shape)
 
-            psi_values.reduce_orbital_products(
-                csrDM, uc_dm.lattice, out=grid.grid, **kwargs
-            )
+                psi_values.reduce_orbital_products(
+                    csrDM, uc_dm.lattice, out=grid.grid, **kwargs
+                )
+            except MemoryError:
+                raise MemoryError(
+                    "Ran out of memory while computing the density with the 'pre-compute'"
+                    " method. Try using method='direct', which is slower but requires much"
+                    " less memory."
+                )
         elif method == "direct":
             self._density_direct(grid, csrDM, atol=atol, eta=eta)
 


### PR DESCRIPTION
I have been testing the limits and for 10000 orbitals numpy needs to allocate 23GiB, which is too much for my RAM, and it fails.

It then throws a `numpy.core._exceptions._ArrayMemoryError`, which a user might not understand how to solve. Here we raise a clearer error for the user that is trying to compute the density.

It takes veeery long to compute such a system with the direct method, but at least it can be computed.
