### PR TITLE
enabled vacuum for all geometries with non-pbc directions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ we hit release version 1.0.0.
 ## [0.15.0] - YYYY-MM-DD
 
 ### Added
+- vacuum argument for all `sisl.geom` methods that can use it
 - `Geometry.find_nsc`, alternate method for calculating `nsc` with more options
 - `sisl._debug_info` for more complete debug information
 - `axes` argument added to `derivative` to only calculate on a subset

--- a/src/sisl/geom/bilayer.py
+++ b/src/sisl/geom/bilayer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from math import acos, pi
 from numbers import Integral
-from typing import Optional
+from typing import Literal, Optional
 
 import numpy as np
 
@@ -24,11 +24,13 @@ def bilayer(
     bond: float = 1.42,
     bottom_atoms: Optional[AtomsLike] = None,
     top_atoms: Optional[AtomsLike] = None,
-    stacking: str = "AB",
+    stacking: Literal["AB", "AA", "BA"] = "AB",
     twist=(0, 0),
     separation: float = 3.35,
+    vacuum: float = 20,
+    *,
+    layer: Literal["both", "bottom", "top"] = "both",
     ret_angle: bool = False,
-    layer: str = "both",
 ) -> Geometry:
     r"""Commensurate unit cell of a hexagonal bilayer structure, possibly with a twist angle.
 
@@ -46,16 +48,18 @@ def bilayer(
        atom (or atoms) in the bottom layer. Defaults to ``Atom(6)``
     top_atoms :
        atom (or atoms) in the top layer, defaults to `bottom_atom`
-    stacking : {'AB', 'AA', 'BA'}
+    stacking :
        stacking sequence of the bilayer, where XY means that site X in bottom layer coincides with site Y in top layer
     twist : tuple of int, optional
        integer coordinates (m, n) defining a commensurate twist angle
     separation :
        distance between the two layers
+    vacuum :
+        length of vacuum region (along 3rd lattice vector)
+    layer :
+       control which layer(s) to return
     ret_angle :
        return the twist angle (in degrees) in addition to the geometry instance
-    layer : {'both', 'bottom', 'top'}
-       control which layer(s) to return
 
     See Also
     --------
@@ -70,8 +74,8 @@ def bilayer(
         top_atoms = bottom_atoms
 
     # Construct two layers
-    bottom = honeycomb(bond, bottom_atoms)
-    top = honeycomb(bond, top_atoms)
+    bottom = honeycomb(bond, bottom_atoms, vacuum=vacuum + separation)
+    top = honeycomb(bond, top_atoms, vacuum=vacuum + separation)
     ref_cell = bottom.cell.copy()
 
     stacking = stacking.lower()

--- a/src/sisl/geom/flat.py
+++ b/src/sisl/geom/flat.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Tuple, Union
 
 import numpy as np
 
@@ -23,9 +23,13 @@ __all__ = [
     "goldene",
 ]
 
+FloatOrFloat3 = Union[float, Tuple[float, float, float]]
+
 
 @set_module("sisl.geom")
-def honeycomb(bond: float, atoms: AtomsLike, orthogonal: bool = False) -> Geometry:
+def honeycomb(
+    bond: float, atoms: AtomsLike, orthogonal: bool = False, vacuum: float = 20
+) -> Geometry:
     """Honeycomb lattice with 2 or 4 atoms per unit-cell, latter orthogonal cell
 
     This enables creating BN lattices with ease, or graphene lattices.
@@ -38,6 +42,8 @@ def honeycomb(bond: float, atoms: AtomsLike, orthogonal: bool = False) -> Geomet
         the atom (or atoms) that the honeycomb lattice consists of
     orthogonal :
         if True returns an orthogonal lattice
+    vacuum :
+        length of vacuum region (along 3rd lattice vector)
 
     See Also
     --------
@@ -48,7 +54,8 @@ def honeycomb(bond: float, atoms: AtomsLike, orthogonal: bool = False) -> Geomet
     if orthogonal:
         lattice = Lattice(
             np.array(
-                [[3.0, 0.0, 0.0], [0.0, 2 * sq3h, 0.0], [0.0, 0.0, 10.0]], np.float64
+                [[3.0, 0.0, 0.0], [0.0, 2 * sq3h, 0.0], [0.0, 0.0, vacuum / bond]],
+                np.float64,
             )
             * bond
         )
