### PR TITLE
fixing many simple PEP-585 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ we hit release version 1.0.0.
 - A new `AtomicMatrixPlot` to plot sparse matrices, #668
 
 ### Fixed
+- PEP-585 compliant
 - buildable for numpy>2, #791
 - `BrillouinZone.tocartesian()` now defaults to `k=self.k`
 - reading XV/STRUCT files from fdf siles could cause problems, #778

--- a/benchmarks/bz_parallel.py
+++ b/benchmarks/bz_parallel.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import os
 import sys
-import time
 
 import numpy as np
 

--- a/benchmarks/graphene_within.py
+++ b/benchmarks/graphene_within.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 
 import sys
 
-import numpy as np
-
 import sisl
 
 method = "cube"

--- a/benchmarks/sparse_matrices.py
+++ b/benchmarks/sparse_matrices.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import cProfile
-import io
 import pstats
 import sys
 

--- a/src/sisl/_core/_ufuncs_geometry.py
+++ b/src/sisl/_core/_ufuncs_geometry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from functools import reduce
 from numbers import Integral
-from typing import Callable, List, Literal, Optional, Tuple, Union
+from typing import Callable, Literal, Optional, Union
 
 import numpy as np
 
@@ -166,7 +166,7 @@ def apply(
 @register_sisl_dispatch(Geometry, module="sisl")
 def sort(
     geometry: Geometry, **kwargs
-) -> Union[Geometry, Tuple[Geometry, List[List[int]]]]:
+) -> Union[Geometry, tuple[Geometry, list[list[int]]]]:
     r"""Sort atoms in a nested fashion according to various criteria
 
     There are many ways to sort a `Geometry`.

--- a/src/sisl/_core/_ufuncs_grid.py
+++ b/src/sisl/_core/_ufuncs_grid.py
@@ -3,14 +3,15 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import numpy as np
 
 import sisl._array as _a
 from sisl._ufuncs import register_sisl_dispatch
 from sisl.messages import SislError
-from sisl.typing import CellAxes, CellAxis, GridLike, SileLike
+from sisl.typing import CellAxis, GridLike, SileLike
 from sisl.utils import import_attr
 from sisl.utils.misc import direction
 

--- a/src/sisl/_core/_ufuncs_lattice.py
+++ b/src/sisl/_core/_ufuncs_lattice.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import math
 from functools import reduce
 from numbers import Integral
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 

--- a/src/sisl/_core/_ufuncs_orbital.py
+++ b/src/sisl/_core/_ufuncs_orbital.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import numpy as np
-
 from sisl._ufuncs import register_sisl_dispatch
 
 from .orbital import (

--- a/src/sisl/_core/_ufuncs_sparse.py
+++ b/src/sisl/_core/_ufuncs_sparse.py
@@ -3,13 +3,5 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import numpy as np
-
-from sisl._indices import indices
-from sisl._ufuncs import register_sisl_dispatch
-from sisl.typing import SparseMatrixExt
-
-from .sparse import SparseCSR
-
 # Nothing gets exposed here
 __all__ = []

--- a/src/sisl/_core/_ufuncs_sparse_geometry.py
+++ b/src/sisl/_core/_ufuncs_sparse_geometry.py
@@ -8,11 +8,10 @@ from functools import partial
 import numpy as np
 
 from sisl import _array as _a
-from sisl._core.geometry import Geometry
 from sisl._ufuncs import register_sisl_dispatch
 from sisl.typing import AtomsIndex
 
-from .sparse import SparseCSR, _ncol_to_indptr, issparse
+from .sparse import SparseCSR, _ncol_to_indptr
 from .sparse_geometry import SparseAtom, SparseOrbital, _SparseGeometry
 
 # Nothing gets exposed here

--- a/src/sisl/_core/grid.py
+++ b/src/sisl/_core/grid.py
@@ -1709,7 +1709,7 @@ def sgrid(grid=None, argv=None, ret_grid=False):
     import sys
     from pathlib import Path
 
-    from sisl.io import BaseSile, get_sile
+    from sisl.io import BaseSile
 
     # The file *MUST* be the first argument
     # (except --help|-h)
@@ -1757,7 +1757,6 @@ This may be unexpected but enables one to do advanced manipulations.
     # First read the input "Sile"
     stdout_grid = True
     if grid is None:
-        from os.path import isfile
 
         argv, input_file = cmd.collect_input(argv)
 

--- a/src/sisl/_core/lattice.py
+++ b/src/sisl/_core/lattice.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 
 import logging
 import math
+from collections.abc import Sequence
 from enum import IntEnum, auto
 from numbers import Integral
 from pathlib import Path
-from typing import Optional, Sequence, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 from numpy import dot, ndarray
@@ -349,7 +350,7 @@ class Lattice(
 
     def parameters(
         self, rad: bool = False
-    ) -> Tuple[float, float, float, float, float, float]:
+    ) -> tuple[float, float, float, float, float, float]:
         r"""Cell parameters of this cell in 3 lengths and 3 angles
 
         Notes
@@ -609,7 +610,7 @@ class Lattice(
 
     def plane(
         self, axis1: CellAxis, axis2: CellAxis, origin: bool = True
-    ) -> Tuple[ndarray, ndarray]:
+    ) -> tuple[ndarray, ndarray]:
         """Query point and plane-normal for the plane spanning `ax1` and `ax2`
 
         Parameters
@@ -755,7 +756,7 @@ class Lattice(
 
         return self.cell[axes] * (length / self.length[axes]).reshape(-1, 1)
 
-    def offset(self, isc=None) -> Tuple[float, float, float]:
+    def offset(self, isc=None) -> tuple[float, float, float]:
         """Returns the supercell offset of the supercell index"""
         if isc is None:
             return _a.arrayd([0, 0, 0])

--- a/src/sisl/_core/orbital.py
+++ b/src/sisl/_core/orbital.py
@@ -4,18 +4,16 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from collections.abc import Iterable
 from functools import partial
 from math import factorial as fact
 from math import pi
 from math import sqrt as msqrt
 from numbers import Integral, Real
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional
 
 import numpy as np
 import numpy.typing as npt
-import scipy
-from numpy import cos, sin, sqrt, square, take
+from numpy import cos, sin, take
 from scipy.special import eval_genlaguerre, factorial, lpmv
 
 try:
@@ -341,7 +339,7 @@ RadialFuncT = Callable[[npt.ArrayLike], npt.NDArray]
 def radial_minimize_range(
     radial_func: Callable[[RadialFuncT], npt.NDArray],
     contains: float,
-    dr: Tuple[float, float] = (0.01, 0.0001),
+    dr: tuple[float, float] = (0.01, 0.0001),
     maxR: float = 100,
     func: Optional[Callable[[RadialFuncT, npt.ArrayLike], npt.NDArray]] = None,
 ) -> float:

--- a/src/sisl/_core/sparse_geometry.py
+++ b/src/sisl/_core/sparse_geometry.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import functools as ftool
 import warnings
 from collections import namedtuple
 from numbers import Integral

--- a/src/sisl/_core/tests/test_atom.py
+++ b/src/sisl/_core/tests/test_atom.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 

--- a/src/sisl/_core/tests/test_atoms.py
+++ b/src/sisl/_core/tests/test_atoms.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 

--- a/src/sisl/_core/tests/test_geometry.py
+++ b/src/sisl/_core/tests/test_geometry.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 
 import itertools
-import math as m
-import os.path as osp
 
 import numpy as np
 import pytest

--- a/src/sisl/_core/tests/test_geometry_return.py
+++ b/src/sisl/_core/tests/test_geometry_return.py
@@ -3,13 +3,12 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
 from numbers import Integral, Real
 
 import numpy as np
 import pytest
 
-from sisl import Atom, Geometry, Lattice, Sphere
+from sisl import Atom, Geometry, Lattice
 
 
 @pytest.fixture

--- a/src/sisl/_core/tests/test_grid.py
+++ b/src/sisl/_core/tests/test_grid.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 from scipy.sparse import csr_matrix
@@ -18,7 +16,6 @@ from sisl import (
     Lattice,
     SislError,
     SislWarning,
-    SphericalOrbital,
     geom,
 )
 

--- a/src/sisl/_core/tests/test_oplist.py
+++ b/src/sisl/_core/tests/test_oplist.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import operator as ops
 
-import numpy as np
 import pytest
 
 from sisl import _array as ar

--- a/src/sisl/_core/tests/test_orbital.py
+++ b/src/sisl/_core/tests/test_orbital.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 from scipy import interpolate as interp

--- a/src/sisl/_core/tests/test_quaternion.py
+++ b/src/sisl/_core/tests/test_quaternion.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
-import numpy as np
 import pytest
 
 from sisl import Quaternion

--- a/src/sisl/_core/tests/test_sgeom.py
+++ b/src/sisl/_core/tests/test_sgeom.py
@@ -1,8 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
-
-import math as m
 
 import numpy as np
 import pytest

--- a/src/sisl/_core/tests/test_sgrid.py
+++ b/src/sisl/_core/tests/test_sgrid.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/_core/tests/test_sparse.py
+++ b/src/sisl/_core/tests/test_sparse.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
 import operator
 import sys
 

--- a/src/sisl/_core/tests/test_sparse_geometry.py
+++ b/src/sisl/_core/tests/test_sparse_geometry.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 import scipy as sc

--- a/src/sisl/_core/tests/test_sparse_orbital.py
+++ b/src/sisl/_core/tests/test_sparse_orbital.py
@@ -3,11 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
-import scipy as sc
 
 import sisl.messages as sm
 from sisl import Atom, Cuboid, Geometry, Lattice

--- a/src/sisl/_dispatch_class.py
+++ b/src/sisl/_dispatch_class.py
@@ -4,12 +4,10 @@
 from __future__ import annotations
 
 import logging
-from collections import namedtuple
-from typing import Any, Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import Any, Optional, Union
 
-from sisl.utils._search_mro import find_implementation
-
-from ._dispatcher import AbstractDispatcher, ClassDispatcher, TypeDispatcher
+from ._dispatcher import ClassDispatcher
 
 """Internal class used for subclassing.
 

--- a/src/sisl/_help.py
+++ b/src/sisl/_help.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import functools
+import importlib.util
 import warnings
 
 import numpy as np
@@ -14,7 +15,7 @@ __all__ = ["array_fill_repeat"]
 __all__ += ["isndarray", "isiterable", "voigt_matrix"]
 __all__ += ["get_dtype"]
 __all__ += ["dtype_complex_to_real", "dtype_real_to_complex"]
-__all__ += ["wrap_filterwarnings"]
+__all__ += ["wrap_filterwarnings", "has_module"]
 
 # Wrappers typically used
 __all__ += ["xml_parse"]
@@ -36,6 +37,11 @@ try:
         raise ImportError
 except ImportError:
     from xml.etree.ElementTree import parse as xml_parse
+
+
+def has_module(*args, **kwargs) -> bool:
+    """Wrapper for `importlib.util.find_spec`"""
+    return importlib.util.find_spec(*args, **kwargs)
 
 
 def array_fill_repeat(array, size, axis=-1, cls=None):

--- a/src/sisl/_internal.py
+++ b/src/sisl/_internal.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 r""" Internal sisl-only methods that should not be used outside """
-import sys
 
 # override module level, inspired by numpy
 

--- a/src/sisl/_lazy_viz.py
+++ b/src/sisl/_lazy_viz.py
@@ -30,7 +30,7 @@ class PlotHandlerPlaceholder:
     def __get__(self, instance, owner):
         # Import sisl.viz, which will remove all the placeholders and
         # set the actual plot handlers as the "plot" attribute.
-        import sisl.viz
+        import sisl.viz  # noqa: F401
 
         # Return the plot handler
         if instance is None:

--- a/src/sisl/_nodify.py
+++ b/src/sisl/_nodify.py
@@ -1,7 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-from typing import List
 
 import sisl
 
@@ -9,7 +8,7 @@ import sisl
 def on_nodify():
     from nodify.server.session import register_file_plot_handler
 
-    def _get_plot_options(file_name: str) -> List[str]:
+    def _get_plot_options(file_name: str) -> list[str]:
         try:
             plot_handler = sisl.get_sile(file_name).plot
         except:

--- a/src/sisl/_sparse_grid.py
+++ b/src/sisl/_sparse_grid.py
@@ -1,4 +1,7 @@
-from typing import Optional, Tuple, Union
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from typing import Optional, Union
 
 import numpy as np
 from scipy.sparse import issparse, spmatrix
@@ -56,7 +59,7 @@ class Sparse4DGrid:
         return new_indices, new_shape
 
     def reduce_dimension(
-        self, weights: Optional[np.ndarray] = None, reduce_grid: Tuple[int, ...] = ()
+        self, weights: Optional[np.ndarray] = None, reduce_grid: tuple[int, ...] = ()
     ) -> Union[Grid, np.ndarray]:
         """Reduces the extra dimension on the grid, possibly applying weights.
 
@@ -258,7 +261,7 @@ class SparseGridOrbitalBZ(Sparse4DGrid):
         return Overlap.fromsp(self.geometry, overlap * dvolume)
 
     def reduce_orbitals(
-        self, weights: np.ndarray, k: Tuple[float, float, float] = (0, 0, 0), **kwargs
+        self, weights: np.ndarray, k: tuple[float, float, float] = (0, 0, 0), **kwargs
     ) -> Union[Grid, np.ndarray]:
         """Reduces the orbitals dimension, applying phases if needed.
 
@@ -320,7 +323,7 @@ class SparseGridOrbitalBZ(Sparse4DGrid):
         self,
         weights: Union[np.ndarray, SparseCSR, spmatrix],
         weights_lattice: Lattice,
