### PR TITLE
Fix bug with numpy v2.0

### DIFF
--- a/src/sisl/viz/processors/orbital.py
+++ b/src/sisl/viz/processors/orbital.py
@@ -272,7 +272,7 @@ class OrbitalQueriesManager:
 
             def _repr(v):
                 if isinstance(v, np.ndarray):
-                    v = list(v.ravel())
+                    v = v.ravel().tolist()
                 if isinstance(v, dict):
                     raise Exception(str(v))
                 return repr(v)


### PR DESCRIPTION
The repr of `numpy` 0D arrays changed from `0` to `np.int64(0)` in numpy 2.0, which caused a bug when creating queries for orbital filtering, making tests fail: https://github.com/zerothi/sisl/actions/runs/9922030378/job/27410643845.