@@ -64,7 +71,8 @@ def honeycomb(bond: float, atoms: AtomsLike, orthogonal: bool = False) -> Geomet
     else:
         lattice = Lattice(
             np.array(
-                [[1.5, -sq3h, 0.0], [1.5, sq3h, 0.0], [0.0, 0.0, 10.0]], np.float64
+                [[1.5, -sq3h, 0.0], [1.5, sq3h, 0.0], [0.0, 0.0, vacuum / bond]],
+                np.float64,
             )
             * bond
         )
@@ -82,7 +90,10 @@ def honeycomb(bond: float, atoms: AtomsLike, orthogonal: bool = False) -> Geomet
 
 @set_module("sisl.geom")
 def graphene(
-    bond: float = 1.42, atoms: AtomsLike = None, orthogonal: bool = False
+    bond: float = 1.42,
+    atoms: AtomsLike = None,
+    orthogonal: bool = False,
+    vacuum: float = 20,
 ) -> Geometry:
     """Graphene lattice with 2 or 4 atoms per unit-cell, latter orthogonal cell
 
@@ -95,6 +106,8 @@ def graphene(
         Default to Carbon atom.
     orthogonal :
         if True returns an orthogonal lattice
+    vacuum :
+        length of vacuum region (along 3rd lattice vector)
 
     See Also
     --------
@@ -103,12 +116,12 @@ def graphene(
     """
     if atoms is None:
         atoms = Atom(Z=6, R=bond * 1.01)
-    return honeycomb(bond, atoms, orthogonal)
+    return honeycomb(bond, atoms, orthogonal, vacuum=vacuum)
 
 
 @set_module("sisl.geom")
 def honeycomb_flake(
-    shells: int, bond: float, atoms: AtomsLike, vacuum: float = 20.0
+    shells: int, bond: float, atoms: AtomsLike, vacuum: FloatOrFloat3 = 20.0
 ) -> Geometry:
     """Hexagonal flake of a honeycomb lattice, with zig-zag edges.
 
@@ -122,7 +135,8 @@ def honeycomb_flake(
     atoms:
         the atom (or atoms) that the honeycomb lattice consists of
     vacuum:
-        Amount of vacuum to add to the cell on all directions
+        Amount of vacuum to add to the cell in all directions (with tuple, individual
+        vacuum lengths)
     """
 
     # Function that generates one of the six triangular portions of the