-        reduce_grid: Tuple[int, ...] = (),
+        reduce_grid: tuple[int, ...] = (),
         out: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """Reduces the orbital dimension by taking products of orbitals with weights.

--- a/src/sisl/_ufuncs.py
+++ b/src/sisl/_ufuncs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from functools import singledispatch
 from textwrap import dedent
-from typing import Callable, Optional
+from typing import Optional
 
 from sisl.messages import SislError, warn
 from sisl.typing import FuncType

--- a/src/sisl/conftest.py
+++ b/src/sisl/conftest.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 
 from sisl import Atom, Geometry, Hamiltonian, Lattice, _environ
+from sisl._help import has_module
 
 # Here we create the necessary methods and fixtures to enabled/disable
 # tests depending on whether a sisl-files directory is present.
@@ -227,9 +228,7 @@ collect_ignore_glob = []
 # We are ignoring stuff in sisl.viz if nodify cannot be imported
 # skip paths
 _skip_paths = []
-try:
-    import nodify
-except ImportError:
+if not has_module("nodify"):
     _skip_paths.append(os.path.join("sisl", "viz"))
 
 

--- a/src/sisl/geom/_category/_coord.py
+++ b/src/sisl/geom/_category/_coord.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import operator
 from functools import wraps
 from numbers import Integral
-from typing import Optional
 
 import numpy as np
 

--- a/src/sisl/geom/_category/_kind.py
+++ b/src/sisl/geom/_category/_kind.py
@@ -7,7 +7,7 @@ import operator as op
 import re
 from functools import reduce, wraps
 from numbers import Integral
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 

--- a/src/sisl/geom/_category/_neighbors.py
+++ b/src/sisl/geom/_category/_neighbors.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Optional
-
 from numpy import ndarray
 
 from sisl._core import Geometry

--- a/src/sisl/geom/_category/base.py
+++ b/src/sisl/geom/_category/base.py
@@ -4,9 +4,8 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import Optional
 
-from sisl._category import Category, NullCategory
+from sisl._category import NullCategory
 from sisl._core import AtomCategory, Geometry
 from sisl.typing import AtomsIndex
 

--- a/src/sisl/geom/_neighbors/_finder.py
+++ b/src/sisl/geom/_neighbors/_finder.py
@@ -3,7 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import Optional, Union
 
 import numpy as np
 
@@ -116,9 +117,9 @@ class NeighborFinder:
     """
 
     #: Memory control of the finder
-    memory: Tuple[str, float] = ("200MB", 1.5)
+    memory: tuple[str, float] = ("200MB", 1.5)
     #: Number of bins along each cell direction
-    nbins: Tuple[int, int, int]
+    nbins: tuple[int, int, int]
     #: Total number of bins
     total_nbins: int
 
@@ -143,7 +144,7 @@ class NeighborFinder:
         geometry: Geometry,
         R: Optional[Union[float, np.ndarray]] = None,
         overlap: bool = False,
-        bin_size: Union[float, Tuple[float, float, float]] = 2,
+        bin_size: Union[float, tuple[float, float, float]] = 2,
     ):
         self.setup(geometry, R=R, overlap=overlap, bin_size=bin_size)
 
@@ -152,7 +153,7 @@ class NeighborFinder:
         geometry: Optional[Geometry] = None,
         R: Optional[Union[float, np.ndarray]] = None,
         overlap: bool = None,
-        bin_size: Union[float, Tuple[float, float, float]] = 2,
+        bin_size: Union[float, tuple[float, float, float]] = 2,
     ):
         """Prepares everything for neighbor finding.
 

--- a/src/sisl/geom/flat.py
+++ b/src/sisl/geom/flat.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -23,7 +23,7 @@ __all__ = [
     "goldene",
 ]
 
-FloatOrFloat3 = Union[float, Tuple[float, float, float]]
+FloatOrFloat3 = Union[float, tuple[float, float, float]]
 
 
 @set_module("sisl.geom")

--- a/src/sisl/geom/nanoribbon.py
+++ b/src/sisl/geom/nanoribbon.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from numbers import Integral
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -26,7 +26,7 @@ __all__ = [
     "graphene_heteroribbon",
 ]
 
-FloatOrFloat2 = Union[float, Tuple[float, float]]
+FloatOrFloat2 = Union[float, tuple[float, float]]
 
 
 @set_module("sisl.geom")
@@ -36,7 +36,7 @@ def nanoribbon(
     atoms: AtomsLike,
     kind: Literal["armchair", "zigzag", "chiral"] = "armchair",
     vacuum: FloatOrFloat2 = 20.0,
-    chirality: Tuple[int, int] = (3, 1),
+    chirality: tuple[int, int] = (3, 1),
 ) -> Geometry:
     r"""Construction of a nanoribbon unit cell of type armchair, zigzag or (n,m)-chiral.
 
@@ -162,7 +162,7 @@ def graphene_nanoribbon(
     atoms: Optional[AtomsLike] = None,
     kind: Literal["armchair", "zigzag", "chiral"] = "armchair",
     vacuum: FloatOrFloat2 = 20.0,
-    chirality: Tuple[int, int] = (3, 1),
+    chirality: tuple[int, int] = (3, 1),
 ) -> Geometry:
     r"""Construction of a graphene nanoribbon
 
@@ -262,7 +262,7 @@ def zgnr(
 @set_module("sisl.geom")
 def cgnr(
     width: int,
-    chirality: Tuple[int, int],
+    chirality: tuple[int, int],
     bond: float = 1.42,
     atoms: Optional[AtomsLike] = None,
     vacuum: FloatOrFloat2 = 20.0,

--- a/src/sisl/geom/nanotube.py
+++ b/src/sisl/geom/nanotube.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -15,14 +15,14 @@ from ._common import geometry_define_nsc
 
 __all__ = ["nanotube"]
 
-FloatOrFloat2 = Union[float, Tuple[float, float]]
+FloatOrFloat2 = Union[float, tuple[float, float]]
 
 
 @set_module("sisl.geom")
 def nanotube(
     bond: float,
     atoms: Optional[AtomsLike] = None,
-    chirality: Tuple[int, int] = (1, 1),
+    chirality: tuple[int, int] = (1, 1),
     vacuum: FloatOrFloat2 = 20.0,
 ) -> Geometry:
     """Nanotube with user-defined chirality.

--- a/src/sisl/geom/surfaces.py
+++ b/src/sisl/geom/surfaces.py
@@ -4,9 +4,10 @@
 from __future__ import annotations
 
 from collections import namedtuple
+from collections.abc import Sequence
 from itertools import groupby
 from numbers import Integral
-from typing import Sequence, Tuple, Union
+from typing import Union
 
 import numpy as np
 
