### PR TITLE
766 shc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ we hit release version 1.0.0.
 ## [0.15.0] - YYYY-MM-DD
 
 ### Added
+- `axes` argument added to `derivative` to only calculate on a subset
+  of directions (can greatly improve performance for some systems)
+- `operator` argument added to `derivative` to apply an operator
+  to `dHk` and `dSk` matrices.
+  of directions (can greatly improve performance for some systems)
 - added `apply_kwargs` to methods which uses a `BrillouinZone` object.
   This enables one to leverage parallel processing for calculations.
 - `SISL_PAR_CHUNKSIZE=25`, new default parameter for parallel processing.
@@ -104,6 +109,8 @@ we hit release version 1.0.0.
 - removed `Selector` and `TimeSelector`, they were never used internally
 
 ### Changed
+- `conductivity` is deprecated, use `ahc` and `shc` instead
+- `berry_curvature` has completely changed, checks it API
 - BZ apply methods are now by default parallel (if ``SISL_NUM_PROCS>1``)
 - `hsxSileSiesta.read_hamiltonian` now implicitly shifts Fermi-level to 0 (for newer HSX versions)
 - deprecated `periodic` to `axes` argument in `BrillouinZone.volume`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ we hit release version 1.0.0.
 - removed `Selector` and `TimeSelector`, they were never used internally
 
 ### Changed
+- units of `conductivity` has changed to S / Ang
 - `conductivity` is deprecated, use `ahc` and `shc` instead
 - `berry_curvature` has completely changed, checks it API
 - BZ apply methods are now by default parallel (if ``SISL_NUM_PROCS>1``)

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -20,6 +20,7 @@ sisl objects.
    add
    append
    apply
+   berry_curvature
    center
    copy
    insert
@@ -29,11 +30,13 @@ sisl objects.
    rotate
    scale
    sort
+   spin_berry_curvature
    sub
    swap
    swapaxes
    tile
    translate
+   velocity
    unrepeat
    untile
    write

--- a/docs/api/physics.electron.rst
+++ b/docs/api/physics.electron.rst
@@ -21,6 +21,8 @@ One may also plot real-space wavefunctions.
    COP
    berry_phase
    berry_curvature
+   ahc
+   shc
    conductivity
    wavefunction
    spin_moment

--- a/docs/api/typing.rst
+++ b/docs/api/typing.rst
@@ -13,7 +13,9 @@ The typing types are shown below:
 .. autosummary::
    :toctree: generated/
 
+   CellAxisStrLiteral
    CellAxisLiteral
+   CartesianAxisStrLiteral
    CartesianAxisLiteral
    CellAxis
    CellAxes

--- a/docs/math.rst
+++ b/docs/math.rst
@@ -40,3 +40,6 @@ please let us know!
   is an atomic index range and :math:`\{\alpha\}` refers
   to some *other* range which should be inferred from
   the context
+
+* the imaginary number is generally referred to as :math:`i` in
+  physics, its meaning should be implicit from the context.

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,5 +1,34 @@
 %comment{This file was created with betterbib v4.3.11.}
 