@@ -184,10 +198,9 @@ def honeycomb_flake(
     geom += geom.rotate(120, [0, 0, 1]) + geom.rotate(240, [0, 0, 1])
 
     # Set the cell according to the requested vacuum
-    max_x = np.max(geom.xyz[:, 0])
-    geom.cell[0, 0] = max_x * 2 + vacuum
-    geom.cell[1, 1] = max_x * 2 + vacuum
-    geom.cell[2, 2] = 20.0
+    xyz = geom.xyz
+    cell = xyz.max(0) - xyz.min(0) + vacuum
+    geom.set_lattice(cell)
 
     # Center the flake
     geom = geom.translate(geom.center(what="cell"))
@@ -200,7 +213,10 @@ def honeycomb_flake(
 
 @set_module("sisl.geom")
 def graphene_flake(
-    shells: int, bond: float = 1.42, atoms: AtomsLike = None, vacuum: float = 20.0
+    shells: int,
+    bond: float = 1.42,
+    atoms: AtomsLike = None,
+    vacuum: FloatOrFloat3 = 20.0,
 ) -> Geometry:
     """Hexagonal flake of graphene, with zig-zag edges.
 
@@ -228,7 +244,10 @@ def graphene_flake(
 
 @set_module("sisl.geom")
 def triangulene(
-    n: int, bond: float = 1.42, atoms: Optional[AtomsLike] = None, vacuum: float = 20.0
+    n: int,
+    bond: float = 1.42,
+    atoms: Optional[AtomsLike] = None,
+    vacuum: FloatOrFloat3 = 20.0,
 ) -> Geometry:
     """Construction of an [n]-triangulene geometry
 
@@ -264,7 +283,10 @@ def triangulene(
 
 
 def hexagonal(
-    bond: float, atoms: AtomsLike = None, orthogonal: bool = False
+    bond: float,
+    atoms: AtomsLike = None,
+    orthogonal: bool = False,
+    vacuum: float = 20.0,
 ) -> Geometry:
     """A hexagonal unit-cell with 1 or 2 atoms in the basic unit cell
 
@@ -280,11 +302,16 @@ def hexagonal(
     orthogonal :
         if True returns an orthogonal lattice (2 atoms), otherwise
         a non-orthogonal lattice (1 atom).
+    vacuum :
+        length of vacuum region (along 3rd lattice vector)
     """
     sq3h = 3.0**0.5 * 0.5
     if orthogonal:
         lattice = Lattice(
-            np.array([[2 * sq3h, 0.0, 0.0], [0, 1, 0.0], [0.0, 0.0, 10.0]], np.float64)
+            np.array(
+                [[2 * sq3h, 0.0, 0.0], [0, 1, 0.0], [0.0, 0.0, vacuum / bond]],
+                np.float64,
+            )
             * bond
         )
         g = Geometry(
@@ -299,7 +326,8 @@ def hexagonal(
     else:
         lattice = Lattice(
             np.array(
-                [[sq3h, -0.5, 0.0], [sq3h, 0.5, 0.0], [0.0, 0.0, 10.0]], np.float64
+                [[sq3h, -0.5, 0.0], [sq3h, 0.5, 0.0], [0.0, 0.0, vacuum / bond]],
+                np.float64,
             )
             * bond
         )
@@ -316,7 +344,10 @@ def hexagonal(
 
 
 def goldene(
-    bond: float = 2.7, atoms: AtomsLike = None, orthogonal: bool = False
+    bond: float = 2.7,
+    atoms: AtomsLike = None,
+    orthogonal: bool = False,
+    vacuum: float = 20.0,
 ) -> Geometry:
     """A goldene unit-cell with 1 or 2 atoms in the basic unit cell
 
@@ -330,6 +361,8 @@ def goldene(
     orthogonal :
         if True returns an orthogonal lattice (2 atoms), otherwise
         a non-orthogonal lattice (1 atom).
+    vacuum :
+        length of vacuum region (along 3rd lattice vector)
 
     See Also
     --------
@@ -337,4 +370,4 @@ def goldene(
     """
     if atoms is None:
         atoms = Atom(Z=79, R=bond * 1.01)
-    return hexagonal(bond, atoms, orthogonal)
+    return hexagonal(bond, atoms, orthogonal, vacuum)

--- a/src/sisl/geom/nanotube.py
+++ b/src/sisl/geom/nanotube.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import numpy as np
 
@@ -15,10 +15,15 @@ from ._common import geometry_define_nsc
 
 __all__ = ["nanotube"]
 
+FloatOrFloat2 = Union[float, Tuple[float, float]]
+
 
 @set_module("sisl.geom")
 def nanotube(
-    bond: float, atoms: Optional[AtomsLike] = None, chirality: Tuple[int, int] = (1, 1)
+    bond: float,
+    atoms: Optional[AtomsLike] = None,
+    chirality: Tuple[int, int] = (1, 1),
+    vacuum: FloatOrFloat2 = 20.0,
 ) -> Geometry:
     """Nanotube with user-defined chirality.
 
@@ -26,11 +31,11 @@ def nanotube(
 
     Parameters
     ----------
-    bond : float
+    bond :
        length between atoms in nano-tube
-    atoms : Atom(6)
+    atoms :
        nanotube atoms
-    chirality : (int, int)
+    chirality :
        chirality of nanotube (n, m)
     """
     if atoms is None:
@@ -142,11 +147,15 @@ def nanotube(
     # Sort the atomic coordinates according to z
     idx = np.argsort(xyz[:, 2])
     xyz = xyz[idx, :]
+    xyz_min, xyz_max = xyz.min(0), xyz.max(0)
 
-    lattice = Lattice([rs * 4, rs * 4, t])
+    cell = xyz_max - xyz_min
+    cell[:2] += vacuum
+    cell[2] = t
+    lattice = Lattice(cell)
 
     geom = Geometry(xyz, atoms, lattice=lattice)
-    geom = geom.translate(-np.amin(geom.xyz, axis=0))
+    geom = geom.translate(-xyz_min)
 
     geometry_define_nsc(geom, [False, False, True])
 

--- a/src/sisl/geom/surfaces.py
+++ b/src/sisl/geom/surfaces.py
@@ -326,7 +326,7 @@ def fcc_slab(
     ----------
     alat :
         lattice constant of the fcc crystal
-    atoms : Atom
+    atoms :
         the atom that the crystal consists of
     miller :
         Miller indices of the surface facet
@@ -528,7 +528,7 @@ def bcc_slab(
     ----------
     alat :
         lattice constant of the fcc crystal
-    atoms : Atom
+    atoms :
         the atom that the crystal consists of
     miller :
         Miller indices of the surface facet
@@ -697,7 +697,7 @@ def rocksalt_slab(
     ----------
     alat :
         lattice constant of the rock-salt crystal
-    atoms : list
+    atoms :
         a list of two atoms that the crystal consist of
     miller :
         Miller indices of the surface facet

--- a/src/sisl/geom/tests/test_geom.py
+++ b/src/sisl/geom/tests/test_geom.py
@@ -28,6 +28,15 @@ def is_right_handed(geometry):
     return sc.volume > 0.0
 
 
+def has_vacuum(geometry, vacuum):
+    fxyz = geometry.fxyz
+    # print(fxyz.max(0) - fxyz.min(0), geometry.lattice.length)
+    vac = (1 - (fxyz.max(0) - fxyz.min(0))) * geometry.lattice.length
+    vac = vac[~geometry.lattice.pbc]
+    print(vac, vacuum)
+    return np.allclose(vac, vacuum)
+
+
 def test_basic():
     a = sc(2.52, Atom["Fe"])
     assert is_right_handed(a)
@@ -46,52 +55,79 @@ def test_basic():
 
 
 @pytest.mark.parametrize(
-    "func, orthogonal",
-    itertools.product([graphene, goldene], [True, False]),
+    "func, orthogonal, vacuum",
+    itertools.product([graphene, goldene], [True, False], [10, 20]),
 )
-def test_flat(func, orthogonal):
-    a = func(orthogonal=orthogonal)
+def test_flat(func, orthogonal, vacuum):
+    a = func(orthogonal=orthogonal, vacuum=vacuum)
     assert is_right_handed(a)
-    a = func(atoms="C", orthogonal=orthogonal)
+    assert has_vacuum(a, vacuum)
+    a = func(atoms="C", orthogonal=orthogonal, vacuum=vacuum)
     assert is_right_handed(a)
+    assert has_vacuum(a, vacuum)
 
 
-def test_flat_flakes():
-    g = graphene_flake(shells=0, bond=1.42)
+@pytest.mark.parametrize(
+    "vacuum",
+    [10, (20, 30, 10)],
+)
+def test_flat_flakes(vacuum):
+    g = graphene_flake(shells=0, bond=1.42, vacuum=vacuum)
     assert g.na == 6
     # All atoms are close to the center
     assert len(g.close(g.center(), 1.44)) == g.na
     # All atoms have two neighbors
     assert len(g.axyz(AtomNeighbors(min=2, max=2, R=1.44))) == g.na
+    assert is_right_handed(g)
+    assert has_vacuum(g, vacuum)
 
-    g = graphene_flake(shells=1, bond=1.42)
+    g = graphene_flake(shells=1, bond=1.42, vacuum=vacuum)
     assert g.na == 24
     assert len(g.close(g.center(), 4)) == g.na
     assert len(g.axyz(AtomNeighbors(min=2, max=2, R=1.44))) == 12
     assert len(g.axyz(AtomNeighbors(min=3, max=3, R=1.44))) == 12
+    assert is_right_handed(g)
+    assert has_vacuum(g, vacuum)
 
-    bn = honeycomb_flake(shells=1, atoms=["B", "N"], bond=1.42)
+    bn = honeycomb_flake(shells=1, atoms=["B", "N"], bond=1.42, vacuum=vacuum)
     assert bn.na == 24
     assert np.allclose(bn.xyz, g.xyz)
     # Check that atoms are alternated.
     assert len(bn.axyz(AtomZ(5) & AtomNeighbors(min=1, R=1.44, neighbor=AtomZ(5)))) == 0
+    assert is_right_handed(bn)
+    assert has_vacuum(bn, vacuum)
 
 
-def test_triangulene():
-    g = triangulene(3)
+@pytest.mark.parametrize(
+    "vacuum",
+    [10, (20, 30, 10)],
+)
+def test_triangulene(vacuum):
+    g = triangulene(3, vacuum=vacuum)
     assert g.na == 22
-    g = triangulene(3, atoms=["B", "N"])
+    assert is_right_handed(g)
+    assert has_vacuum(g, vacuum)
+
+    g = triangulene(3, atoms=["B", "N"], vacuum=vacuum)
     assert g.atoms.nspecies == 2
-    g = triangulene(3, bond=1.6)
+    assert is_right_handed(g)
+    assert has_vacuum(g, vacuum)
 
 
-def test_nanotube():
-    a = nanotube(1.42)
+@pytest.mark.parametrize(
+    "vacuum",
+    [10, (30, 10)],
+)
+def test_nanotube(vacuum):
+    a = nanotube(1.42, vacuum=vacuum)
     assert is_right_handed(a)
-    a = nanotube(1.42, chirality=(3, 5))
+    assert has_vacuum(a, vacuum)
+    a = nanotube(1.42, chirality=(3, 5), vacuum=vacuum)
     assert is_right_handed(a)
-    a = nanotube(1.42, chirality=(6, -3))
+    assert has_vacuum(a, vacuum)
+    a = nanotube(1.42, chirality=(6, -3), vacuum=vacuum)
     assert is_right_handed(a)
+    assert has_vacuum(a, vacuum)
 
 
 def test_diamond():
@@ -99,9 +135,18 @@ def test_diamond():
     assert is_right_handed(a)
 
 
-def test_bilayer():
-    a = bilayer(1.42)
+@pytest.mark.parametrize(
+    "vacuum",
+    [10, 30],
+)
+def test_bilayer(vacuum):
+    a = bilayer(1.42, vacuum=vacuum)
     assert is_right_handed(a)
+    assert has_vacuum(a, vacuum)
+
+
+def test_bilayer_arguments():
+    # Just test arguments
     bilayer(1.42, stacking="AA")
     bilayer(1.42, stacking="BA")
     bilayer(1.42, stacking="AB")
@@ -123,15 +168,24 @@ def test_bilayer():
         bilayer(1.42, twist=("str", 7), stacking="undefined")
 
 
-def test_nanoribbon():
+@pytest.mark.parametrize(
+    "vacuum",
+    [10, (30, 10)],
+)
+def test_nanoribbon(vacuum):
+    for w in range(0, 5):
+        a = nanoribbon(w, 1.42, (Atom(5), Atom(7)), kind="zigzag", vacuum=vacuum)
+        assert is_right_handed(a)
+        assert has_vacuum(a, vacuum)
+
+
+def test_nanoribbon_arguments():
     for w in range(0, 5):
         nanoribbon(w, 1.42, Atom(6), kind="armchair")
         nanoribbon(w, 1.42, Atom(6), kind="zigzag")
         nanoribbon(w, 1.42, Atom(6), kind="chiral")
         nanoribbon(w, 1.42, Atom(6), kind="chiral", chirality=(2, 2))
         nanoribbon(w, 1.42, (Atom(5), Atom(7)), kind="armchair")
-        a = nanoribbon(w, 1.42, (Atom(5), Atom(7)), kind="zigzag")
-        assert is_right_handed(a)
 
     with pytest.raises(ValueError):
         nanoribbon(6, 1.42, (Atom(5), Atom(7)), kind="undefined")
@@ -142,27 +196,36 @@ def test_nanoribbon():
 
 def test_graphene_nanoribbon():
     graphene_nanoribbon(6, kind="armchair")
-    graphene_nanoribbon(6, kind="zigzag")
-    graphene_nanoribbon(6, kind="chiral")
-    a = graphene_nanoribbon(5)
+
+
+@pytest.mark.parametrize(
+    "vacuum",
+    [10, (30, 10)],
+)
+def test_agnr(vacuum):
+    a = agnr(5, vacuum=vacuum)
     assert is_right_handed(a)
+    assert has_vacuum(a, vacuum)
 
 
-def test_agnr():
-    a = agnr(5)
+@pytest.mark.parametrize(
+    "vacuum",
+    [10, (30, 10)],
+)
+def test_zgnr(vacuum):
+    a = zgnr(5, vacuum=vacuum)
     assert is_right_handed(a)
+    assert has_vacuum(a, vacuum)
 
 
-def test_zgnr():
-    a = zgnr(5)
+@pytest.mark.parametrize(
+    "vacuum",
+    [10, (30, 10)],
+)
+def test_cgnr(vacuum):
+    a = cgnr(6, (3, 1), atoms=["B", "N"], vacuum=vacuum)
     assert is_right_handed(a)
-
-
-def test_cgnr():
-    cgnr(6, (3, 1), vacuum=0)
-    cgnr(6, (3, 1), bond=1.6)
-    a = cgnr(6, (3, 1), atoms=["B", "N"])
-    assert is_right_handed(a)
+    assert has_vacuum(a, vacuum)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is a long saught solution to fix vacuum lengths by enabling users to control them.

@tfrederiksen @pfebrer I hope this covers everything, without breaking stuff...
I don't know if this should be moved to the `_common.py` file, perhaps it should... Well...

Let me know if this is ok, as is, or something is not covered.
<!-- Feel free to remove check-list items aren't relevant to your change -->