@@ -306,7 +307,7 @@ def _slab_with_vacuum(func, *args, **kwargs):
 def fcc_slab(
     alat: float,
     atoms: AtomsLike,
-    miller: Union[int, str, Tuple[int, int, int]],
+    miller: Union[int, str, tuple[int, int, int]],
     layers=None,
     vacuum: Union[float, Sequence[float]] = 20.0,
     *,
@@ -508,7 +509,7 @@ def fcc_slab(
 def bcc_slab(
     alat: float,
     atoms: AtomsLike,
-    miller: Union[int, str, Tuple[int, int, int]],
+    miller: Union[int, str, tuple[int, int, int]],
     layers=None,
     vacuum: Union[float, Sequence[float]] = 20.0,
     *,
@@ -672,7 +673,7 @@ def bcc_slab(
 def rocksalt_slab(
     alat: float,
     atoms: AtomsLike,
-    miller: Union[int, str, Tuple[int, int, int]],
+    miller: Union[int, str, tuple[int, int, int]],
     layers=None,
     vacuum: Union[float, Sequence[float]] = 20.0,
     *,

--- a/src/sisl/geom/tests/test_geom.py
+++ b/src/sisl/geom/tests/test_geom.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import itertools
-import math as m
 from functools import partial
 
 import numpy as np

--- a/src/sisl/io/_exceptions.py
+++ b/src/sisl/io/_exceptions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import warnings
 from functools import wraps
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 from sisl._internal import set_module
 from sisl.messages import SislError, SislException, SislInfo, SislWarning, info, warn
@@ -50,7 +50,7 @@ class SileInfo(SislInfo):
     """Information for the user, this is hidden in a warning, but is not as severe so as to issue a warning."""
 
 
-InputsType = Optional[Union[List[Tuple[str, str]], List[str], str]]
+InputsType = Optional[Union[list[tuple[str, str]], list[str], str]]
 
 
 class MissingInputSileException(SislException):

--- a/src/sisl/io/_help.py
+++ b/src/sisl/io/_help.py
@@ -3,8 +3,9 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
+from collections.abc import Sequence
 from re import compile as re_compile
-from typing import List, Optional, Sequence, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -136,7 +137,7 @@ def parse_order(
     return order
 
 
-def _fill_basis_empty(sp: np.ndarray, basis: List[Atom], start_Z=1000) -> Atoms:
+def _fill_basis_empty(sp: np.ndarray, basis: list[Atom], start_Z=1000) -> Atoms:
     """Adds atoms in `basis` with ``AtomUnknown(start_Z + species_idx)``
 
     This is useful when one does not have the required atom in the basis,

--- a/src/sisl/io/_multiple.py
+++ b/src/sisl/io/_multiple.py
@@ -7,7 +7,7 @@ from functools import reduce, update_wrapper
 from itertools import zip_longest
 from numbers import Integral
 from textwrap import dedent
-from typing import Any, Callable, Optional, Type
+from typing import Any, Callable, Optional
 
 Func = Callable[..., Optional[Any]]
 
@@ -54,9 +54,9 @@ class SileSlicer:
 
     def __init__(
         self,
-        obj: Type[Any],
+        obj: type[Any],
         func: Func,
-        key: Type[Any],
+        key: type[Any],
         *,
         check_empty: Optional[Func] = None,
         skip_func: Optional[Func] = None,
@@ -170,10 +170,10 @@ class SileBound:
 
     def __init__(
         self,
-        obj: Type[Any],
+        obj: type[Any],
         func: Callable[..., Any],
         *,
-        slicer: Type[SileSlicer] = SileSlicer,
+        slicer: type[SileSlicer] = SileSlicer,
         default_slice: Optional[Any] = None,
         **kwargs,
     ):

--- a/src/sisl/io/dftb/tests/test_realdat.py
+++ b/src/sisl/io/dftb/tests/test_realdat.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 """ pytest test configures """
 
-import os.path as osp
 
 import numpy as np
 import pytest

--- a/src/sisl/io/fhiaims/tests/test_in.py
+++ b/src/sisl/io/fhiaims/tests/test_in.py
@@ -3,12 +3,10 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 
-from sisl import Atom, Geometry
+from sisl import Atom
 from sisl.io.fhiaims._geometry import *
 
 pytestmark = [pytest.mark.io, pytest.mark.fhiaims, pytest.mark.aims]

--- a/src/sisl/io/gulp/got.py
+++ b/src/sisl/io/gulp/got.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from sisl import Atom, Geometry, Lattice, Orbital, constant, units
 from sisl._internal import set_module
-from sisl.messages import deprecate_argument, deprecation, info, warn
+from sisl.messages import deprecation, info, warn
 from sisl.physics import DynamicalMatrix
 
 from .._help import parse_order

--- a/src/sisl/io/gulp/tests/test_gout.py
+++ b/src/sisl/io/gulp/tests/test_gout.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 """ pytest test configures """
 
-import os.path as osp
 
 import numpy as np
 import pytest

--- a/src/sisl/io/orca/tests/test_stdout.py
+++ b/src/sisl/io/orca/tests/test_stdout.py
@@ -3,14 +3,9 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-import sys
-
-import numpy as np
 import pytest
 from pytest import approx
 
-import sisl
 from sisl.io.orca.stdout import *
 
 pytestmark = [pytest.mark.io, pytest.mark.orca]

--- a/src/sisl/io/orca/tests/test_txt.py
+++ b/src/sisl/io/orca/tests/test_txt.py
@@ -3,13 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-import sys
-
-import numpy as np
 import pytest
 
-import sisl
 from sisl.io.orca.txt import *
 
 pytestmark = [pytest.mark.io, pytest.mark.orca]

--- a/src/sisl/io/orca/txt.py
+++ b/src/sisl/io/orca/txt.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import List
-
 import numpy as np
 
 from sisl._core.geometry import Geometry
@@ -215,7 +213,7 @@ class txtSileORCA(SileORCA):
         return G
 
     @sile_fh_open()
-    def read_hyperfine_coupling(self, units: UnitsVar = "eV") -> List[PropertyDict]:
+    def read_hyperfine_coupling(self, units: UnitsVar = "eV") -> list[PropertyDict]:
         r"""Reads hyperfine couplings from the ``EPRNMR_ATensor`` block
 
         For a nucleus :math:`k`, the hyperfine interaction is usually

--- a/src/sisl/io/pdb.py
+++ b/src/sisl/io/pdb.py
@@ -9,7 +9,7 @@ Sile object for reading/writing PDB files
 
 import numpy as np
 
-from sisl import Atom, Atoms, Geometry, Lattice
+from sisl import Geometry, Lattice
 from sisl._internal import set_module
 from sisl.messages import deprecate_argument
 

--- a/src/sisl/io/scaleup/rham.py
+++ b/src/sisl/io/scaleup/rham.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Optional
-
 import numpy as np
 from scipy.sparse import lil_matrix
 

--- a/src/sisl/io/siesta/_help.py
+++ b/src/sisl/io/siesta/_help.py
@@ -3,12 +3,9 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import warnings
-
 import numpy as np
 
 import sisl._array as _a
-from sisl import SislError
 from sisl.messages import warn
 
 __all__ = ["_siesta_sc_off"]

--- a/src/sisl/io/siesta/binaries.py
+++ b/src/sisl/io/siesta/binaries.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from collections import deque, namedtuple
 from itertools import product
 from numbers import Integral
-from typing import Optional, Tuple
+from typing import Optional
 
 import numpy as np
 
@@ -2433,7 +2433,7 @@ class _gfSileSiesta(SileBinSiesta):
 
         return mem
 
-    def read_hamiltonian(self) -> Tuple[np.ndarray, np.ndarray]:
+    def read_hamiltonian(self) -> tuple[np.ndarray, np.ndarray]:
         """Return current Hamiltonian and overlap matrix from the GF file
 
         Returns
@@ -2467,7 +2467,7 @@ class _gfSileSiesta(SileBinSiesta):
         # we don't convert to C order!
         return SE * _Ry2eV
 
-    def HkSk(self, k=(0, 0, 0), spin: int = 0) -> Tuple[np.ndarray, np.ndarray]:
+    def HkSk(self, k=(0, 0, 0), spin: int = 0) -> tuple[np.ndarray, np.ndarray]:
         """Retrieve H and S for the given k-point
 
         Parameters

--- a/src/sisl/io/siesta/fdf.py
+++ b/src/sisl/io/siesta/fdf.py
@@ -27,6 +27,7 @@ from sisl import (
     SphericalOrbital,
     constant,
 )
+from sisl._help import has_module
 from sisl._indices import indices_only
 from sisl._internal import set_module
 from sisl.messages import SislError, deprecate_argument, deprecation, info, warn
@@ -41,7 +42,6 @@ from .._help import *
 from ..sile import (
     SileCDF,
     SileError,
-    _import_netCDF4,
     add_sile,
     get_sile_class,
     sile_fh_open,
@@ -79,9 +79,7 @@ _log = logging.getLogger(__name__)
 
 def _order_remove_netcdf(order):
     """Removes the order elements that refer to siles based on NetCDF"""
-    try:
-        _import_netCDF4()
-    except SileError:
+    if not has_module("netCDF4"):
         # We got an import error
         def accept(suffix):
             try:

--- a/src/sisl/io/siesta/orb_indx.py
+++ b/src/sisl/io/siesta/orb_indx.py
@@ -7,15 +7,7 @@ from typing import Optional, Union
 
 import numpy as np
 
-from sisl import (
-    Atom,
-    AtomicOrbital,
-    Atoms,
-    AtomUnknown,
-    Geometry,
-    Orbital,
-    PeriodicTable,
-)
+from sisl import Atom, AtomicOrbital, Atoms, AtomUnknown, Geometry, PeriodicTable
 from sisl._array import arrayi
 from sisl._internal import set_module
 from sisl.messages import deprecate_argument

--- a/src/sisl/io/siesta/siesta_grid.py
+++ b/src/sisl/io/siesta/siesta_grid.py
@@ -14,7 +14,7 @@ from sisl.messages import deprecate_argument, info
 from sisl.unit.siesta import unit_convert
 
 from .._help import grid_reduce_indices
-from ..sile import SileError, add_sile, sile_raise_write
+from ..sile import add_sile, sile_raise_write
 from .sile import SileCDFSiesta
 
 __all__ = ["gridncSileSiesta"]

--- a/src/sisl/io/siesta/siesta_nc.py
+++ b/src/sisl/io/siesta/siesta_nc.py
@@ -18,7 +18,6 @@ from sisl.physics import (
     DynamicalMatrix,
     EnergyDensityMatrix,
     Hamiltonian,
-    SparseOrbitalBZ,
 )
 from sisl.physics.overlap import Overlap
 from sisl.unit.siesta import unit_convert

--- a/src/sisl/io/siesta/tests/test_ani.py
+++ b/src/sisl/io/siesta/tests/test_ani.py
@@ -3,12 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
-import numpy as np
 import pytest
 
-from sisl import Geometry
 from sisl.io.siesta import aniSileSiesta
 
 pytestmark = [pytest.mark.io, pytest.mark.siesta]

--- a/src/sisl/io/siesta/tests/test_bands.py
+++ b/src/sisl/io/siesta/tests/test_bands.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 """ pytest test configures """
 
-import os.path as osp
 
 import pytest
 

--- a/src/sisl/io/siesta/tests/test_basis.py
+++ b/src/sisl/io/siesta/tests/test_basis.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
 from io import StringIO
 
 import pytest

--- a/src/sisl/io/siesta/tests/test_dm.py
+++ b/src/sisl/io/siesta/tests/test_dm.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 """ pytest test configures """
 
-import os.path as osp
 
 import numpy as np
 import pytest

--- a/src/sisl/io/siesta/tests/test_eig.py
+++ b/src/sisl/io/siesta/tests/test_eig.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/siesta/tests/test_fa.py
+++ b/src/sisl/io/siesta/tests/test_fa.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/siesta/tests/test_fc.py
+++ b/src/sisl/io/siesta/tests/test_fc.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/siesta/tests/test_fdf.py
+++ b/src/sisl/io/siesta/tests/test_fdf.py
@@ -3,14 +3,13 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
 from pathlib import Path
 
 import numpy as np
 import pytest
 
 import sisl
-from sisl import Atom, AtomUnknown, Geometry, geom
+from sisl import geom
 from sisl.io import SileError, fdfSileSiesta
 from sisl.messages import SislWarning
 from sisl.unit.siesta import unit_convert

--- a/src/sisl/io/siesta/tests/test_gf.py
+++ b/src/sisl/io/siesta/tests/test_gf.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/siesta/tests/test_grid.py
+++ b/src/sisl/io/siesta/tests/test_grid.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/siesta/tests/test_hsx.py
+++ b/src/sisl/io/siesta/tests/test_hsx.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-import re
 import warnings
 
 import numpy as np

--- a/src/sisl/io/siesta/tests/test_orb_indx.py
+++ b/src/sisl/io/siesta/tests/test_orb_indx.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/siesta/tests/test_pdos.py
+++ b/src/sisl/io/siesta/tests/test_pdos.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 """ pytest test configures """
 
-import os.path as osp
 
 import numpy as np
 import pytest

--- a/src/sisl/io/siesta/tests/test_siesta.py
+++ b/src/sisl/io/siesta/tests/test_siesta.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/siesta/tests/test_stdout.py
+++ b/src/sisl/io/siesta/tests/test_stdout.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-import sys
-
 import numpy as np
 import pytest
 from pytest import approx

--- a/src/sisl/io/siesta/tests/test_stdout_charges.py
+++ b/src/sisl/io/siesta/tests/test_stdout_charges.py
@@ -3,10 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-import sys
-from itertools import product
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/siesta/tests/test_struct.py
+++ b/src/sisl/io/siesta/tests/test_struct.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/siesta/tests/test_tsde.py
+++ b/src/sisl/io/siesta/tests/test_tsde.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 """ pytest test configures """
 
-import os.path as osp
 
 import numpy as np
 import pytest

--- a/src/sisl/io/siesta/tests/test_tshs.py
+++ b/src/sisl/io/siesta/tests/test_tshs.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 """ pytest test configures """
 
-import os.path as osp
 
 import numpy as np
 import pytest

--- a/src/sisl/io/siesta/tests/test_vibra.py
+++ b/src/sisl/io/siesta/tests/test_vibra.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/siesta/tests/test_wfsx.py
+++ b/src/sisl/io/siesta/tests/test_wfsx.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
-import numpy as np
 import pytest
 
 import sisl

--- a/src/sisl/io/siesta/tests/test_xv.py
+++ b/src/sisl/io/siesta/tests/test_xv.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/siesta/transiesta_grid.py
+++ b/src/sisl/io/siesta/transiesta_grid.py
@@ -11,7 +11,6 @@ from sisl.unit.siesta import unit_convert
 
 from ..sile import add_sile, sile_raise_write
 from .siesta_grid import gridncSileSiesta
-from .sile import SileCDFSiesta
 
 __all__ = ["tsvncSileSiesta"]
 

--- a/src/sisl/io/siesta/vibra.py
+++ b/src/sisl/io/siesta/vibra.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import re
-from typing import Iterator
+from collections.abc import Iterator
 
 import numpy as np
 

--- a/src/sisl/io/tbtrans/se.py
+++ b/src/sisl/io/tbtrans/se.py
@@ -10,7 +10,6 @@ except Exception:
 
 import numpy as np
 
-from sisl._indices import indices
 from sisl._internal import set_module
 
 # Import the geometry object

--- a/src/sisl/io/tbtrans/tbt.py
+++ b/src/sisl/io/tbtrans/tbt.py
@@ -12,7 +12,7 @@ except Exception:
 
 import itertools
 from functools import reduce
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -26,7 +26,7 @@ from sisl import Atoms, Geometry, constant
 from sisl._core.sparse import _ncol_to_indptr
 from sisl._help import wrap_filterwarnings
 from sisl._internal import set_module
-from sisl.messages import SislError, deprecate, deprecate_argument, info, warn
+from sisl.messages import SislError, deprecate_argument, info, warn
 from sisl.physics.densitymatrix import DensityMatrix
 from sisl.physics.distribution import fermi_dirac
 from sisl.unit.siesta import unit_convert
@@ -156,7 +156,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
     def _value_avg(
         self,
         name: str,
-        tree: Optional[Union[str, List[str]]] = None,
+        tree: Optional[Union[str, list[str]]] = None,
         kavg: bool = False,
     ):
         """Local method for obtaining the data from the SileCDF.
@@ -207,7 +207,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
     def _value_E(
         self,
         name: str,
-        tree: Optional[Union[str, List[str]]] = None,
+        tree: Optional[Union[str, list[str]]] = None,
         kavg: bool = False,
         E: Optional[Union[int, float]] = None,
     ):

--- a/src/sisl/io/tbtrans/tests/test_delta.py
+++ b/src/sisl/io/tbtrans/tests/test_delta.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/tbtrans/tests/test_tbt.py
+++ b/src/sisl/io/tbtrans/tests/test_tbt.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 """ pytest test configures """
 
-import os.path as osp
 import warnings
 
 import numpy as np

--- a/src/sisl/io/tbtrans/tests/test_tbtproj.py
+++ b/src/sisl/io/tbtrans/tests/test_tbtproj.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 """ pytest test configures """
 
-import os.path as osp
 
 import numpy as np
 import pytest

--- a/src/sisl/io/tests/test_cube.py
+++ b/src/sisl/io/tests/test_cube.py
@@ -3,12 +3,10 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 
-from sisl import Atom, Geometry, Grid, SislError
+from sisl import Geometry, Grid, SislError
 from sisl.io.cube import *
 
 pytestmark = [pytest.mark.io, pytest.mark.generic]

--- a/src/sisl/io/tests/test_object.py
+++ b/src/sisl/io/tests/test_object.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import os
-import os.path as osp
 import sys
 from pathlib import Path
 

--- a/src/sisl/io/tests/test_table.py
+++ b/src/sisl/io/tests/test_table.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/tests/test_tb.py
+++ b/src/sisl/io/tests/test_tb.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/tests/test_xsf.py
+++ b/src/sisl/io/tests/test_xsf.py
@@ -3,13 +3,10 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-from itertools import zip_longest
-
 import numpy as np
 import pytest
 
-from sisl import Atom, Geometry, Grid, Lattice
+from sisl import Geometry, Grid
 from sisl.io.xsf import *
 
 pytestmark = [pytest.mark.io, pytest.mark.generic]

--- a/src/sisl/io/tests/test_xyz.py
+++ b/src/sisl/io/tests/test_xyz.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/vasp/chg.py
+++ b/src/sisl/io/vasp/chg.py
@@ -13,7 +13,6 @@ from sisl._internal import set_module
 from .._help import grid_reduce_indices
 from ..sile import add_sile, sile_fh_open
 from .car import carSileVASP
-from .sile import SileVASP
 
 __all__ = ["chgSileVASP"]
 

--- a/src/sisl/io/vasp/locpot.py
+++ b/src/sisl/io/vasp/locpot.py
@@ -15,7 +15,6 @@ from sisl.unit import serialize_units_arg, unit_convert
 from .._help import grid_reduce_indices
 from ..sile import add_sile, sile_fh_open
 from .car import carSileVASP
-from .sile import SileVASP
 
 __all__ = ["locpotSileVASP"]
 

--- a/src/sisl/io/vasp/tests/test_car.py
+++ b/src/sisl/io/vasp/tests/test_car.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/vasp/tests/test_chg.py
+++ b/src/sisl/io/vasp/tests/test_chg.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/vasp/tests/test_doscar.py
+++ b/src/sisl/io/vasp/tests/test_doscar.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/vasp/tests/test_eigenval.py
+++ b/src/sisl/io/vasp/tests/test_eigenval.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/vasp/tests/test_locpot.py
+++ b/src/sisl/io/vasp/tests/test_locpot.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/vasp/tests/test_outcar.py
+++ b/src/sisl/io/vasp/tests/test_outcar.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
-import numpy as np
 import pytest
 
 import sisl

--- a/src/sisl/io/wannier90/seedname.py
+++ b/src/sisl/io/wannier90/seedname.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 Sile object for reading/writing Wannier90 in/output
 """
 from collections import defaultdict
-from pathlib import Path
 
 import numpy as np
 import scipy.sparse as sps

--- a/src/sisl/io/wannier90/tests/test_seedname.py
+++ b/src/sisl/io/wannier90/tests/test_seedname.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import os.path as osp
-
 import numpy as np
 import pytest
 

--- a/src/sisl/io/xsf.py
+++ b/src/sisl/io/xsf.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import os.path as osp
-from numbers import Integral
 from typing import Optional
 
 import numpy as np

--- a/src/sisl/io/xyz.py
+++ b/src/sisl/io/xyz.py
@@ -13,7 +13,7 @@ import numpy as np
 import sisl._array as _a
 from sisl import Atoms, BoundaryCondition, Geometry, Lattice
 from sisl._internal import set_module
-from sisl.messages import deprecate_argument, warn
+from sisl.messages import deprecate_argument
 
 # Import sile objects
 from ._help import header_to_dict

--- a/src/sisl/messages.py
+++ b/src/sisl/messages.py
@@ -26,6 +26,7 @@ import warnings
 from functools import wraps
 
 from ._environ import get_environ_variable
+from ._help import has_module
 from ._internal import set_module
 
 __all__ = ["SislDeprecation", "SislInfo", "SislWarning", "SislException", "SislError"]
@@ -213,18 +214,12 @@ def is_jupyter_notebook():
 # Figure out if we can import tqdm.
 # If so, simply use the progressbar class there.
 # Otherwise, create a fake one.
-try:
+if has_module("tqdm"):
     if is_jupyter_notebook():
         from tqdm.notebook import tqdm as _tqdm
     else:
         from tqdm import tqdm as _tqdm
-except ImportError:
-    # Notify user of better option
-    info(
-        "Please install tqdm (pip install tqdm) for better looking progress bars",
-        register=True,
-    )
-
+else:
     # Necessary methods used
     from sys import stdout as _stdout
     from time import time as _time
@@ -235,6 +230,11 @@ except ImportError:
         __slots__ = ["total", "desc", "t0", "n", "l"]
 
         def __init__(self, total, desc, unit):
+            # Only inform them when we hit this
+            info(
+                "Please install tqdm (pip install tqdm) for better looking progress bars",
+                register=True,
+            )
             self.total = total
             self.desc = desc
             _stdout.write(f"{self.desc}  ETA = ?????h ??m ????s\r")

--- a/src/sisl/mixing/base.py
+++ b/src/sisl/mixing/base.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import operator as op
 from abc import abstractmethod
 from collections import deque
+from collections.abc import Iterator, Sequence
 from numbers import Integral
-from typing import Any, Callable, Iterator, Optional, Sequence, TypeVar, Union
+from typing import Any, Callable, Optional, TypeVar, Union
 
 from sisl._internal import set_module
 

--- a/src/sisl/mixing/diis.py
+++ b/src/sisl/mixing/diis.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from functools import reduce
 from numbers import Real
 from operator import add
-from typing import Any, Optional, Tuple, Type, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -15,14 +15,7 @@ import sisl._array as _a
 from sisl._internal import set_module
 from sisl.linalg import solve_destroy
 
-from .base import (
-    BaseHistoryWeightMixer,
-    History,
-    T,
-    TypeArgHistory,
-    TypeMetric,
-    TypeWeight,
-)
+from .base import BaseHistoryWeightMixer, T, TypeArgHistory, TypeMetric, TypeWeight
 
 __all__ = ["DIISMixer", "PulayMixer"]
 __all__ += ["AdaptiveDIISMixer", "AdaptivePulayMixer"]
@@ -86,7 +79,7 @@ class DIISMixer(BaseHistoryWeightMixer):
 
         self._metric = metric
 
-    def solve_lagrange(self) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    def solve_lagrange(self) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
         r"""Calculate the coefficients according to Pulay's method, return everything + Lagrange multiplier"""
         hist = self.history
         n_h = len(hist)
@@ -185,7 +178,7 @@ class AdaptiveDIISMixer(DIISMixer):
 
     def __init__(
         self,
-        weight: Tuple[TypeWeight, TypeWeight] = (0.03, 0.5),
+        weight: tuple[TypeWeight, TypeWeight] = (0.03, 0.5),
         history: TypeArgHistory = 2,
         metric: Optional[TypeMetric] = None,
     ):

--- a/src/sisl/mixing/tests/test_diis.py
+++ b/src/sisl/mixing/tests/test_diis.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 

--- a/src/sisl/mixing/tests/test_history.py
+++ b/src/sisl/mixing/tests/test_history.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
-import numpy as np
 import pytest
 
 from sisl.mixing import History

--- a/src/sisl/mixing/tests/test_linear.py
+++ b/src/sisl/mixing/tests/test_linear.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
 import operator as op
 
 import numpy as np

--- a/src/sisl/mixing/tests/test_step.py
+++ b/src/sisl/mixing/tests/test_step.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-import operator as op
-
 import numpy as np
 import pytest
 

--- a/src/sisl/physics/_feature.py
+++ b/src/sisl/physics/_feature.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Iterator, List
+from collections.abc import Iterator
 
 import numpy as np
 
@@ -23,7 +23,7 @@ def comply_gauge(gauge: GaugeType) -> str:
     }[gauge]
 
 
-def yield_manifolds(values, atol: float = 0.1, axis: int = -1) -> Iterator[List]:
+def yield_manifolds(values, atol: float = 0.1, axis: int = -1) -> Iterator[list]:
     r"""Yields indices for manifolds along the axis `axis`
 
     A manifold is found under the criteria that all neighboring

--- a/src/sisl/physics/_ufuncs_electron.py
+++ b/src/sisl/physics/_ufuncs_electron.py
@@ -3,14 +3,12 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import numpy.typing as npt
 
-import sisl._array as _a
 from sisl._ufuncs import register_sisl_dispatch
-from sisl.typing import SeqOrScalarFloat
 
 from .distribution import get_distribution
 from .electron import StateCElectron, _create_sigma, _TDist, _velocity_const
@@ -101,7 +99,7 @@ def berry_curvature(
     *,
     distribution: Optional[_TDist] = None,
     derivative_kwargs: dict = {},
-    operator: Union[_dM_Operator, Tuple[_dM_Operator, _dM_Operator]] = lambda M, d: M,
+    operator: Union[_dM_Operator, tuple[_dM_Operator, _dM_Operator]] = lambda M, d: M,
     eta: float = 0.0,
 ) -> np.ndarray:
     r"""Calculate the Berry curvature matrix for a set of states (Kubo)

--- a/src/sisl/physics/_ufuncs_matrix.py
+++ b/src/sisl/physics/_ufuncs_matrix.py
@@ -10,10 +10,8 @@ import sisl._array as _a
 from sisl._ufuncs import register_sisl_dispatch
 from sisl.typing import GaugeType, KPoint
 
-from ._matrix_ddk import matrix_ddk, matrix_ddk_nc, matrix_ddk_nc_diag, matrix_ddk_so
-from ._matrix_dk import matrix_dk, matrix_dk_nc, matrix_dk_nc_diag, matrix_dk_so
-from ._matrix_k import matrix_k, matrix_k_nc, matrix_k_nc_diag, matrix_k_so
-from .sparse import SparseOrbitalBZ, SparseOrbitalBZSpin
+from ._matrix_k import matrix_k
+from .sparse import SparseOrbitalBZ
 
 # Nothing gets exposed here
 __all__ = []

--- a/src/sisl/physics/_ufuncs_state.py
+++ b/src/sisl/physics/_ufuncs_state.py
@@ -3,14 +3,13 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Optional, Tuple, Union
+from typing import Optional
 
 import numpy as np
-import numpy.typing as npt
 
 import sisl._array as _a
 from sisl._ufuncs import register_sisl_dispatch
-from sisl.typing import SeqOrScalarFloat, SimpleIndex
+from sisl.typing import SimpleIndex
 
 from .state import Coefficient, State, StateC
 

--- a/src/sisl/physics/bloch.py
+++ b/src/sisl/physics/bloch.py
@@ -9,10 +9,10 @@ r"""Bloch's theorem
 Bloch's theorem is a very powerful proceduce that enables one to utilize
 the periodicity of a given direction to describe the complete system.
 """
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
-from numpy import add, empty, exp, multiply, zeros
+from numpy import empty
 
 import sisl._array as _a
 from sisl._help import dtype_real_to_complex

--- a/src/sisl/physics/brillouinzone.py
+++ b/src/sisl/physics/brillouinzone.py
@@ -143,24 +143,21 @@ on the chunksize of the jobs. By default the chunksize is controlled by
 from __future__ import annotations
 
 import itertools
-from functools import reduce
+from collections.abc import Sequence
 from numbers import Integral, Real
-from typing import Sequence, Tuple, Union
+from typing import Union
 
 import numpy as np
 import numpy.typing as npt
-from numpy import argsort, dot, pi, sum
+from numpy import argsort, dot, pi
 
 import sisl._array as _a
-from sisl._core.grid import Grid
 from sisl._core.lattice import Lattice
-from sisl._core.oplist import oplist
 from sisl._core.quaternion import Quaternion
 from sisl._dispatcher import ClassDispatcher
 from sisl._internal import set_module
 from sisl._math_small import cross3, dot3
-from sisl.messages import SislError, deprecate_argument, info, progressbar, warn
-from sisl.unit import units
+from sisl.messages import SislError, deprecate_argument, info, warn
 from sisl.utils import batched_indices
 from sisl.utils.mathematics import cart2spher, fnorm
 from sisl.utils.misc import direction, listify
@@ -407,7 +404,7 @@ class BrillouinZone:
     )
     def volume(
         self, ret_dim: bool = False, axes: Optional[CellAxes] = None
-    ) -> Union[float, Tuple[float, int]]:
+    ) -> Union[float, tuple[float, int]]:
         """Calculate the volume of the BrillouinZone, optionally only on some axes `axes`
 
         This will return the volume of the Brillouin zone,

--- a/src/sisl/physics/electron.py
+++ b/src/sisl/physics/electron.py
@@ -56,24 +56,22 @@ from numpy import (
     conj,
     cos,
     dot,
-    einsum,
     empty,
     exp,
     floor,
     int32,
     log,
-    matmul,
     ogrid,
     pi,
     sin,
     sort,
     zeros,
 )
-from scipy.sparse import csr_matrix, hstack, identity, issparse
+from scipy.sparse import csr_matrix, hstack, issparse
 
 import sisl._array as _a
 from sisl import BoundaryCondition as BC
-from sisl import C, Geometry, Grid, Lattice, units
+from sisl import C, Geometry, Grid, Lattice
 from sisl._core.oplist import oplist
 from sisl._indices import indices_le
 from sisl._internal import set_module
@@ -98,7 +96,7 @@ if TYPE_CHECKING:
 from .distribution import get_distribution
 from .sparse import SparseOrbitalBZSpin
 from .spin import Spin
-from .state import Coefficient, State, StateC, _FakeMatrix, degenerate_decouple
+from .state import Coefficient, State, StateC, _FakeMatrix
 
 __all__ = ["DOS", "PDOS", "COP"]
 __all__ += ["spin_moment", "spin_contamination"]

--- a/src/sisl/physics/phonon.py
+++ b/src/sisl/physics/phonon.py
@@ -37,13 +37,12 @@ from numpy import delete, fabs
 
 import sisl._array as _a
 from sisl import constant, units
-from sisl._help import dtype_complex_to_real
 from sisl._internal import set_module
 
 from .distribution import get_distribution
 from .electron import DOS as electron_DOS
 from .electron import PDOS as electron_PDOS
-from .state import Coefficient, State, StateC, degenerate_decouple
+from .state import Coefficient, State, StateC
 
 __all__ = ["DOS", "PDOS"]
 __all__ += ["CoefficientPhonon", "ModePhonon", "ModeCPhonon"]

--- a/src/sisl/physics/self_energy.py
+++ b/src/sisl/physics/self_energy.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Literal, Union
+from typing import Literal
 
 import numpy as np
 from numpy import abs as _abs
@@ -16,7 +16,6 @@ from numpy import (
     eye,
     matmul,
     subtract,
-    zeros,
     zeros_like,
 )
 
@@ -26,7 +25,7 @@ from sisl._help import array_replace
 from sisl._internal import set_module
 from sisl.linalg import inv, linalg_info, solve
 from sisl.linalg.base import _compute_lwork
-from sisl.messages import deprecate_argument, deprecation, info, warn
+from sisl.messages import deprecate_argument, deprecation, warn
 from sisl.physics.bloch import Bloch
 from sisl.physics.brillouinzone import MonkhorstPack
 from sisl.utils.mathematics import fnorm

--- a/src/sisl/physics/sparse.py
+++ b/src/sisl/physics/sparse.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import warnings
-from typing import Literal
 
 import numpy as np
 from scipy.sparse import SparseEfficiencyWarning, csr_matrix

--- a/src/sisl/physics/state.py
+++ b/src/sisl/physics/state.py
@@ -4,13 +4,11 @@
 from __future__ import annotations
 
 from functools import singledispatchmethod
-from numbers import Real
 from typing import Callable, Literal, Optional
 
 import numpy as np
 import numpy.typing as npt
 from numpy import bool_, einsum, exp, ndarray
-from scipy.sparse import csr_matrix
 
 import sisl._array as _a
 from sisl._core import Geometry

--- a/src/sisl/physics/tests/test_brillouinzone.py
+++ b/src/sisl/physics/tests/test_brillouinzone.py
@@ -10,10 +10,8 @@ import numpy as np
 import pytest
 
 from sisl import (
-    Atom,
     BandStructure,
     BrillouinZone,
-    Geometry,
     Lattice,
     LatticeChild,
     MonkhorstPack,

--- a/src/sisl/physics/tests/test_density_matrix.py
+++ b/src/sisl/physics/tests/test_density_matrix.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 

--- a/src/sisl/physics/tests/test_distribution.py
+++ b/src/sisl/physics/tests/test_distribution.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 

--- a/src/sisl/physics/tests/test_dynamical_matrix.py
+++ b/src/sisl/physics/tests/test_dynamical_matrix.py
@@ -3,14 +3,13 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 
 if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
     from numpy.exceptions import ComplexWarning
 else:
     from numpy import ComplexWarning
+
 import pytest
 
 from sisl import Atom, DynamicalMatrix, Geometry, Lattice

--- a/src/sisl/physics/tests/test_energy_density_matrix.py
+++ b/src/sisl/physics/tests/test_energy_density_matrix.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 

--- a/src/sisl/physics/tests/test_overlap.py
+++ b/src/sisl/physics/tests/test_overlap.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from sisl import Atom, AtomicOrbital, Geometry, Grid, Lattice, SphericalOrbital, Spin
+from sisl import Atom, Geometry, Lattice, SphericalOrbital
 from sisl.physics.overlap import Overlap
 
 pytestmark = [pytest.mark.physics, pytest.mark.overlap]

--- a/src/sisl/physics/tests/test_physics_sparse.py
+++ b/src/sisl/physics/tests/test_physics_sparse.py
@@ -3,14 +3,13 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
 import platform
 import sys
 
 import numpy as np
 import pytest
 
-from sisl import Atom, Geometry, SislWarning, Spin, geom
+from sisl import Atom, SislWarning, Spin, geom
 from sisl.physics.sparse import SparseOrbitalBZ, SparseOrbitalBZSpin
 
 pytestmark = [pytest.mark.physics, pytest.mark.sparse]

--- a/src/sisl/physics/tests/test_self_energy.py
+++ b/src/sisl/physics/tests/test_self_energy.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-import warnings
-
 import numpy as np
 import pytest
 from scipy.sparse import SparseEfficiencyWarning
@@ -21,7 +18,6 @@ from sisl import (
     RealSpaceSE,
     RealSpaceSI,
     RecursiveSI,
-    SelfEnergy,
     SemiInfinite,
     WideBandSE,
 )

--- a/src/sisl/physics/tests/test_spin.py
+++ b/src/sisl/physics/tests/test_spin.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 

--- a/src/sisl/shape/base.py
+++ b/src/sisl/shape/base.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
+from collections.abc import Sequence
 from math import sqrt as msqrt
-from typing import Sequence
 
 import numpy as np
 
@@ -323,7 +323,6 @@ CompositeShape.to.register("Sphere", ToSphereDispatch)
 
 class ToEllipsoidDispatcher(ShapeToDispatch):
     def dispatch(self, *args, center=None, **kwargs):
-        from .ellipsoid import Ellipsoid
 
         shape = self._get_object()
         return shape.to.Sphere(center=center).to.Ellipsoid()

--- a/src/sisl/shape/tests/test_cylinder.py
+++ b/src/sisl/shape/tests/test_cylinder.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 

--- a/src/sisl/shape/tests/test_ellipsoid.py
+++ b/src/sisl/shape/tests/test_ellipsoid.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 

--- a/src/sisl/shape/tests/test_prism4.py
+++ b/src/sisl/shape/tests/test_prism4.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 

--- a/src/sisl/shape/tests/test_shape.py
+++ b/src/sisl/shape/tests/test_shape.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 

--- a/src/sisl/tests/test_help.py
+++ b/src/sisl/tests/test_help.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
 import sys
 
 import numpy as np

--- a/src/sisl/tests/test_package.py
+++ b/src/sisl/tests/test_package.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
-import numpy as np
 import pytest
 
 import sisl
@@ -36,7 +33,7 @@ def test_import_in_io():
 def test_import_in_io_from():
     # The imports should only be visible in the io module
     with pytest.raises(ImportError):
-        from sisl import xyzSile
+        from sisl import xyzSile  # noqa: F401
 
 
 def test_dispatch_methods():

--- a/src/sisl/typing/_atom.py
+++ b/src/sisl/typing/_atom.py
@@ -3,7 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence, Union
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Union
 
 # To prevent import cycles place any internal imports in the branch below
 # and use a string literal forward reference to it in subsequent types

--- a/src/sisl/typing/_common.py
+++ b/src/sisl/typing/_common.py
@@ -3,20 +3,16 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Sequence, Union
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Callable, Union
 
-import numpy as np
-import numpy.typing as npt
 import scipy.sparse as sps
 
 # To prevent import cycles place any internal imports in the branch below
 # and use a string literal forward reference to it in subsequent types
 # https://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
 if TYPE_CHECKING:
-    from sisl import BaseSile, Geometry, Grid, Lattice, Shape
-    from sisl._category import GenericCategory
-    from sisl.geom.category import AtomCategory
+    from sisl import Geometry, Lattice
 
 __all__ = [
     "Coord",

--- a/src/sisl/typing/_core.py
+++ b/src/sisl/typing/_core.py
@@ -4,11 +4,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Tuple, Union
+from typing import TYPE_CHECKING, Union
 
-import numpy as np
 import numpy.typing as npt
-import scipy.sparse as sps
 
 # To prevent import cycles place any internal imports in the branch below
 # and use a string literal forward reference to it in subsequent types
@@ -38,7 +36,7 @@ GeometryLike = Union[
 ]
 """Data-types that can be converted to a `Geometry`"""
 
-LatticeLike = Union[SileLike, "Lattice", "LatticeChild", npt.NDArray, List, Tuple]
+LatticeLike = Union[SileLike, "Lattice", "LatticeChild", npt.ArrayLike]
 """Data-types that can be converted to a `Lattice`"""
 
 GridLike = Union[

--- a/src/sisl/typing/_indices.py
+++ b/src/sisl/typing/_indices.py
@@ -3,9 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import typing
-from itertools import permutations
-from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, Union
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Literal, Union
 
 # To prevent import cycles place any internal imports in the branch below
 # and use a string literal forward reference to it in subsequent types

--- a/src/sisl/typing/_units.py
+++ b/src/sisl/typing/_units.py
@@ -3,7 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Mapping, Sequence, Union
+from collections.abc import Mapping, Sequence
+from typing import Union
 
 __all__ = ["UnitsVar"]
 

--- a/src/sisl/typing/tests/test_typing.py
+++ b/src/sisl/typing/tests/test_typing.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import operator as ops
-
-import numpy as np
 import pytest
 
 import sisl.typing as st

--- a/src/sisl/utils/tests/test_mathematics.py
+++ b/src/sisl/utils/tests/test_mathematics.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
-
 import numpy as np
 import pytest
 

--- a/src/sisl/utils/tests/test_ranges.py
+++ b/src/sisl/utils/tests/test_ranges.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import math as m
 from functools import partial
 
 import pytest

--- a/src/sisl/viz/__init__.py
+++ b/src/sisl/viz/__init__.py
@@ -12,7 +12,7 @@ Visualization utilities
 import os
 
 try:
-    import nodify as _
+    import nodify as _  # noqa: F401
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
         """\

--- a/src/sisl/viz/_plotables.py
+++ b/src/sisl/viz/_plotables.py
@@ -8,7 +8,7 @@ This file provides tools to handle plotability of objects
 """
 import inspect
 from collections import ChainMap
-from typing import Sequence, Type
+from collections.abc import Sequence
 
 from sisl._dispatcher import AbstractDispatch, ClassDispatcher, ObjectDispatcher
 
@@ -216,7 +216,7 @@ def register_data_source(
     plot_cls,
     setting_key,
     name=None,
-    default: Sequence[Type] = [],
+    default: Sequence[type] = [],
     plot_handler_attr="plot",
     data_source_init_kwargs: dict = {},
     **kwargs,

--- a/src/sisl/viz/_plotables_register.py
+++ b/src/sisl/viz/_plotables_register.py
@@ -10,7 +10,7 @@ It does so by patching them accordingly
 """
 import sisl
 import sisl.io.siesta as siesta
-from sisl.io.sile import BaseSile, get_siles
+from sisl.io.sile import get_siles
 
 from ._plotables import register_data_source, register_plotable, register_sile_method
 from .data import *

--- a/src/sisl/viz/_splot.py
+++ b/src/sisl/viz/_splot.py
@@ -12,9 +12,7 @@ NOT FUNCTIONAL WITH THE NEW REFACTORING OF SISL.VIZ, MUST UPDATE
 
 import argparse
 import ast
-import sys
 
-import sisl
 from sisl.utils import cmd
 
 from ._user_customs import PLOTS_FILE, PRESETS_FILE, PRESETS_VARIABLE

--- a/src/sisl/viz/data/bands.py
+++ b/src/sisl/viz/data/bands.py
@@ -6,9 +6,10 @@
 # from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Sequence
 from functools import partial
 from pathlib import Path
-from typing import Dict, Optional, Sequence, Union
+from typing import Optional, Union
 
 import numpy as np
 import xarray as xr
@@ -329,7 +330,7 @@ class BandsData(XarrayData):
         cls,
         bz: sisl.BrillouinZone,
         H: Union[sisl.Hamiltonian, None] = None,
-        extra_vars: Sequence[Union[Dict, str]] = (),
+        extra_vars: Sequence[Union[dict, str]] = (),
     ):
         """Uses a sisl's `BrillouinZone` object to calculate the bands."""
         if bz is None:
@@ -582,7 +583,7 @@ class BandsData(XarrayData):
 
 
 def _get_eigenstate_wrapper(
-    k_vals, spin, extra_vars: Sequence[Union[Dict, str]] = (), spin_moments: bool = True
+    k_vals, spin, extra_vars: Sequence[Union[dict, str]] = (), spin_moments: bool = True
 ):
     """Helper function to build the function to call on each eigenstate.
 

--- a/src/sisl/viz/data/eigenstate.py
+++ b/src/sisl/viz/data/eigenstate.py
@@ -5,7 +5,7 @@
 # from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal, Tuple
+from typing import Literal
 
 import sisl
 from sisl.io import fdfSileSiesta, wfsxSileSiesta
@@ -46,7 +46,7 @@ class EigenstateData(Data):
         cls,
         fdf: fdfSileSiesta,
         source: Literal["wfsx", "hamiltonian"] = "wfsx",
-        k: Tuple[float, float, float] = (0, 0, 0),
+        k: tuple[float, float, float] = (0, 0, 0),
         spin: int = 0,
     ):
         if source == "wfsx":
@@ -68,7 +68,7 @@ class EigenstateData(Data):
         cls,
         wfsx_file: wfsxSileSiesta,
         geometry: sisl.Geometry,
-        k: Tuple[float, float, float] = (0, 0, 0),
+        k: tuple[float, float, float] = (0, 0, 0),
         spin: int = 0,
     ):
         """Reads the wavefunction coefficients from a SIESTA WFSX file"""
@@ -94,7 +94,7 @@ class EigenstateData(Data):
     def from_hamiltonian(
         cls,
         H: sisl.Hamiltonian,
-        k: Tuple[float, float, float] = (0, 0, 0),
+        k: tuple[float, float, float] = (0, 0, 0),
         spin: int = 0,
     ):
         """Calculates the eigenstates from a Hamiltonian and then generates the wavefunctions."""

--- a/src/sisl/viz/data/pdos.py
+++ b/src/sisl/viz/data/pdos.py
@@ -4,8 +4,9 @@
 # TODO when forward refs work with locals
 # from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Literal, Optional, Sequence, Union
+from typing import Literal, Optional, Union
 
 import numpy as np
 from xarray import DataArray

--- a/src/sisl/viz/data_sources/atom_data.py
+++ b/src/sisl/viz/data_sources/atom_data.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Dict
-
 import numpy as np
 
 from sisl._core.atom import AtomGhost, PeriodicTable
@@ -74,7 +72,7 @@ def AtomNOrbitals(geometry, atoms=None):
 
 class AtomColors(AtomData):
     _fallback_color: str = "pink"
-    _atoms_colors: Dict[str, str] = {}
+    _atoms_colors: dict[str, str] = {}
 
     def function(self, geometry, atoms=None):
         return np.array(

--- a/src/sisl/viz/data_sources/file/siesta.py
+++ b/src/sisl/viz/data_sources/file/siesta.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import sisl
 
-from .file_source import FileData
+from .file_source import FileData  # noqa: F401
 
 
 def get_sile(path=None, fdf=None, cls=None, **kwargs):

--- a/src/sisl/viz/data_sources/orbital_data.py
+++ b/src/sisl/viz/data_sources/orbital_data.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Literal, Union
-
 import numpy as np
 
 from ..plotutils import random_color

--- a/src/sisl/viz/figure/__init__.py
+++ b/src/sisl/viz/figure/__init__.py
@@ -16,7 +16,7 @@ class NotAvailableFigure(Figure):
 
 
 try:
-    import plotly
+    import plotly  # noqa: F401
 except ModuleNotFoundError:
 
     class PlotlyFigure(NotAvailableFigure):
@@ -26,7 +26,7 @@ else:
     from .plotly import PlotlyFigure
 
 try:
-    import matplotlib
+    import matplotlib  # noqa: F401
 except ModuleNotFoundError:
 
     class MatplotlibFigure(NotAvailableFigure):
@@ -36,7 +36,7 @@ else:
     from .matplotlib import MatplotlibFigure
 
 try:
-    import py3Dmol
+    import py3Dmol  # noqa: F401
 except ModuleNotFoundError:
 
     class Py3DmolFigure(NotAvailableFigure):
@@ -46,7 +46,7 @@ else:
     from .py3dmol import Py3DmolFigure
 
 try:
-    import bpy
+    import bpy  # noqa: F401
 except ModuleNotFoundError:
 
     class BlenderFigure(NotAvailableFigure):

--- a/src/sisl/viz/figure/figure.py
+++ b/src/sisl/viz/figure/figure.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections import ChainMap
-from typing import Any, Dict, Literal, Optional, Tuple
+from typing import Any, Literal, Optional
 
 import numpy as np
 
@@ -126,7 +126,7 @@ class Figure:
             "animation",
         ] = None,
         plot_actions=(),
-        init_kwargs: Dict[str, Any] = {},
+        init_kwargs: dict[str, Any] = {},
     ):
         if composite_method is None:
             self._composite_mode = self._NONE
@@ -201,7 +201,7 @@ class Figure:
         rows: Optional[int] = None,
         cols: Optional[int] = None,
         arrange: Literal["rows", "cols", "square"] = "rows",
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Returns the number of rows and columns for a subplot grid."""
         if rows is None and cols is None:
             if arrange == "rows":

--- a/src/sisl/viz/figure/plotly.py
+++ b/src/sisl/viz/figure/plotly.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 import itertools
-from typing import Optional, Sequence
+from collections.abc import Sequence
+from typing import Optional
 
 import numpy as np
 import plotly.graph_objs as go

--- a/src/sisl/viz/plots/bands.py
+++ b/src/sisl/viz/plots/bands.py
@@ -3,7 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Dict, Literal, Optional, Sequence, Tuple
+from collections.abc import Sequence
+from typing import Literal, Optional
 
 import numpy as np
 
@@ -52,10 +53,10 @@ def _group_traces(actions, group_legend: bool = True):
 
 def bands_plot(
     bands_data: BandsData,
-    Erange: Optional[Tuple[float, float]] = None,
+    Erange: Optional[tuple[float, float]] = None,
     E0: float = 0.0,
     E_axis: Literal["x", "y"] = "y",
-    bands_range: Optional[Tuple[int, int]] = None,
+    bands_range: Optional[tuple[int, int]] = None,
     spin: Optional[Literal[0, 1]] = None,
     bands_style: StyleSpec = {
         "color": "black",
@@ -70,7 +71,7 @@ def bands_plot(
     gap_color: str = "red",
     gap_marker: dict = {"size": 7},
     direct_gaps_only: bool = False,
-    custom_gaps: Sequence[Dict] = [],
+    custom_gaps: Sequence[dict] = [],
     line_mode: Literal["line", "scatter", "area_line"] = "line",
     group_legend: bool = True,
     backend: str = "plotly",
@@ -186,10 +187,10 @@ def bands_plot(
 # I am yet to find a nice solution for extending workflows.
 def fatbands_plot(
     bands_data: BandsData,
-    Erange: Optional[Tuple[float, float]] = None,
+    Erange: Optional[tuple[float, float]] = None,
     E0: float = 0.0,
     E_axis: Literal["x", "y"] = "y",
-    bands_range: Optional[Tuple[int, int]] = None,
+    bands_range: Optional[tuple[int, int]] = None,
     spin: Optional[Literal[0, 1]] = None,
     bands_style: StyleSpec = {"color": "black", "width": 1, "opacity": 1},
     spindown_style: StyleSpec = {"color": "blue", "width": 1},
@@ -198,7 +199,7 @@ def fatbands_plot(
     gap_color: str = "red",
     gap_marker: dict = {"size": 7},
     direct_gaps_only: bool = False,
-    custom_gaps: Sequence[Dict] = [],
+    custom_gaps: Sequence[dict] = [],
     bands_mode: Literal["line", "scatter", "area_line"] = "line",
     bands_group_legend: bool = True,
     # Fatbands inputs

--- a/src/sisl/viz/plots/geometry.py
+++ b/src/sisl/viz/plots/geometry.py
@@ -3,7 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Callable, Literal, Optional, Sequence, Tuple, TypeVar, Union
+from collections.abc import Sequence
+from typing import Callable, Literal, Optional, TypeVar, Union
 
 import numpy as np
 
@@ -89,7 +90,7 @@ def _get_arrow_plottings(atoms_data, arrows, nsc=[1, 1, 1]):
 
 
 def _sanitize_scale(
-    scale: float, ndim: int, ndim_scale: Tuple[float, float, float] = (16, 16, 1)
+    scale: float, ndim: int, ndim_scale: tuple[float, float, float] = (16, 16, 1)
 ):
     return ndim_scale[ndim - 1] * scale
 
@@ -111,9 +112,9 @@ def geometry_plot(
     show_bonds: bool = True,
     show_cell: Literal["box", "axes", False] = "box",
     cell_style: StyleSpec = {},
-    nsc: Tuple[int, int, int] = (1, 1, 1),
-    atoms_ndim_scale: Tuple[float, float, float] = (16, 16, 1),
-    bonds_ndim_scale: Tuple[float, float, float] = (1, 1, 10),
+    nsc: tuple[int, int, int] = (1, 1, 1),
+    atoms_ndim_scale: tuple[float, float, float] = (16, 16, 1),
+    bonds_ndim_scale: tuple[float, float, float] = (1, 1, 10),
     dataaxis_1d: Optional[Union[np.ndarray, Callable]] = None,
     arrows: Sequence[AtomArrowSpec] = (),
     backend="plotly",
@@ -294,8 +295,8 @@ def sites_plot(
     drawing_mode: Literal["scatter", "balls", "line", None] = None,
     show_cell: Literal["box", "axes", False] = False,
     cell_style: StyleSpec = {},
-    nsc: Tuple[int, int, int] = (1, 1, 1),
-    sites_ndim_scale: Tuple[float, float, float] = (1, 1, 1),
+    nsc: tuple[int, int, int] = (1, 1, 1),
+    sites_ndim_scale: tuple[float, float, float] = (1, 1, 1),
     dataaxis_1d: Optional[Union[np.ndarray, Callable]] = None,
     arrows: Sequence[AtomArrowSpec] = (),
     backend="plotly",

--- a/src/sisl/viz/plots/grid.py
+++ b/src/sisl/viz/plots/grid.py
@@ -3,7 +3,9 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Callable, ChainMap, Literal, Optional, Sequence, Tuple, Union
+from collections import ChainMap
+from collections.abc import Sequence
+from typing import Callable, Literal, Optional, Union
 
 from sisl._core import Geometry, Grid
 
@@ -65,12 +67,12 @@ def grid_plot(
     transforms: Sequence[Union[str, Callable]] = (),
     reduce_method: Literal["average", "sum"] = "average",
     boundary_mode: str = "grid-wrap",
-    nsc: Tuple[int, int, int] = (1, 1, 1),
-    interp: Tuple[int, int, int] = (1, 1, 1),
+    nsc: tuple[int, int, int] = (1, 1, 1),
+    interp: tuple[int, int, int] = (1, 1, 1),
     isos: Sequence[dict] = [],
     smooth: bool = False,
     colorscale: Optional[Colorscale] = None,
-    crange: Optional[Tuple[float, float]] = None,
+    crange: Optional[tuple[float, float]] = None,
     cmid: Optional[float] = None,
     show_cell: Literal["box", "axes", False] = "box",
     cell_style: dict = {},
@@ -215,12 +217,12 @@ def wavefunction_plot(
     transforms: Sequence[Union[str, Callable]] = (),
     reduce_method: Literal["average", "sum"] = "average",
     boundary_mode: str = "grid-wrap",
-    nsc: Tuple[int, int, int] = (1, 1, 1),
-    interp: Tuple[int, int, int] = (1, 1, 1),
+    nsc: tuple[int, int, int] = (1, 1, 1),
+    interp: tuple[int, int, int] = (1, 1, 1),
     isos: Sequence[dict] = [],
     smooth: bool = False,
     colorscale: Optional[Colorscale] = None,
-    crange: Optional[Tuple[float, float]] = None,
+    crange: Optional[tuple[float, float]] = None,
     cmid: Optional[float] = None,
     show_cell: Literal["box", "axes", False] = "box",
     cell_style: dict = {},

--- a/src/sisl/viz/plots/matrix.py
+++ b/src/sisl/viz/plots/matrix.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 from scipy.sparse import spmatrix
@@ -33,18 +33,18 @@ def atomic_matrix_plot(
     isc: Optional[int] = None,
     fill_value: Optional[float] = None,
     geometry: Union[sisl.Geometry, None] = None,
-    atom_lines: Union[bool, Dict] = False,
-    orbital_lines: Union[bool, Dict] = False,
-    sc_lines: Union[bool, Dict] = False,
+    atom_lines: Union[bool, dict] = False,
+    orbital_lines: Union[bool, dict] = False,
+    sc_lines: Union[bool, dict] = False,
     color_pixels: bool = True,
     colorscale: Optional[Colorscale] = "RdBu",
-    crange: Optional[Tuple[float, float]] = None,
+    crange: Optional[tuple[float, float]] = None,
     cmid: Optional[float] = None,
     text: Optional[str] = None,
     textfont: Optional[dict] = {},
     set_labels: bool = False,
     constrain_axes: bool = True,
-    arrows: List[dict] = [],
+    arrows: list[dict] = [],
     backend: str = "plotly",
 ) -> Figure:
     """Plots a (possibly sparse) matrix where rows and columns are either orbitals or atoms.

--- a/src/sisl/viz/plots/merged.py
+++ b/src/sisl/viz/plots/merged.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import Literal, Optional
 
 from ..figure import Figure, get_figure
-from ..plot import Plot
 from ..plotters.plot_actions import combined
 
 

--- a/src/sisl/viz/plots/pdos.py
+++ b/src/sisl/viz/plots/pdos.py
@@ -3,7 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Any, Literal, Optional, Sequence, Tuple
+from collections.abc import Sequence
+from typing import Literal
 
 import numpy as np
 
@@ -11,7 +12,6 @@ from sisl.viz.types import OrbitalStyleQuery
 
 from ..data import PDOSData
 from ..figure import Figure, get_figure
-from ..plot import Plot
 from ..plotters.xarray import draw_xarray_xy
 from ..processors.data import accept_data
 from ..processors.logic import swap
@@ -23,7 +23,7 @@ from .orbital_groups_plot import OrbitalGroupsPlot
 def pdos_plot(
     pdos_data: PDOSData,
     groups: Sequence[OrbitalStyleQuery] = [{"name": "DOS"}],
-    Erange: Tuple[float, float] = (-2, 2),
+    Erange: tuple[float, float] = (-2, 2),
     E_axis: Literal["x", "y"] = "x",
     line_mode: Literal["line", "scatter", "area_line"] = "line",
     line_scale: float = 1.0,

--- a/src/sisl/viz/plots/tests/test_geometry.py
+++ b/src/sisl/viz/plots/tests/test_geometry.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import numpy as np
 import pytest
 
 import sisl

--- a/src/sisl/viz/plotters/cell.py
+++ b/src/sisl/viz/plotters/cell.py
@@ -3,11 +3,13 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Literal, Sequence
+from typing import Literal
+
+from sisl.typing import LatticeLike
 
 from ..processors.cell import cell_to_lines, gen_cell_dataset
 from ..processors.coords import project_to_axes
-from ..types import Axes, LatticeLike
+from ..types import Axes
 from .xarray import draw_xarray_xy
 
 

--- a/src/sisl/viz/plotters/grid.py
+++ b/src/sisl/viz/plotters/grid.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 import xarray as xr
@@ -14,9 +14,9 @@ from sisl.viz.processors.grid import get_isos
 
 def draw_grid(
     data,
-    isos: List[dict] = [],
+    isos: list[dict] = [],
     colorscale: Optional[str] = None,
-    crange: Optional[Tuple[float, float]] = None,
+    crange: Optional[tuple[float, float]] = None,
     cmid: Optional[float] = None,
     smooth: bool = False,
     color_pixels_2d: bool = True,
@@ -97,7 +97,7 @@ def draw_grid(
     return to_plot
 
 
-def draw_grid_arrows(data, arrows: List[dict]):
+def draw_grid_arrows(data, arrows: list[dict]):
     to_plot = []
 
     # If it is a numpy array, convert it to a DataArray

--- a/src/sisl/viz/plotters/matrix.py
+++ b/src/sisl/viz/plotters/matrix.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import List, Literal, Union
+from typing import Literal, Union
 
 import numpy as np
 
@@ -20,7 +20,7 @@ def draw_matrix_separators(
     separator_mode: Literal["orbitals", "atoms", "supercells"],
     draw_supercells: bool = True,
     showlegend: bool = True,
-) -> List[dict]:
+) -> list[dict]:
     """Returns the actions to draw separators in a matrix.
 
     Parameters
@@ -133,7 +133,7 @@ def set_matrix_axes(
     matrix_mode: Literal["orbitals", "atoms"],
     constrain_axes: bool = True,
     set_labels: bool = False,
-) -> List[dict]:
+) -> list[dict]:
     """Configure the axes of a matrix plot
 
     Parameters

--- a/src/sisl/viz/plotters/plot_actions.py
+++ b/src/sisl/viz/plotters/plot_actions.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 import functools
 import inspect
 import sys
-from typing import Literal, Optional, Type
+from typing import Literal, Optional
 
 from ..figure import Figure
 
 
-def _register_actions(figure_cls: Type[Figure]):
+def _register_actions(figure_cls: type[Figure]):
     # Take all actions possible from the Figure class
     module = sys.modules[__name__]
 

--- a/src/sisl/viz/plotters/xarray.py
+++ b/src/sisl/viz/plotters/xarray.py
@@ -10,7 +10,6 @@ import numpy as np
 from xarray import DataArray
 
 import sisl.viz.plotters.plot_actions as plot_actions
-from sisl.messages import info
 
 # from sisl.viz.nodes.processors.grid import get_isos
 

--- a/src/sisl/viz/plotutils.py
+++ b/src/sisl/viz/plotutils.py
@@ -9,13 +9,11 @@ from pathlib import Path
 import numpy as np
 
 try:
-    from pathos.pools import ProcessPool as Pool
 
     pathos_avail = True
 except Exception:
     pathos_avail = False
 try:
-    import tqdm
 
     tqdm_avail = True
 except Exception:
@@ -95,7 +93,6 @@ def check_widgets():
 
     if "ipyevents" in out:
         try:
-            import ipyevents
 
             widgets["events_avail"] = True
         except Exception:

--- a/src/sisl/viz/processors/atom.py
+++ b/src/sisl/viz/processors/atom.py
@@ -3,11 +3,10 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from collections import defaultdict
-from typing import Any, Callable, Optional, Sequence, TypedDict, Union
+from collections.abc import Sequence
+from typing import Any, Callable, Optional, Union
 
 import numpy as np
-import xarray as xr
 from xarray import DataArray, Dataset
 
 from sisl._core import Geometry

--- a/src/sisl/viz/processors/axes.py
+++ b/src/sisl/viz/processors/axes.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 import re
-from typing import Callable, List, Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import Callable, Optional, Union
 
 import numpy as np
 
@@ -39,7 +40,7 @@ def sanitize_axis(ax) -> Union[str, int, np.ndarray]:
 
 def sanitize_axes(
     val: Union[str, Sequence[Union[str, int, np.ndarray]]]
-) -> List[Union[str, int, np.ndarray]]:
+) -> list[Union[str, int, np.ndarray]]:
     if isinstance(val, str):
         val = re.findall("[+-]?[xyzabc012]", val)
     return [sanitize_axis(ax) for ax in val]

--- a/src/sisl/viz/processors/bands.py
+++ b/src/sisl/viz/processors/bands.py
@@ -5,7 +5,8 @@
 # from __future__ import annotations
 
 import itertools
-from typing import List, Literal, Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import Literal, Optional, Union
 
 import numpy as np
 import xarray as xr
@@ -15,9 +16,9 @@ from ..plotters import plot_actions
 
 def filter_bands(
     bands_data: xr.Dataset,
-    Erange: Optional[Tuple[float, float]] = None,
+    Erange: Optional[tuple[float, float]] = None,
     E0: float = 0,
-    bands_range: Optional[Tuple[int, int]] = None,
+    bands_range: Optional[tuple[int, int]] = None,
     spin: Optional[int] = None,
 ) -> xr.Dataset:
     filtered_bands = bands_data.copy()
@@ -235,11 +236,11 @@ def sanitize_k(bands_data: xr.Dataset, k: Union[float, str]) -> Optional[float]:
 
 def get_gap_coords(
     bands_data: xr.Dataset,
-    bands: Tuple[int, int],
+    bands: tuple[int, int],
     from_k: Union[float, str],
     to_k: Optional[Union[float, str]] = None,
     spin: int = 0,
-) -> Tuple[Tuple[float, float], Tuple[float, float]]:
+) -> tuple[tuple[float, float], tuple[float, float]]:
     """Calculates the coordinates of a gap given some k values.
 
     Parameters
@@ -303,7 +304,7 @@ def draw_gaps(
     direct_gaps_only: bool,
     custom_gaps: Sequence[dict],
     E_axis: Literal["x", "y"],
-) -> List[dict]:
+) -> list[dict]:
     """Returns the drawing actions to draw gaps.
 
     Parameters
@@ -406,8 +407,8 @@ def draw_gaps(
 
 
 def draw_gap(
-    ks: Tuple[float, float],
-    Es: Tuple[float, float],
+    ks: tuple[float, float],
+    Es: tuple[float, float],
     color: Optional[str] = None,
     marker: dict = {},
     name: str = "Gap",

--- a/src/sisl/viz/processors/cell.py
+++ b/src/sisl/viz/processors/cell.py
@@ -4,15 +4,13 @@
 # TODO when forward refs work with annotations
 # from __future__ import annotations
 
-import itertools
-from typing import Any, List, Literal, TypedDict, Union
+from typing import Any, Literal, TypedDict
 
 import numpy as np
-import numpy.typing as npt
 from xarray import Dataset
 
 from sisl._core.lattice import Lattice
-from sisl.viz.types import LatticeLike
+from sisl.typing import LatticeLike
 
 from .coords import CoordsDataset
 
@@ -65,7 +63,7 @@ def is_1D_cartesian(
     return is_1D_cartesian and (cell[lattice_vecs[0]] > tol).sum() == 1
 
 
-def infer_cell_axes(cell: LatticeLike, axes: List[str], tol: float = 1e-3) -> List[int]:
+def infer_cell_axes(cell: LatticeLike, axes: list[str], tol: float = 1e-3) -> list[int]:
     """Returns the indices of the lattice vectors that correspond to the given axes."""
     cell = Lattice.new(cell).cell
 

--- a/src/sisl/viz/processors/coords.py
+++ b/src/sisl/viz/processors/coords.py
@@ -3,8 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-import re
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -12,9 +11,10 @@ from xarray import Dataset
 
 from sisl._core._lattice import cell_invert
 from sisl._core.lattice import Lattice
+from sisl.typing import LatticeLike
 from sisl.utils.mathematics import fnorm
 
-from ..types import Axes, Axis, LatticeLike
+from ..types import Axes, Axis
 from .axes import axes_cross_product, axis_direction, get_ax_title
 
 CoordsDataset = Dataset
@@ -143,7 +143,7 @@ def coords_depth(coords_data: CoordsDataset, axes: Axes) -> npt.NDArray[np.float
 
 def sphere(
     center: npt.ArrayLike = [0, 0, 0], r: float = 1, vertices: int = 10
-) -> Dict[str, np.ndarray]:
+) -> dict[str, np.ndarray]:
     """Computes a mesh defining a sphere."""
     phi, theta = np.mgrid[
         0.0 : np.pi : 1j * vertices, 0.0 : 2.0 * np.pi : 1j * vertices

--- a/src/sisl/viz/processors/data.py
+++ b/src/sisl/viz/processors/data.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Type, TypeVar
+from typing import TypeVar
 
 from ..data import Data
 
@@ -11,7 +11,7 @@ DataInstance = TypeVar("DataInstance", bound=Data)
 
 
 def accept_data(
-    data: DataInstance, cls: Type[Data], check: bool = True
+    data: DataInstance, cls: type[Data], check: bool = True
 ) -> DataInstance:
     if not isinstance(data, cls):
         raise TypeError(
@@ -24,7 +24,7 @@ def accept_data(
     return data
 
 
-def extract_data(data: Data, cls: Type[Data], check: bool = True):
+def extract_data(data: Data, cls: type[Data], check: bool = True):
     if not isinstance(data, cls):
         raise TypeError(
             f"Data must be of type {cls.__name__} and was {type(data).__name__}"

--- a/src/sisl/viz/processors/eigenstate.py
+++ b/src/sisl/viz/processors/eigenstate.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -69,7 +69,7 @@ def eigenstate_geometry(
 
 def tile_if_k(
     geometry: sisl.Geometry,
-    nsc: Tuple[int, int, int],
+    nsc: tuple[int, int, int],
     eigenstate: sisl.EigenstateElectron,
 ) -> sisl.Geometry:
     """Tiles the geometry if the eigenstate does not correspond to gamma.
@@ -83,7 +83,7 @@ def tile_if_k(
     ----------
     geometry : sisl.Geometry
         The geometry for which the wavefunction was calculated.
-    nsc : Tuple[int, int, int]
+    nsc : tuple[int, int, int]
         The number of supercells that are to be displayed in each direction.
     eigenstate : sisl.EigenstateElectron
         The eigenstate for which the wavefunction was calculated.
@@ -103,8 +103,8 @@ def tile_if_k(
 
 
 def get_grid_nsc(
-    nsc: Tuple[int, int, int], eigenstate: sisl.EigenstateElectron
-) -> Tuple[int, int, int]:
+    nsc: tuple[int, int, int], eigenstate: sisl.EigenstateElectron
+) -> tuple[int, int, int]:
     """Returns the supercell to display once the geometry is tiled.
 
     The geometry must be tiled if the eigenstate is not calculated at gamma,
@@ -113,7 +113,7 @@ def get_grid_nsc(
 
     Parameters
     ----------
-    nsc : Tuple[int, int, int]
+    nsc : tuple[int, int, int]
         The number of supercells to be display in each direction.
     eigenstate : sisl.EigenstateElectron
         The eigenstate for which the wavefunction was calculated.

--- a/src/sisl/viz/processors/geometry.py
+++ b/src/sisl/viz/processors/geometry.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import itertools
+from collections.abc import Sequence
 from dataclasses import asdict
-from typing import Any, List, Optional, Sequence, Tuple, TypedDict, Union
+from typing import Any, Optional, TypedDict, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -38,14 +39,14 @@ BondsDataset = GeometryDataset
 #     return Geometry.new(obj)
 
 
-def tile_geometry(geometry: Geometry, nsc: Tuple[int, int, int]) -> Geometry:
+def tile_geometry(geometry: Geometry, nsc: tuple[int, int, int]) -> Geometry:
     """Tiles a geometry along the three lattice vectors.
 
     Parameters
     -----------
     geometry: sisl.Geometry
         the geometry to be tiled.
-    nsc: Tuple[int, int, int]
+    nsc: tuple[int, int, int]
         the number of repetitions along each lattice vector.
     """
 
@@ -138,7 +139,7 @@ def sanitize_atoms(
 
 
 def tile_data_sc(
-    geometry_data: GeometryDataset, nsc: Tuple[int, int, int] = (1, 1, 1)
+    geometry_data: GeometryDataset, nsc: tuple[int, int, int] = (1, 1, 1)
 ) -> GeometryDataset:
     """Tiles coordinates from unit cell to a supercell.
 
@@ -289,7 +290,7 @@ def sanitize_arrows(
     atoms: AtomsIndex,
     ndim: int,
     axes: Sequence[str],
-) -> List[dict]:
+) -> list[dict]:
     """Sanitizes a list of arrow specifications.
 
     Each arrow specification in the output has the atoms sanitized and

--- a/src/sisl/viz/processors/grid.py
+++ b/src/sisl/viz/processors/grid.py
@@ -3,14 +3,14 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Callable, List, Literal, Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import Callable, Literal, Optional, Union
 
 import numpy as np
 import numpy.typing as npt
 from scipy.ndimage import affine_transform
 from xarray import DataArray
 
-import sisl
 from sisl import _array as _a
 from sisl._core import Geometry, Grid
 from sisl._core._lattice import cell_invert
@@ -63,7 +63,7 @@ def get_grid_representation(
     return grid.apply(_func)
 
 
-def tile_grid(grid: Grid, nsc: Tuple[int, int, int] = (1, 1, 1)) -> Grid:
+def tile_grid(grid: Grid, nsc: tuple[int, int, int] = (1, 1, 1)) -> Grid:
     """Tiles the grid"""
     for ax, reps in enumerate(nsc):
         grid = grid.tile(reps, ax)
@@ -73,7 +73,7 @@ def tile_grid(grid: Grid, nsc: Tuple[int, int, int] = (1, 1, 1)) -> Grid:
 def transform_grid_cell(
     grid: Grid,
     cell: npt.NDArray[np.float64] = np.eye(3),
-    output_shape: Optional[Tuple[int, int, int]] = None,
+    output_shape: Optional[nuple[int, int, int]] = None,
     mode: str = "constant",
     order: int = 1,
     **kwargs,
@@ -170,7 +170,7 @@ def transform_grid_cell(
 
 def orthogonalize_grid(
     grid: Grid,
-    interp: Tuple[int, int, int] = (1, 1, 1),
+    interp: tuple[int, int, int] = (1, 1, 1),
     mode: str = "constant",
     **kwargs,
 ) -> Grid:
@@ -204,7 +204,7 @@ def orthogonalize_grid_if_needed(
     grid: Grid,
     axes: Sequence[str],
     tol: float = 1e-3,
-    interp: Tuple[int, int, int] = (1, 1, 1),
+    interp: tuple[int, int, int] = (1, 1, 1),
     mode: str = "constant",
     **kwargs,
 ) -> Grid:
@@ -306,9 +306,9 @@ def reduce_grid(
 
 def sub_grid(
     grid: Grid,
-    x_range: Optional[Tuple[float, float]] = None,
-    y_range: Optional[Tuple[float, float]] = None,
-    z_range: Optional[Tuple[float, float]] = None,
+    x_range: Optional[tuple[float, float]] = None,
+    y_range: Optional[tuple[float, float]] = None,
+    z_range: Optional[tuple[float, float]] = None,
     cart_tol: float = 1e-3,
 ) -> Grid:
     """Returns only the part of the grid that is within the specified ranges.
@@ -378,7 +378,7 @@ def sub_grid(
 
 
 def interpolate_grid(
-    grid: Grid, interp: Tuple[int, int, int] = (1, 1, 1), force: bool = False
+    grid: Grid, interp: tuple[int, int, int] = (1, 1, 1), force: bool = False
 ) -> Grid:
     """Interpolates the grid.
 
@@ -473,7 +473,7 @@ def should_transform_grid_cell_plotting(
     return should_orthogonalize
 
 
-def get_grid_axes(grid: Grid, axes: Sequence[str]) -> List[int]:
+def get_grid_axes(grid: Grid, axes: Sequence[str]) -> list[int]:
     """Returns the indices of the lattice vectors that correspond to the axes.
 
     If axes is of length 3 (i.e. a 3D view), this function always returns [0, 1, 2]
@@ -502,7 +502,7 @@ def get_grid_axes(grid: Grid, axes: Sequence[str]) -> List[int]:
 def get_ax_vals(
     grid: Grid,
     ax: Literal[0, 1, 2, "a", "b", "c", "x", "y", "z"],
-    nsc: Tuple[int, int, int],
+    nsc: tuple[int, int, int],
 ) -> npt.NDArray[np.float64]:
     """Returns the values of a given axis on all grid points.
 
@@ -556,7 +556,7 @@ GridDataArray = DataArray
 
 
 def grid_to_dataarray(
-    grid: Grid, axes: Sequence[str], grid_axes: Sequence[int], nsc: Tuple[int, int, int]
+    grid: Grid, axes: Sequence[str], grid_axes: Sequence[int], nsc: tuple[int, int, int]
 ) -> GridDataArray:
     transpose_grid_axes = [*grid_axes]
     for ax in (0, 1, 2):
@@ -577,7 +577,7 @@ def grid_to_dataarray(
     return arr
 
 
-def get_isos(data: GridDataArray, isos: Sequence[dict]) -> List[dict]:
+def get_isos(data: GridDataArray, isos: Sequence[dict]) -> list[dict]:
     """Gets the iso surfaces or isocontours of an array of data.
 
     Parameters

--- a/src/sisl/viz/processors/logic.py
+++ b/src/sisl/viz/processors/logic.py
@@ -3,13 +3,13 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Tuple, TypeVar, Union
+from typing import TypeVar, Union
 
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
 
 
-def swap(val: Union[T1, T2], vals: Tuple[T1, T2]) -> Union[T1, T2]:
+def swap(val: Union[T1, T2], vals: tuple[T1, T2]) -> Union[T1, T2]:
     """Given two values, returns the one that is not the input value."""
     if val == vals[0]:
         return vals[1]

--- a/src/sisl/viz/processors/matrix.py
+++ b/src/sisl/viz/processors/matrix.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import List, Literal, Optional, Tuple, Union
+from typing import Literal, Optional, Union
 
 import numpy as np
 from scipy.sparse import issparse
@@ -11,7 +11,7 @@ from scipy.sparse import issparse
 import sisl
 
 
-def get_orbital_sets_positions(atoms: List[sisl.Atom]) -> List[List[int]]:
+def get_orbital_sets_positions(atoms: list[sisl.Atom]) -> list[list[int]]:
     """Gets the orbital indices where an orbital set starts for each atom.
 
     An "orbital set" is a group of 2l + 1 orbitals with an angular momentum l
@@ -108,7 +108,7 @@ def matrix_as_array(
 def determine_color_midpoint(
     matrix: np.ndarray,
     cmid: Optional[float] = None,
-    crange: Optional[Tuple[float, float]] = None,
+    crange: Optional[tuple[float, float]] = None,
 ) -> Optional[float]:
     """Determines the midpoint of a colorscale given a matrix of values.
 
@@ -149,7 +149,7 @@ def get_matrix_mode(matrix) -> Literal["atoms", "orbitals"]:
     return "atoms" if isinstance(matrix, sisl.SparseAtom) else "orbitals"
 
 
-def sanitize_matrix_arrows(arrows: Union[dict, List[dict]]) -> List[dict]:
+def sanitize_matrix_arrows(arrows: Union[dict, list[dict]]) -> list[dict]:
     """Sanitizes an ``arrows`` argument to a list of sanitized specifications.
 
     Parameters

--- a/src/sisl/viz/processors/orbital.py
+++ b/src/sisl/viz/processors/orbital.py
@@ -5,9 +5,10 @@
 # from __future__ import annotations
 
 from collections import ChainMap, defaultdict
+from collections.abc import Sequence
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Sequence, TypedDict, Union
+from typing import Any, Callable, Optional, TypedDict, Union
 
 import numpy as np
 import xarray
@@ -48,7 +49,7 @@ class OrbitalQueriesManager:
     geometry: Geometry
     spin: Spin
 
-    key_gens: Dict[str, Callable] = {}
+    key_gens: dict[str, Callable] = {}
 
     @singledispatchmethod
     @classmethod
@@ -56,7 +57,7 @@ class OrbitalQueriesManager:
         cls,
         geometry: Geometry,
         spin: Union[str, Spin] = "",
-        key_gens: Dict[str, Callable] = {},
+        key_gens: dict[str, Callable] = {},
     ):
         return cls(geometry=geometry, spin=spin or "", key_gens=key_gens)
 
@@ -66,7 +67,7 @@ class OrbitalQueriesManager:
         cls,
         geometry: Geometry,
         spin: Union[str, Spin] = "",
-        key_gens: Dict[str, Callable] = {},
+        key_gens: dict[str, Callable] = {},
     ):
         return cls(geometry=geometry, spin=spin or "", key_gens=key_gens)
 
@@ -76,7 +77,7 @@ class OrbitalQueriesManager:
         cls,
         string: str,
         spin: Union[str, Spin] = "",
-        key_gens: Dict[str, Callable] = {},
+        key_gens: dict[str, Callable] = {},
     ):
         """Initializes an OrbitalQueriesManager from a string, assuming it is a path."""
         return cls.new(Path(string), spin=spin, key_gens=key_gens)
@@ -84,7 +85,7 @@ class OrbitalQueriesManager:
     @new.register
     @classmethod
     def from_path(
-        cls, path: Path, spin: Union[str, Spin] = "", key_gens: Dict[str, Callable] = {}
+        cls, path: Path, spin: Union[str, Spin] = "", key_gens: dict[str, Callable] = {}
     ):
         """Initializes an OrbitalQueriesManager from a path, converting it to a sile."""
         return cls.new(sisl.get_sile(path), spin=spin, key_gens=key_gens)
@@ -95,7 +96,7 @@ class OrbitalQueriesManager:
         cls,
         sile: sisl.io.BaseSile,
         spin: Union[str, Spin] = "",
-        key_gens: Dict[str, Callable] = {},
+        key_gens: dict[str, Callable] = {},
     ):
         """Initializes an OrbitalQueriesManager from a sile."""
         return cls.new(sile.read_geometry(), spin=spin, key_gens=key_gens)
@@ -106,7 +107,7 @@ class OrbitalQueriesManager:
         cls,
         array: xarray.core.common.AttrAccessMixin,
         spin: Optional[Union[str, Spin]] = None,
-        key_gens: Dict[str, Callable] = {},
+        key_gens: dict[str, Callable] = {},
     ):
         """Initializes an OrbitalQueriesManager from an xarray object."""
         if spin is None:
@@ -120,7 +121,7 @@ class OrbitalQueriesManager:
         cls,
         data: Data,
         spin: Optional[Union[str, Spin]] = None,
-        key_gens: Dict[str, Callable] = {},
+        key_gens: dict[str, Callable] = {},
     ):
         """Initializes an OrbitalQueriesManager from a sisl Data object."""
         return cls.new(data._data, spin=spin, key_gens=key_gens)
@@ -129,7 +130,7 @@ class OrbitalQueriesManager:
         self,
         geometry: Optional[Geometry] = None,
         spin: Union[str, Spin] = "",
-        key_gens: Dict[str, Callable] = {},
+        key_gens: dict[str, Callable] = {},
     ):
         self.geometry = geometry
         self.spin = Spin(spin)
@@ -722,7 +723,7 @@ def reduce_orbital_data(
 
 
 def get_orbital_queries_manager(
-    obj, spin: Optional[str] = None, key_gens: Dict[str, Callable] = {}
+    obj, spin: Optional[str] = None, key_gens: dict[str, Callable] = {}
 ) -> OrbitalQueriesManager:
     return OrbitalQueriesManager.new(obj, spin=spin, key_gens=key_gens)
 
@@ -775,7 +776,7 @@ def split_orbitals(
 def atom_data_from_orbital_data(
     orbital_data,
     atoms: AtomsIndex = None,
-    request_kwargs: Dict = {},
+    request_kwargs: dict = {},
     geometry: Optional[Geometry] = None,
     reduce_func: Callable = np.mean,
     spin_reduce: Optional[Callable] = None,

--- a/src/sisl/viz/processors/spin.py
+++ b/src/sisl/viz/processors/spin.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import List, Literal, Union
+from typing import Literal, Union
 
 from sisl import Spin
 
@@ -24,7 +24,7 @@ _options = {
 
 def get_spin_options(
     spin: Union[Spin, str], only_if_polarized: bool = False
-) -> List[Literal[0, 1, "total", "x", "y", "z"]]:
+) -> list[Literal[0, 1, "total", "x", "y", "z"]]:
     """Returns the options for a given spin class.
 
     Parameters

--- a/src/sisl/viz/processors/tests/test_bands.py
+++ b/src/sisl/viz/processors/tests/test_bands.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 import xarray as xr
 
-import sisl
 from sisl import Spin
 from sisl.viz.data import BandsData
 from sisl.viz.processors.bands import (

--- a/src/sisl/viz/processors/tests/test_sci_groupreduce.py
+++ b/src/sisl/viz/processors/tests/test_sci_groupreduce.py
@@ -9,7 +9,6 @@ import xarray as xr
 
 import sisl
 from sisl.viz.processors.atom import reduce_atom_data
-from sisl.viz.processors.orbital import reduce_orbital_data
 
 pytestmark = [pytest.mark.viz, pytest.mark.processors]
 

--- a/src/sisl/viz/processors/xarray.py
+++ b/src/sisl/viz/processors/xarray.py
@@ -5,8 +5,9 @@
 # from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Sequence
 from functools import singledispatchmethod
-from typing import Any, Callable, Optional, Sequence, Tuple, TypedDict, Union
+from typing import Any, Callable, Optional, TypedDict, Union
 
 import numpy as np
 import xarray as xr
@@ -38,8 +39,8 @@ class Group(TypedDict, total=False):
 def group_reduce(
     data: Union[DataArray, Dataset, XarrayData],
     groups: Sequence[Group],
-    reduce_dim: Union[str, Tuple[str, ...]],
-    reduce_func: Union[Callable, Tuple[Callable, ...]] = np.mean,
+    reduce_dim: Union[str, tuple[str, ...]],
+    reduce_func: Union[Callable, tuple[Callable, ...]] = np.mean,
     groups_dim: str = "group",
     sanitize_group: Callable = lambda x: x,
     group_vars: Optional[Sequence[str]] = None,
@@ -219,7 +220,7 @@ def select(dataset: Dataset, dim: str, selector: Any) -> Dataset:
 
 def filter_energy_range(
     data: Union[DataArray, Dataset],
-    Erange: Optional[Tuple[float, float]] = None,
+    Erange: Optional[tuple[float, float]] = None,
     E0: float = 0,
 ) -> Union[DataArray, Dataset]:
     # Shift the energies

--- a/src/sisl/viz/types.py
+++ b/src/sisl/viz/types.py
@@ -3,18 +3,13 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, NewType, Optional, Sequence, Tuple, TypedDict, Union
+from typing import Any, Literal, NewType, Optional, TypedDict, Union
 
-import numpy as np
-import numpy.typing as npt
-
-import sisl
-from sisl._core.geometry import AtomCategory, Geometry
-from sisl._core.lattice import Lattice
 from sisl.io.sile import BaseSile
-from sisl.typing import AtomsIndex, GeometryLike, LatticeLike
+from sisl.typing import AtomsIndex
 
 PathLike = Union[str, Path, BaseSile]
 
@@ -22,7 +17,7 @@ Color = NewType("Color", str)
 
 # A colorscale can be a scale name, a sequence of colors or a sequence of
 # (value, color) tuples.
-Colorscale = Union[str, Sequence[Color], Sequence[Tuple[float, Color]]]
+Colorscale = Union[str, Sequence[Color], Sequence[tuple[float, Color]]]
 
 Axis = Union[
     Literal["x", "y", "z", "-x", "-y", "-z", "a", "b", "c", "-a", "-b", "-c"],

--- a/src/sisl_toolbox/cli/_cli_imports.py
+++ b/src/sisl_toolbox/cli/_cli_imports.py
@@ -7,5 +7,6 @@ from __future__ import annotations
 # going to be added. If they are not imported, they wont be registered
 __all__ = []
 
-import sisl_toolbox.siesta.atom
-import sisl_toolbox.transiesta.poisson
+
+import sisl_toolbox.siesta.atom  # noqa: F401
+import sisl_toolbox.transiesta.poisson  # noqa: F401

--- a/src/sisl_toolbox/siesta/atom/__init__.py
+++ b/src/sisl_toolbox/siesta/atom/__init__.py
@@ -4,3 +4,5 @@
 from __future__ import annotations
 
 from ._atom import AtomInput
+
+__all__ = ["AtomInput"]

--- a/src/sisl_toolbox/siesta/minimizer/_minimize_siesta.py
+++ b/src/sisl_toolbox/siesta/minimizer/_minimize_siesta.py
@@ -4,15 +4,12 @@
 from __future__ import annotations
 
 import logging
-from functools import partial
 from subprocess import CompletedProcess
 
 import numpy as np
 
 from sisl._array import arangei, arrayi, zerosd
 from sisl._internal import set_module
-from sisl.io import tableSile
-from sisl.io.siesta import fdfSileSiesta
 from sisl.utils import PropertyDict
 
 from ._minimize import *

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -42,7 +42,6 @@ import datetime
 import os
 import re
 import sys
-import time
 
 from git import Repo
 from github import Github

--- a/tools/codata.py
+++ b/tools/codata.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import sys
-from collections import OrderedDict
 from dataclasses import dataclass
 
 import numpy as np


### PR DESCRIPTION
This means moving from typing to intrinsics.

Many of the collections types are still not in-place.

<!-- Feel free to remove check-list items aren't relevant to your change -->
 - [x] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` [24.2.0] at top-level
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`