+@article{PhysRevB.98.214402,
+  title = {Calculation of intrinsic spin Hall conductivity by Wannier interpolation},
+  author = {Qiao, Junfeng and Zhou, Jiaqi and Yuan, Zhe and Zhao, Weisheng},
+  journal = {Phys. Rev. B},
+  volume = {98},
+  issue = {21},
+  pages = {214402},
+  numpages = {10},
+  year = {2018},
+  month = {Dec},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevB.98.214402},
+  url = {https://link.aps.org/doi/10.1103/PhysRevB.98.214402}
+}
+
+@article{Ji2022,
+  title = {Spin Hall conductivity and anomalous Hall conductivity in full Heusler compounds},
+  volume = {24},
+  ISSN = {1367-2630},
+  url = {http://dx.doi.org/10.1088/1367-2630/ac696c},
+  DOI = {10.1088/1367-2630/ac696c},
+  number = {5},
+  journal = {New Journal of Physics},
+  publisher = {IOP Publishing},
+  author = {Ji,  Yimin and Zhang,  Wenxu and Zhang,  Hongbin and Zhang,  Wanli},
+  year = {2022},
+  month = may,
+  pages = {053027}
+}
 
 @article{Sengupta2023,
   author    = {Sengupta, Sanghita and Frederiksen, Thomas and Giedke, Geza},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,5 +1,14 @@
 %comment{This file was created with betterbib v4.3.11.}
 
+@article{gan2021calculation,
+      title={Calculation of Berry curvature using nonorthogonal atomic orbitals},
+      author={Jin Gan and Daye Zheng and Lixin He},
+      year={2021},
+      eprint={2105.14662},
+      archivePrefix={arXiv},
+      primaryClass={id='cond-mat.mtrl-sci' full_name='Materials Science' is_active=True alt_name='mtrl-th' in_archive='cond-mat' is_general=False description='Techniques, synthesis, characterization, structure.  Structural phase transitions, mechanical properties, phonons. Defects, adsorbates, interfaces'}
+}
+
 @article{PhysRevB.98.214402,
   title = {Calculation of intrinsic spin Hall conductivity by Wannier interpolation},
   author = {Qiao, Junfeng and Zhou, Jiaqi and Yuan, Zhe and Zhao, Weisheng},

--- a/src/sisl/physics/__init__.py
+++ b/src/sisl/physics/__init__.py
@@ -133,6 +133,7 @@ from ._brillouinzone_apply import *
 from ._ufuncs_brillouinzone import *
 from ._ufuncs_densitymatrix import *
 from ._ufuncs_dynamicalmatrix import *
+from ._ufuncs_electron import *
 from ._ufuncs_energydensitymatrix import *
 from ._ufuncs_hamiltonian import *
 from ._ufuncs_overlap import *

--- a/src/sisl/physics/_ufuncs_electron.py
+++ b/src/sisl/physics/_ufuncs_electron.py
@@ -1,0 +1,322 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
+from typing import Optional, Tuple, Union
+
+import numpy as np
+
+import sisl._array as _a
+from sisl._ufuncs import register_sisl_dispatch
+from sisl.typing import SeqOrScalarFloat, npt
+
+from .distribution import get_distribution
+from .electron import StateCElectron, _create_sigma, _velocity_const
+from .state import _dM_Operator
+
+# Nothing gets exposed here
+__all__ = []
+
+
+@register_sisl_dispatch(StateCElectron, module="sisl.physics.electron")
+def velocity(state: StateCElectron, *args, **kwargs):
+    r"""Calculate velocity for the states
+
+    This routine calls ``derivative(1, *args, **kwargs)`` and returns the velocity for the states.
+
+    Note that the coefficients associated with the `StateCElectron` *must* correspond
+    to the energies of the states.
+
+    The unit is Ang/ps.
+
+    Notes
+    -----
+    The states and energies for the states *may* have changed after calling this routine.
+    This is because of the velocity un-folding for degenerate modes. I.e. calling
+    `PDOS` after this method *may* change the result.
+
+    The velocities are calculated without the Berry curvature contribution see Eq. (2) in :cite:`Wang2006`.
+    It is thus typically denoted as the *effective velocity operater* (see Ref. 21 in :cite:`Wang2006`.
+    The missing contribution may be added in later editions, for completeness sake, it is:
+
+    .. math::
+       \delta \mathbf v = - \mathbf k\times \Omega_i(\mathbf k)
+
+    where :math:`\Omega_i` is the Berry curvature for state :math:`i`.
+
+
+    See Also
+    --------
+    derivative : for details of the implementation
+    """
+    v = state.derivative(1, *args, **kwargs)
+    v *= _velocity_const
+    return v
+
+
+@register_sisl_dispatch(StateCElectron, module="sisl.physics.electron")
+def berry_curvature(
+    state: StateCElectron,
+    distribution: Optional = None,
+    sum: bool = True,
+    *,
+    derivative_kwargs: dict = {},
+    operator: Union[_dM_Operator, Tuple[_dM_Operator, _dM_Operator]] = lambda M, d: M,
+    eta: float = 0.0,
+) -> np.ndarray:
+    r"""Calculate the Berry curvature matrix for a set of states (using Kubo)
+
+    The Berry curvature is calculated using the following expression
+    (:math:`\alpha`, :math:`\beta` corresponding to Cartesian directions):
+
+    .. math::
+
+       \boldsymbol\Omega_{\alpha\beta,i} = - 2hbar^2\Im\sum_{j\neq i}
+                \frac{v^{\alpha}_{ij} v^\beta_{ji}}
+                     {[\epsilon_i - \epsilon_j]^2 + i\eta^2}
+
+    For details on the Berry curvature, see Eq. (11) in :cite:`Wang2006`
+    or Eq. (2.59) in :cite:`TopInvCourse`.
+
+    The `operator` argument can be used to define the Berry curvature in other
+    quantities. E.g. the spin Berry curvature is defined by replacing :math:`v^\alpha`
+    by the spin current operator. see `spin_berry_curvature` for details.
+
+    For additional details on the spin Berry curvature, see Eq. (1) in
+    :cite:`PhysRevB.98.21402` and Eq. (2) in :cite:`Ji2022`.
+
+    Parameters
+    ----------
+    state :
+        the state describing the electronic states we wish to calculate the Berry curvature
+        of.
+    distribution:
+        An optional distribution enabling one to automatically sum states
+        across occupied/unoccupied states.
+    sum:
+        only return the summed Berry curvature (over all states).
+    derivative_kwargs:
+        arguments passed to `derivative`. Since `operator` is defined here,
+        one cannot have `operator` in `derivative_kwargs`.
+    operator:
+        the operator to use for changing the `dPk` matrices.
+        Note, that this may change the resulting units, and it will be up
+        to the user to adapt the units accordingly. The returned units are
+        by default :math:`\mathrm{Ang}^2`.
+    eta:
+        direct imaginary part broadening of the Lorentzian.
+
+    See Also
+    --------
+    derivative: method for calculating the exact derivatives
+
+    Returns
+    -------
+    numpy.ndarray
+        Berry flux with final dimension ``(3, 3, state.shape[0])``
+    """
+    # cast dtypes to *any* complex valued data-type that can be expressed
+    # minimally by a complex64 object
+
+    if isinstance(operator, (tuple, list)):
+        opA = operator[0]
+        opB = operator[1]
+    else:
+        opA = operator
+        opB = operator
+
+    if opA is opB:
+
+        # same operator
+        dA = dB = state.derivative(
+            order=1, operator=opA, matrix=True, **derivative_kwargs
+        )
+
+    else:
+        # different operators
+        dA = state.derivative(order=1, operator=opA, matrix=True, **derivative_kwargs)
+        dB = state.derivative(order=1, operator=opB, matrix=True, **derivative_kwargs)
+
+    if distribution is None:
+        distribution = get_distribution("step")
+
+    ieta2 = 1j * eta**2
+    energy = state.c
+
+    # when calculating the distribution, one should always
+    # find the energy dimension along the last axis, so x0
+    # must have a shape (-1, 1) to allow b-casting!
+    # Hence the last dimension of distribution(energy) corresponds
+    # to the states.
+    # Hence we transpose it for direct usage below.
+    dist_e = distribution(energy).T
+
+    if sum:
+        dsigma_shape = (len(dA), len(dB)) + (1,) * (dist_e.ndim - 1)
+
+        # then it will be: [3, 3[, dist.shape]]
+        shape = np.broadcast_shapes(dist_e.shape[1:], dsigma_shape)
+        sigma = np.zeros(shape, dtype=dA.real.dtype)
+
+        for si, ei in enumerate(energy):
+            de = (energy - ei) ** 2 + ieta2
+            np.divide(-2, de, where=(de != 0), out=de)
+            dd = dist_e - dist_e[si]
+
+            for iA in range(len(dA)):
+                for iB in range(len(dB)):
+                    dsigma = (de * dA[iA, si] * dB[iB, :, si]).imag
+
+                    sigma[iA, iB] += dsigma @ dd
+
+    else:
+        dsigma_shape = (len(dA), len(dB)) + (1,) * dist_e.ndim
+
+        # then it will be: [3, 3, nstates[, dist.shape]]
+        shape = np.broadcast_shapes(dist_e.shape, dsigma_shape)
+        sigma = np.zeros(shape, dtype=dA.real.dtype)
+
+        for si, ei in enumerate(energy):
+            de = (energy - ei) ** 2 + ieta2
+            np.divide(-2, de, where=(de != 0), out=de)
+            dd = dist_e - dist_e[si]
+
+            for iA in range(len(dA)):
+                for iB in range(len(dB)):
+                    dsigma = (de * dA[iA, si] * dB[iB, :, si]).imag
+
+                    sigma[iA, iB, si] += dsigma @ dd
+
+    # When the operators are the simple velocity operators, then
+    # we don't need to do anything for the units.
+    # The velocity operator is 1/hbar \hat v
+    # and the pre-factor of hbar ^2 means they cancel out.
+    """
+    Original implementation would be something like:
+            eig = es.eig
+            dx, dy, _ = es.derivative(1, matrix=True, degenerate=None)
+            f_nm = np.zeros_like(E)
+            for i in range(len(dx)):
+                f_nm += (
+                    np.imag(dx[:, i] * dy[i])
+                    / ((eig - eig[i]) ** 2 + gamma**2)
+                    * (
+                        fd(eig[i], x0=E).reshape(-1, 1)
+                        - fd(eig.reshape(1, -1), x0=E.reshape(-1, 1))
+                    )
+                ).real.sum(1)
+
+            return f_nm
+    """
+    return sigma
+
+
+@register_sisl_dispatch(StateCElectron, module="sisl.physics.electron")
+def spin_berry_curvature(
+    state: StateCElectron,
+    J_axis: CartesianAxisStrLiteral = "y",
+    spin_axis: CartesianAxisStrLiteral = "z",
+    distribution: Optional = None,
+    sum: bool = True,
+    *,
+    derivative_kwargs: dict = {},
+    eta: float = 0.0,
+) -> np.ndarray:
+    """Calculate the spin Berry curvature
+
+    This is equivalent to calling `berry_curvature`
+    with the spin current operator and the regular velocity
+    operator instead of :math:`v^\alpha`:
+
+    .. code-block:: python
+
+        def noop(M, d): return M
+        def Jz(M, d):
+            if d == "y":
+                return (M @ sigma_z + sigma_z @ M) * 0.5
+            return M
+
+        state.berry_curvature(..., operator=(Jz, noop))
+
+    I.e. the *left* velocity operator being swapped with the
+    spin current operator:
+
+    .. math::
+
+        J^{\gamma\alpha} = \frac12 \{ v^\alpha, \sigma^\gamma \}
+
+    where :math:`\{\}` means the anticommutator.
+
+    When calling it like this the spin berry curvature is found in the
+    first index corresponding to axis the spin operator is acting on.
+
+    E.g. if ``J_axis = 'y', spin_axis = 'z'``, then ``shc[1, 0]`` will be the
+    spin Berry curvature using the Pauli matrix :math:`\sigma^z`,
+    and ``shc[0, 1]`` will be the *normal* Berry curvature (since only
+    the left velocity operator will be changed.
+
+    Notes
+    -----
+    For performance reasons, it can be very benificial to extract the
+    above methods and call `berry_curvature` directly.
+    This is because ``sigma`` gets created on every call of this method.
+
+    This, repeated matrix creation,
+    might change in the future with `BrillouinZone` contexts.
+
+    Parameters
+    ----------
+    J_axis:
+        the direction where the :math:`J` operator will be applied.
+    spin_axis:
+        the direction of the Pauli matrix.
+    **kwargs:
+        see `berry_curvature` for the remaining arguments.
+
+    See Also
+    --------
+    berry_curvature : the called routine
+    """
+    parent = state.parent
+    spin = parent.spin
+
+    # A spin-berry-curvature requires the objects parent
+    # to have a spin associated
+    if spin.is_diagonal:
+        raise ValueError(
+            f"spin_berry_curvature requires 'state' to be a non-colinear matrix."
+        )
+
+    dtype = np.result_type(state.dtype, state.info.get("dtype", np.complex128))
+
+    m = _create_sigma(H.no, spin_axis, dtype, eigenstate_kwargs.get("format", "csr"))
+
+    def J(M, d):
+        nonlocal m, J_axis
+        if d == J_axis:
+            return M @ m + m @ M
+        return M
+
+    def noop(M, d):
+        return M
+
+    bc = berry_curvature(
+        state,
+        distribution,
+        sum,
+        derivative_kwargs=derivative_kwargs,
+        operator=(J, noop),
+        eta=eta,
+    )
+
+    # For the spin Berry curvature, there is a single unit-shift for the elements
+    # corresponding to the velocity operator.
+
+    # idx = "xyz".index(J_axis)
+
+    # a factor of \hbar / 2 for the spin operator means we need this:
+    # conv = constant.hbar("eV s") / 2
+    # bc[idx] *= conv
+
+    return bc

--- a/src/sisl/physics/_ufuncs_electron.py
+++ b/src/sisl/physics/_ufuncs_electron.py
@@ -219,7 +219,7 @@ def berry_curvature(
 @register_sisl_dispatch(StateCElectron, module="sisl.physics.electron")
 def spin_berry_curvature(
     state: StateCElectron,
-    sigma: CartesianAxisStrLiteral = "z",
+    sigma: Union[CartesianAxisStrLiteral, npt.ArrayLike] = "z",
     distribution: _TDist = "step",
     sum: bool = True,
     *,
@@ -274,7 +274,8 @@ def spin_berry_curvature(
     Parameters
     ----------
     sigma:
-        which Pauli matrix is used.
+        which Pauli matrix is used, alternatively one can pass a custom spin matrix,
+        or the full sigma.
     J_axes:
         the direction(s) where the :math:`J^\sigma` operator will be applied, defaults
         to all.

--- a/src/sisl/physics/_ufuncs_electron.py
+++ b/src/sisl/physics/_ufuncs_electron.py
@@ -290,7 +290,7 @@ def spin_berry_curvature(
 
     dtype = np.result_type(state.dtype, state.info.get("dtype", np.complex128))
 
-    m = _create_sigma(H.no, spin_axis, dtype, eigenstate_kwargs.get("format", "csr"))
+    m = _create_sigma(parent.no, spin_axis, dtype, state.info.get("format", "csr"))
 
     def J(M, d):
         nonlocal m, J_axis

--- a/src/sisl/physics/_ufuncs_state.py
+++ b/src/sisl/physics/_ufuncs_state.py
@@ -3,13 +3,13 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Tuple, Union
 
 import numpy as np
 
 import sisl._array as _a
 from sisl._ufuncs import register_sisl_dispatch
-from sisl.typing import SimpleIndex
+from sisl.typing import SeqOrScalarFloat, SimpleIndex, npt
 
 from .state import Coefficient, State, StateC
 

--- a/src/sisl/physics/electron.py
+++ b/src/sisl/physics/electron.py
@@ -74,7 +74,6 @@ import sisl._array as _a
 from sisl import BoundaryCondition as BC
 from sisl import Geometry, Grid, Lattice, constant, units
 from sisl._core.oplist import oplist
-from sisl._help import dtype_real_to_complex
 from sisl._indices import indices_le
 from sisl._internal import set_module
 from sisl._math_small import xyz_to_spherical_cos_phi

--- a/src/sisl/physics/electron.py
+++ b/src/sisl/physics/electron.py
@@ -1,12 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-from __future__ import annotations
-
-from typing import Literal, Optional
-
-from sisl.messages import deprecate_argument
-
 r"""Electron related functions and classes
 ==========================================
 
@@ -22,8 +16,8 @@ One may also plot real-space wavefunctions.
    PDOS
    COP
    berry_phase
-   berry_curvature
-   conductivity
+   ahc
+   shc
    wavefunction
    spin_moment
    spin_contamination
@@ -48,10 +42,13 @@ automatically passes the correct ``S`` because it knows the states :math:`\mathb
    EigenstateElectron
 
 """
+from __future__ import annotations
 
 from functools import reduce
+from typing import Literal, Optional
 
 import numpy as np
+import scipy.sparse as scs
 from numpy import (
     add,
     ceil,
@@ -77,14 +74,23 @@ import sisl._array as _a
 from sisl import BoundaryCondition as BC
 from sisl import Geometry, Grid, Lattice, constant, units
 from sisl._core.oplist import oplist
-from sisl._help import dtype_complex_to_real, dtype_real_to_complex
+from sisl._help import dtype_real_to_complex
 from sisl._indices import indices_le
 from sisl._internal import set_module
 from sisl._math_small import xyz_to_spherical_cos_phi
 from sisl.linalg import det
 from sisl.linalg import eigvals as la_eigvals
 from sisl.linalg import sqrth, svd_destroy
-from sisl.messages import SislError, info, progressbar, warn
+from sisl.messages import (
+    SislError,
+    deprecate_argument,
+    deprecation,
+    info,
+    progressbar,
+    warn,
+)
+from sisl.typing import CartesianAxisStrLiteral
+from sisl.utils.misc import direction
 
 from .distribution import get_distribution
 from .sparse import SparseOrbitalBZSpin
@@ -94,7 +100,7 @@ from .state import Coefficient, State, StateC, _FakeMatrix, degenerate_decouple
 __all__ = ["DOS", "PDOS", "COP"]
 __all__ += ["spin_moment", "spin_contamination"]
 __all__ += ["berry_phase", "berry_curvature"]
-__all__ += ["conductivity"]
+__all__ += ["ahc", "shc", "conductivity"]
 __all__ += ["wavefunction"]
 __all__ += ["CoefficientElectron", "StateElectron", "StateCElectron"]
 __all__ += ["EigenvalueElectron", "EigenvectorElectron", "EigenstateElectron"]
@@ -240,9 +246,7 @@ def PDOS(E, eig, state, S=None, distribution="gaussian", spin=None):
             S = S[::2, ::2]
 
         # Initialize data
-        PDOS = empty(
-            [4, state.shape[1] // 2, len(E)], dtype=dtype_complex_to_real(state.dtype)
-        )
+        PDOS = empty([4, state.shape[1] // 2, len(E)], dtype=state.real.dtype)
 
         # Do spin-box calculations:
         #  PDOS[0] = total DOS (diagonal)
@@ -356,7 +360,7 @@ def COP(E, eig, state, M, distribution="gaussian", atol: float = 1e-10):
     ), "COP: number of eigenvalues and states are not consistent"
 
     # get default dtype
-    dtype = dtype_complex_to_real(state.dtype)
+    dtype = state.real.dtype
 
     # initialize the COP values
     no = M.shape[0]
@@ -495,7 +499,7 @@ def spin_moment(state, S=None, project: bool = False):
     if project:
         s = empty(
             [3, state.shape[0], state.shape[1] // 2],
-            dtype=dtype_complex_to_real(state.dtype),
+            dtype=state.real.dtype,
         )
 
         for i in range(len(state)):
@@ -509,7 +513,7 @@ def spin_moment(state, S=None, project: bool = False):
             s[1, i] = D2.imag - D1.imag
 
     else:
-        s = empty([3, state.shape[0]], dtype=dtype_complex_to_real(state.dtype))
+        s = empty([3, state.shape[0]], dtype=state.real.dtype)
 
         # TODO consider doing this all in a few lines
         # TODO Since there are no energy dependencies here we can actually do all
@@ -603,7 +607,7 @@ def spin_contamination(state_alpha, state_beta, S=None, sum: bool = True):
 
     else:
 
-        Sa = empty([n_alpha], dtype=dtype_complex_to_real(state_alpha.dtype))
+        Sa = empty([n_alpha], dtype=state_alpha.real.dtype)
         Sb = zeros([n_beta], dtype=Sa.dtype)
 
         # Loop alpha...
@@ -621,190 +625,11 @@ def spin_contamination(state_alpha, state_beta, S=None, sum: bool = True):
 _velocity_const = 1 / constant.hbar("eV ps")
 
 
-def _velocity_matrix_non_ortho(
-    state, dHk, energy, dSk, degenerate, degenerate_dir, dtype
-):
-    r"""For states in a non-orthogonal basis"""
-
-    # All matrix elements along the 3 directions
-    n = state.shape[0]
-    v = empty([3, n, n], dtype=dtype)
-
-    # Decouple the degenerate states
-    if not degenerate is None:
-        degenerate_dir = _a.asarrayd(degenerate_dir)
-        degenerate_dir /= (degenerate_dir**2).sum() ** 0.5
-        deg_dHk = sum(d * dh for d, dh in zip(degenerate_dir, dHk))
-        for deg in degenerate:
-            # Set the average energy
-            e = np.average(energy[deg])
-            energy[deg] = e
-
-            # Now diagonalize to find the contributions from individual states
-            # then re-construct the seperated degenerate states
-            # Since we do this for all directions we should decouple them all
-            state[deg] = degenerate_decouple(
-                state[deg],
-                deg_dHk - sum(d * e * ds for d, ds in zip(degenerate_dir, dSk)),
-            )
-        del deg_dHk
-
-    # Since they depend on the state energies and dSk we have to loop them individually.
-    cs = conj(state)
-    for s, e in enumerate(energy):
-        # Since dHk *may* be a csr_matrix or sparse, we have to do it like
-        # this. A sparse matrix cannot be re-shaped with an extra dimension.
-        v[0, s] = cs @ (dHk[0] - e * dSk[0]) @ state[s]
-        v[1, s] = cs @ (dHk[1] - e * dSk[1]) @ state[s]
-        v[2, s] = cs @ (dHk[2] - e * dSk[2]) @ state[s]
-
-    v *= _velocity_const
-    return v
-
-
-def _velocity_matrix_ortho(state, dHk, degenerate, degenerate_dir, dtype):
-    r"""For states in an orthogonal basis"""
-
-    # All matrix elements along the 3 directions
-    n = state.shape[0]
-    v = empty([3, n, n], dtype=dtype)
-
-    # Decouple the degenerate states
-    if not degenerate is None:
-        degenerate_dir = _a.asarrayd(degenerate_dir)
-        degenerate_dir /= (degenerate_dir**2).sum() ** 0.5
-        deg_dHk = sum(d * dh for d, dh in zip(degenerate_dir, dHk))
-        for deg in degenerate:
-            # Now diagonalize to find the contributions from individual states
-            # then re-construct the seperated degenerate states
-            # Since we do this for all directions we should decouple them all
-            state[deg] = degenerate_decouple(state[deg], deg_dHk)
-        del deg_dHk
-
-    cs = conj(state)
-    for s in range(n):
-        v[0, s] = cs @ dHk[0] @ state[s]
-        v[1, s] = cs @ dHk[1] @ state[s]
-        v[2, s] = cs @ dHk[2] @ state[s]
-
-    v *= _velocity_const
-    return v
-
-
 @set_module("sisl.physics.electron")
-def berry_curvature(
-    state, energy, dHk, dSk=None, degenerate=None, degenerate_dir=(1, 1, 1)
-):
-    r"""Calculate the Berry curvature matrix for a set of states (using Kubo)
-
-    The Berry curvature is calculated using the following expression
-    (:math:`\alpha`, :math:`\beta` corresponding to Cartesian directions):
-
-    .. math::
-
-       \boldsymbol\Omega_{\alpha\beta,i} = - \frac2{\hbar^2}\Im\sum_{j\neq i}
-                \frac{v^\alpha_{ij} v^\beta_{ji}}
-                     {[\epsilon_j - \epsilon_i]^2}
-
-    For details see Eq. (11) in :cite:`Wang2006` or Eq. (2.59) in :cite:`TopInvCourse`.
-
-    Parameters
-    ----------
-    state : array_like
-       vectors describing the electronic states, 2nd dimension contains the states. In case of degenerate
-       states the vectors *may* be rotated upon return.
-    energy : array_like, optional
-       energies of the states. In case of degenerate
-       states the eigenvalues of the states will be averaged in the degenerate sub-space.
-    dHk : list of array_like
-       Hamiltonian derivative with respect to :math:`\mathbf k`. This needs to be a tuple or
-       list of the Hamiltonian derivative along the 3 Cartesian directions.
-    dSk : list of array_like, optional
-       :math:`\delta \mathbf S_{\mathbf k}` matrix required for non-orthogonal basis.
-       Same derivative as `dHk`.
-       NOTE: Using non-orthogonal basis sets are not tested.
-    degenerate : list of array_like, optional
-       a list containing the indices of degenerate states. In that case a prior diagonalization
-       is required to decouple them.
-    degenerate_dir : (3,), optional
-       along which direction degenerate states are decoupled.
-
-    See Also
-    --------
-    velocity : calculate state velocities
-    velocity_matrix : calculate state velocities between all states
-    Hamiltonian.dHk : function for generating the Hamiltonian derivatives (`dHk` argument)
-    Hamiltonian.dSk : function for generating the Hamiltonian derivatives (`dSk` argument)
-
-    Returns
-    -------
-    numpy.ndarray
-        Berry flux with final dimension ``(3, 3, state.shape[0])``
-    """
-    if state.ndim == 1:
-        return berry_curvature(
-            state.reshape(1, -1), energy, dHk, dSk, degenerate, degenerate_dir
-        )[0]
-
-    # cast dtypes to *any* complex valued data-type that can be expressed
-    # minimally by a complex64 object
-    dtype = np.result_type(state.dtype, dHk[0].dtype, np.complex64)
-
-    if dSk is None:
-        v_matrix = _velocity_matrix_ortho(state, dHk, degenerate, degenerate_dir, dtype)
-    else:
-        v_matrix = _velocity_matrix_non_ortho(
-            state, dHk, energy, dSk, degenerate, degenerate_dir, dtype
-        )
-        warn(
-            "berry_curvature calculation for non-orthogonal basis sets are not tested! Do not expect this to be correct!"
-        )
-    return _berry_curvature(v_matrix, energy)
-
-
-# This reverses the velocity unit (squared since Berry curvature is v.v)
-_berry_curvature_const = 1 / _velocity_const**2
-
-
-def _berry_curvature(v_M, energy):
-    r"""Calculate Berry curvature for a given velocity matrix"""
-
-    # All matrix elements along the 3 directions
-    N = v_M.shape[1]
-    # For cases where all states are degenerate then we would not be able
-    # to calculate anything. Hence we need to initialize as zero
-    #   \Omega_{\alpha \beta, n}
-    sigma = zeros([3, 3, N], dtype=dtype_complex_to_real(v_M.dtype))
-
-    for s, e in enumerate(energy):
-        de = (energy - e) ** 2
-        # add factor 2 here, but omit the minus sign until later
-        # where we are forced to use the constant upon return anyways
-        np.divide(2, de, where=(de != 0), out=de)
-
-        # Calculate the berry-curvature
-        sigma[:, :, s] = ((de * v_M[:, s]) @ v_M[:, :, s].T).imag
-
-    # negative here
-    sigma *= -_berry_curvature_const
-    return sigma
-
-
-@set_module("sisl.physics.electron")
-def conductivity(
-    bz,
-    distribution="fermi-dirac",
-    method="ahc",
-    degenerate=1.0e-5,
-    degenerate_dir=(1, 1, 1),
-    *,
-    eigenstate_kwargs=None,
-    apply_kwargs=None,
-):
-    r"""Electronic conductivity for a given `BrillouinZone` integral
-
-    Currently the *only* implemented method is the anomalous Hall conductivity (AHC, see :cite:`Wang2006`)
-    which may be calculated as:
+def ahc(
+    bz, distribution="step", *, eigenstate_kwargs={}, apply_kwargs={}, **berry_kwargs
+) -> np.ndarray:
+    r"""Electronic anomalous Hall conductivity for a given `BrillouinZone` integral
 
     .. math::
        \sigma_{\alpha\beta} = \frac{-e^2}{\hbar}\int\,\mathrm d\mathbf k\sum_i f_i\Omega_{i,\alpha\beta}(\mathbf k)
@@ -812,85 +637,273 @@ def conductivity(
     where :math:`\Omega_{i,\alpha\beta}` and :math:`f_i` is the Berry curvature and occupation
     for state :math:`i`.
 
-    The conductivity will be averaged by the Brillouin zone volume of the parent. See `BrillouinZone.volume` for details.
-    Hence for 1D the returned unit will be S/Ang, 2D it will be S/Ang^2 and 3D it will be S/Ang^3.
+    The conductivity will be averaged by volume of the periodic unit cell.
+    See `Lattice.volumef` for details.
+
+    See :cite:`Wang2006` for details on the implementation.
 
     Parameters
     ----------
     bz : BrillouinZone
         containing the integration grid and has the ``bz.parent`` as an instance of Hamiltonian.
     distribution : str or func, optional
-        distribution used to find occupations
-    method : {"ahc"}
-       "ahc" calculates the dc anomalous Hall conductivity
-    degenerate : float, optional
-       de-couple degenerate states within the given tolerance (in eV)
-    degenerate_dir : (3,), optional
-       along which direction degenerate states are decoupled.
-    eigenstate_kwargs : dict, optional
+        distribution used to find occupations.
+    eigenstate_kwargs :
        keyword arguments passed directly to the ``contour.eigenstate`` method.
        One should *not* pass a ``k`` or a ``wrap`` keyword argument as they are
        already used.
-    apply_kwargs : dict, optional
+    apply_kwargs :
        keyword arguments passed directly to ``bz.apply(**apply_kwargs)``.
+    **kwargs : dict, optional
+        arguments passed directly to the underlying calculation method.
 
     Returns
     -------
-    cond : float
-        conductivity in units [S/cm^D]. The D is the dimensionality of the system.
+    cond :
+        conductivity in units [S/cm].
+
+    Examples
+    --------
+
+    To calculate the AHC for a range of energy-points.
+    First create ``E`` which is the energy grid.
+    In order for the internal algorithm to be able
+    to broadcast arrays correctly, we have to allow the eigenvalue
+    spectrum to be appended by reshaping.
+
+    >>> E = np.linspace(-2, 2, 51)
+    >>> dist = get_distribution("step", x0=E.reshape(-1, 1))
+    >>> ahc_cond = ahc(bz, dist)
+    >>> assert ahc_cond.shape == (3, 3, len(E))
 
     See Also
     --------
-    berry_curvature: method used to calculate the Berry-flux for calculating the conductivity
+    berry_curvature: method used to calculate the Berry curvature for calculating the conductivity
     BrillouinZone.volume: volume calculation of the Brillouin zone
     """
     from .hamiltonian import Hamiltonian
 
+    H = bz.parent
+
     # Currently we require the conductivity calculation to *only* accept Hamiltonians
-    if not isinstance(bz.parent, Hamiltonian):
+    if not isinstance(H, Hamiltonian):
         raise SislError(
-            "conductivity: requires the Brillouin zone object to contain a Hamiltonian!"
+            "ahc: requires the Brillouin zone object to contain a Hamiltonian!"
         )
 
     if isinstance(distribution, str):
         distribution = get_distribution(distribution)
 
-    if eigenstate_kwargs is None:
-        eigenstate_kwargs = {}
-    if apply_kwargs is None:
-        apply_kwargs = {}
+    # kwargs is mutable in the method call, we have to assign a new variable
+    berry_kwargs = {**berry_kwargs, "distribution": distribution}
 
-    method = method.lower()
-    if method == "ahc":
+    def _ahc(es, k, weight, parent):
+        # the latter arguments are merely for speeding up the procedure
+        nonlocal berry_kwargs
+        return es.berry_curvature(**berry_kwargs)
 
-        def _ahc(es):
-            occ = distribution(es.eig)
-            bc = es.berry_curvature(
-                degenerate=degenerate, degenerate_dir=degenerate_dir
-            )
-            return bc @ occ
+    cond = bz.apply(**apply_kwargs).average.eigenstate(**eigenstate_kwargs, wrap=_ahc)
 
-        vol, dim = bz.volume(ret_dim=True)
+    geom = H.geometry
+    lat = geom.lattice
+    per_axes = lat.pbc.nonzero()[0]
+    vol = lat.volumef(per_axes)
 
-        if dim == 0:
-            raise SislError(
-                f"conductivity: found a dimensionality of 0 which is non-physical"
-            )
+    conv = -1 / vol
 
-        cond = bz.apply(**apply_kwargs).average.eigenstate(
-            **eigenstate_kwargs, wrap=_ahc
-        ) * (-constant.G0 / (4 * np.pi))
-
-        # Convert the dimensions from S/m^D to S/cm^D
-        cond /= vol * units(f"Ang^{dim}", f"cm^{dim}")
-        warn(
-            "conductivity: be aware that the units are currently not tested, please provide feedback!"
-        )
-
-    else:
-        raise SislError("conductivity: requires the method to be [ahc]")
+    cond *= conv
+    warn(
+        "ahc: be aware that the units are currently not tested, please provide feedback!"
+    )
 
     return cond
+
+
+def _create_sigma(n, sigma, dtype, format):
+    """This will return the Pauli matrix filled in a diagonal of the matrix
+
+    It will not return the spin operator, which has the pre-factor hbar/2
+    """
+
+    sigma = getattr(Spin, sigma.upper()) / 2
+
+    if format in ("array", "matrix"):
+        m = np.zeros([n, 2, n, 2], dtype=dtype)
+        idx = np.arange(n)
+        m[idx, 0, idx, 0] = sigma[0, 0]
+        m[idx, 0, idx, 1] = sigma[0, 1]
+        m[idx, 1, idx, 0] = sigma[1, 0]
+        m[idx, 1, idx, 1] = sigma[1, 1]
+        m.shape = (n * 2, n * 2)
+    else:
+        m = scs.kron(scs.eye(n, dtype=dtype), sigma).tocsr()
+    return m
+
+
+@set_module("sisl.physics.electron")
+def shc(
+    bz,
+    distribution="step",
+    J_axis: CartesianAxisStrLiteral = "y",
+    spin_axis: CartesianAxisStrLiteral = "z",
+    *,
+    eigenstate_kwargs={},
+    apply_kwargs={},
+    **berry_kwargs,
+) -> np.ndarray:
+    r"""Electronic spin Hall conductivity for a given `BrillouinZone` integral
+
+    .. math::
+       \sigma^\gamma_{\alpha\beta} = \frac{-e^2}{\hbar}\int\,\mathrm d\mathbf k
+       \sum_i f_i\boldsymbol\Omega^\gamma_{i,\alpha\beta}(\mathbf k)
+
+    where :math:`\boldsymbol\Omega^\gamma_{i,\alpha\beta}` and :math:`f_i` are the spin Berry curvature and occupation
+    for state :math:`i`.
+
+    The conductivity will be averaged by volume of the periodic unit cell.
+    See `Lattice.volumef` for details.
+
+    See :cite:`PhysRevB.98.214402` and :cite:`Ji2022` for details on the implementation.
+
+    Parameters
+    ----------
+    bz : BrillouinZone
+        containing the integration grid and has the ``bz.parent`` as an instance of Hamiltonian.
+    J_axis:
+        the direction where the :math:`J` operator will be applied.
+    spin_axis:
+        the direction of the Pauli matrix.
+    distribution : str or func, optional
+        distribution used to find occupations
+    eigenstate_kwargs :
+       keyword arguments passed directly to the ``contour.eigenstate`` method.
+       One should *not* pass a ``k`` or a ``wrap`` keyword argument as they are
+       already used.
+    apply_kwargs :
+       keyword arguments passed directly to ``bz.apply(**apply_kwargs)``.
+    **berry_kwargs : dict, optional
+        arguments passed directly to the underlying calculation method.
+
+    Examples
+    --------
+    For instance, ``J_axis = 'z', spin_axis = 'y'`` will result in
+    :math:`J^{\sigma^y}_z=\dfrac12\{\sigma^y, \hat v_z\}`.
+
+    To calculate the SHC for a range of energy-points.
+    First create ``E`` which is the energy grid.
+    In order for the internal algorithm to be able
+    to broadcast arrays correctly, we have to allow the eigenvalue
+    spectrum to be appended by reshaping.
+
+    >>> E = np.linspace(-2, 2, 51)
+    >>> dist = get_distribution("step", x0=E.reshape(-1, 1))
+    >>> ahc_cond = shc(bz, distribution=dist)
+    >>> assert ahc_cond.shape == (3, 3, len(E))
+
+    Returns
+    -------
+    cond :
+        conductivity in units [S/Ang]
+
+    See Also
+    --------
+    spin_berry_curvature: method used to calculate the Berry-flux for calculating the spin conductivity
+    BrillouinZone.volume: volume calculation of the Brillouin zone
+    """
+    from .hamiltonian import Hamiltonian
+
+    H = bz.parent
+
+    # Currently we require the conductivity calculation to *only* accept Hamiltonians
+    if not isinstance(H, Hamiltonian):
+        raise SislError(
+            "shc: requires the Brillouin zone object to contain a Hamiltonian!"
+        )
+
+    if isinstance(distribution, str):
+        distribution = get_distribution(distribution)
+
+    dtype = eigenstate_kwargs.get("dtype", np.complex128)
+
+    m = _create_sigma(H.no, spin_axis, dtype, eigenstate_kwargs.get("format", "csr"))
+
+    # To reduce (heavily) the computational load, we pre-setup the
+    # operators here.
+    def J(M, d):
+        nonlocal m, J_axis
+        if d == J_axis:
+            return M @ m + m @ M
+        return M
+
+    axes = berry_kwargs.get("derivative_kwargs", {}).get("axes", "xyz")
+    axes = [direction(axis) for axis in sorted(axes)]
+
+    def noop(M, d):
+        return M
+
+    # kwargs is mutable in the method call, we have to assign a new variable
+    berry_kwargs = {**berry_kwargs, "distribution": distribution, "operator": (J, noop)}
+
+    def _shc(es, k, weight, parent):
+        # the latter arguments are merely for speeding up the procedure
+        nonlocal berry_kwargs
+        return es.berry_curvature(**berry_kwargs)
+
+    cond = bz.apply(**apply_kwargs).average.eigenstate(**eigenstate_kwargs, wrap=_shc)
+
+    """
+    # G0 = 2e^2/h
+    # hbar = h/(2pi)
+    # we want -e^2/hbar=-2e^2pi/h = 2pi G0
+    # but no matter
+    ahc_conv = -constant.G0 *2* np.pi / (bz.parent.geometry.volume * units("Ang^3", "m^3") * units("m", "cm")) * units("eV", "J")
+    print("ahc-conv", ahc_conv, -1e4 / bz.parent.geometry.volume)
+    # the SHC misses the factor -2e/hbar = -4 pi e^2/(he) = -G0 2pi/e
+    shc_conv = -constant.G0 * 2 *np.pi /constant.q * ahc_conv
+    # to convert to units:
+    #  hbar/e S/length we just multiply by: -hbar /(2e) = - he/(4pi e^2) = -e/(2pi G0)
+    print("shc-conv", shc_conv, shc_conv -1e4 / bz.parent.geometry.volume)
+
+    """
+
+    geom = H.geometry
+    lat = geom.lattice
+    per_axes = lat.pbc.nonzero()[0]
+    vol = lat.volumef(per_axes)
+
+    ahc_conv = -1 / vol
+    shc_conv = 1
+
+    shc_idx = axes.index(direction(J_axis))
+    cond *= ahc_conv
+    cond[shc_idx] *= shc_conv
+
+    warn(
+        "shc: be aware that the units are currently not tested, please provide feedback!"
+    )
+
+    return cond
+
+
+@set_module("sisl.physics.electron")
+@deprecation("conductivity is deprecated, please use 'ahc' instead.")
+def conductivity(
+    bz,
+    distribution="fermi-dirac",
+    method: Literal["ahc"] = "ahc",
+    *,
+    eigenstate_kwargs={},
+    apply_kwargs={},
+    **kwargs,
+):
+    r"""Deprecated, please see `ahc`"""
+    return ahc(
+        bz,
+        distribution,
+        eigenstate_kwargs=eigenstate_kwargs,
+        apply_kwargs=apply_kwargs,
+        **kwargs,
+    )
 
 
 @set_module("sisl.physics.electron")
@@ -1645,53 +1658,6 @@ class StateCElectron(_electron_State, StateC):
     r"""A state describing a physical quantity related to electrons, with associated coefficients of the state"""
 
     __slots__ = []
-
-    def velocity(self, *args, **kwargs):
-        r"""Calculate velocity for the states
-
-        This routine calls ``derivative(1, *args, **kwargs)`` and returns the velocity for the states.
-
-        Note that the coefficients associated with the `StateCElectron` *must* correspond
-        to the energies of the states.
-
-        Notes
-        -----
-        The states and energies for the states *may* have changed after calling this routine.
-        This is because of the velocity un-folding for degenerate modes. I.e. calling
-        `PDOS` after this method *may* change the result.
-
-        The velocities are calculated without the Berry curvature contribution see Eq. (2) in :cite:`Wang2006`.
-        The missing contribution may be added in later editions, for completeness sake, it is:
-
-        .. math::
-           \delta \mathbf v = - \mathbf k\times \Omega_i(\mathbf k)
-
-        where :math:`\Omega_i` is the Berry curvature for state :math:`i`.
-
-        See Also
-        --------
-        derivative : for details of the implementation
-        """
-        v = self.derivative(1, *args, **kwargs)
-        v *= _velocity_const
-        return v
-
-    def berry_curvature(self, *args, **kwargs):
-        r"""Calculate Berry curvature for the states
-
-        This routine calls ``derivative(1, *args, **kwargs, matrix=True)`` and
-        returns the Berry curvature for the states.
-
-        Note that the coefficients associated with the `StateCElectron` *must* correspond
-        to the energies of the states.
-
-        See Also
-        --------
-        derivative : for details of the velocity matrix calculation implementation
-        sisl.physics.electron.berry_curvature : for details of the Berry curvature implementation
-        """
-        v = self.derivative(1, *args, **kwargs, matrix=True)
-        return _berry_curvature(v, self.c)
 
     def effective_mass(self, *args, **kwargs):
         r"""Calculate effective mass tensor for the states, units are (ps/Ang)^2

--- a/src/sisl/physics/state.py
+++ b/src/sisl/physics/state.py
@@ -1098,7 +1098,7 @@ coefficients assigned to each state
     def derivative(
         self,
         order: Literal[1, 2] = 1,
-        degenerate=1e-5,
+        degenerate=None,
         degenerate_dir=(1, 1, 1),
         matrix: bool = False,
         axes: CartesianAxes = "xyz",

--- a/src/sisl/physics/state.py
+++ b/src/sisl/physics/state.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from functools import singledispatchmethod
 from numbers import Real
-from typing import Any, Callable, Literal, Optional
+from typing import Callable, Literal, Optional
 
 import numpy as np
 from numpy import bool_, einsum, exp, ndarray

--- a/src/sisl/physics/tests/test_hamiltonian.py
+++ b/src/sisl/physics/tests/test_hamiltonian.py
@@ -992,7 +992,7 @@ class TestHamiltonian:
         H.construct((R, param))
 
         mp = MonkhorstPack(H, [5, 5, 1])
-        cond = ahc(mp)
+        ahc(mp)
 
     @pytest.mark.filterwarnings("ignore", category=np.ComplexWarning)
     def test_ahc_spin(self, setup):
@@ -1017,6 +1017,9 @@ class TestHamiltonian:
         cond = shc(mp)
         cond2 = shc(mp, sum=False)
         assert np.allclose(cond, cond2.sum(-1))
+
+        cond2 = shc(mp, sigma=Spin.Z)
+        assert np.allclose(cond, cond2)
 
     @pytest.mark.xfail(reason="Gauges make different decouplings")
     def test_gauge_eff(self, setup):

--- a/src/sisl/physics/tests/test_hamiltonian.py
+++ b/src/sisl/physics/tests/test_hamiltonian.py
@@ -26,7 +26,7 @@ from sisl import (
     get_distribution,
     oplist,
 )
-from sisl.physics.electron import berry_phase, conductivity, spin_contamination
+from sisl.physics.electron import ahc, berry_phase, shc, spin_contamination
 
 pytestmark = [
     pytest.mark.physics,
@@ -792,6 +792,23 @@ class TestHamiltonian:
         v = es.derivative(1)
         assert np.allclose(v1, v)
 
+    def test_derivative_orthogonal_axis(self, setup):
+        R, param = [0.1, 1.5], [1.0, 0.1]
+        g = setup.g.tile(2, 0).tile(2, 1).tile(2, 2)
+        H = Hamiltonian(g)
+        H.construct((R, param))
+
+        k = [0.1] * 3
+        es = H.eigenstate()
+
+        v1, vv1 = es.derivative(2, axes="x")
+        assert len(v1) == 1
+        assert len(vv1) == 1
+
+        v1, vv1 = es.derivative(2, axes="xy")
+        assert len(v1) == 2
+        assert len(vv1) == 3
+
     def test_derivative_non_orthogonal(self, setup):
         R, param = [0.1, 1.5], [(1.0, 1.0), (0.1, 0.1)]
         g = setup.g.tile(2, 0).tile(2, 1).tile(2, 2)
@@ -953,28 +970,40 @@ class TestHamiltonian:
 
         k = [0.1] * 3
         ie1 = H.eigenstate(k, gauge="cell").berry_curvature()
-        ie2 = H.eigenstate(k, gauge="orbital").berry_curvature(degenerate_dir=(1, 1, 0))
+        ie2 = H.eigenstate(k, gauge="orbital").berry_curvature(
+            derivative_kwargs={"degenerate_dir": (1, 1, 0)}
+        )
         assert np.allclose(ie1, ie2)
 
     @pytest.mark.filterwarnings("ignore", category=np.ComplexWarning)
-    def test_conductivity(self, setup):
+    def test_ahc(self, setup):
         R, param = [0.1, 1.5], [1.0, 0.1]
         g = setup.g.tile(2, 0).tile(2, 1).tile(2, 2)
         H = Hamiltonian(g)
         H.construct((R, param))
 
-        mp = MonkhorstPack(H, [11, 11, 1])
-        cond = conductivity(mp)
+        mp = MonkhorstPack(H, [5, 5, 1])
+        cond = ahc(mp)
 
     @pytest.mark.filterwarnings("ignore", category=np.ComplexWarning)
-    def test_conductivity_spin(self, setup):
+    def test_ahc_spin(self, setup):
         R, param = [0.1, 1.5], [[1.0, 2.0], [0.1, 0.2]]
         g = setup.g.tile(2, 0).tile(2, 1).tile(2, 2)
         H = Hamiltonian(g, spin=Spin.POLARIZED)
         H.construct((R, param))
 
-        mp = MonkhorstPack(H, [11, 11, 1])
-        cond = conductivity(mp)
+        mp = MonkhorstPack(H, [5, 5, 1])
+        cond = ahc(mp)
+
+    @pytest.mark.filterwarnings("ignore", category=np.ComplexWarning)
+    def test_shc(self, setup):
+        R, param = [0.1, 1.5], [[1.0, 0.1, 0, 0], [0.4, 0.2, 0.3, 0.2]]
+        g = setup.g.tile(2, 0).tile(2, 1).tile(2, 2)
+        H = Hamiltonian(g, spin=Spin.NONCOLINEAR)
+        H.construct((R, param))
+
+        mp = MonkhorstPack(H, [5, 5, 1])
+        cond = shc(mp)
 
     @pytest.mark.xfail(reason="Gauges make different decouplings")
     def test_gauge_eff(self, setup):

--- a/src/sisl/physics/tests/test_hamiltonian.py
+++ b/src/sisl/physics/tests/test_hamiltonian.py
@@ -1001,7 +1001,7 @@ class TestHamiltonian:
         H = Hamiltonian(g, spin=Spin.POLARIZED)
         H.construct((R, param))
 
-        mp = MonkhorstPack(H, [5, 5, 1])
+        mp = MonkhorstPack(H, [3, 3, 1])
         cond = ahc(mp)
         cond2 = ahc(mp, sum=False)
         assert np.allclose(cond, cond2.sum(-1))
@@ -1013,13 +1013,31 @@ class TestHamiltonian:
         H = Hamiltonian(g, spin=Spin.NONCOLINEAR)
         H.construct((R, param))
 
-        mp = MonkhorstPack(H, [5, 5, 1])
+        mp = MonkhorstPack(H, [3, 3, 1])
         cond = shc(mp)
         cond2 = shc(mp, sum=False)
         assert np.allclose(cond, cond2.sum(-1))
 
         cond2 = shc(mp, sigma=Spin.Z)
         assert np.allclose(cond, cond2)
+
+    @pytest.mark.filterwarnings("ignore", category=np.ComplexWarning)
+    def test_shc_and_ahc(self, setup):
+        R, param = [0.1, 1.5], [
+            [1.0, 0.1, 0, 0, 0, 0, 0, 0],
+            [0.4, 0.2, 0.3, 0.3, 0.5, 0.4, 0.2, 0.3],
+        ]
+        g = setup.g.tile(2, 0).tile(2, 1).tile(2, 2)
+        H = Hamiltonian(g, spin=Spin.SPINORBIT)
+        H.construct((R, param))
+
+        mp = MonkhorstPack(H, [3, 3, 1])
+        c_ahc = ahc(mp)
+        # Ensure that shc calculates AHC in other segments
+        c_shc = shc(mp, J_axes="y")
+        assert np.allclose(c_ahc[0], c_shc[0])
+        assert not np.allclose(c_ahc[1], c_shc[1])
+        assert np.allclose(c_ahc[2], c_shc[2])
 
     @pytest.mark.xfail(reason="Gauges make different decouplings")
     def test_gauge_eff(self, setup):

--- a/src/sisl/typing/_indices.py
+++ b/src/sisl/typing/_indices.py
@@ -16,7 +16,10 @@ if TYPE_CHECKING:
     from sisl.geom.category import AtomCategory
 
 __all__ = [
+    "AxisIntLiteral",
+    "CellAxisStrLiteral",
     "CellAxisLiteral",
+    "CartesianAxisStrLiteral",
     "CartesianAxisLiteral",
     "CellAxis",
     "CellAxes",
@@ -29,12 +32,18 @@ __all__ = [
     "OrbitalsIndex",
 ]
 
+AxisIntLiteral = Literal[0, 1, 2]
+"""Defining axis specification in 3D space (int)"""
+CellAxisStrLiteral = Literal["a", "b", "c"]
+"""Defining lattice axis specification in 3D space (str)"""
+CartesianAxisStrLiteral = Literal["x", "y", "z"]
+"""Defining Cartesian axis specification in 3D space (str)"""
 
 # The literal interpretations of what an axis specification can be
 # Both for lattice vectors and cartesian vectors
-CellAxisLiteral = Literal[0, 1, 2, "a", "b", "c"]
+CellAxisLiteral = Union[AxisIntLiteral, CellAxisStrLiteral]
 """Defining lattice vector allowed arguments"""
-CartesianAxisLiteral = Literal[0, 1, 2, "x", "y", "z"]
+CartesianAxisLiteral = Union[AxisIntLiteral, CartesianAxisStrLiteral]
 """Defining Cartesian vector allowed arguments"""
 
 # Axis specifications


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
- `berry_curvature` is changed to only live on
  the `StateCElectron`.
  Old scripts relying on `berry_curvature`
  will not work now.
- `conductivity` has been deprecated, in favor
  of explicit calculations, `ahc` and `shc`.
- `axes` and `operator` arguments has been added
  for `derivative`
  They allow to determine which axes to extract the derivatives
  of, and to change the velocity operator to something else.

The above changes are required to enable the `ahc` and `shc` calculations.

ahc is basically the same as the old `conductivity` with changed API.
shc is the ahc where one of the velocity operators is changed
to the spin current operator.

Lots of the methods has changed their API's to enable faster parallel
calculations by explicitly allowing arguments passed to apply
methods.

However, the units of these methods are still wrong.
That needs subsequent fixing.

 - [x] Closes #766
 - [ ] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` [24.2.0] at top-level
 - [ ] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`
