### PR TITLE
Fixed spin polarized fatbands

### DIFF
--- a/src/sisl/viz/plots/bands.py
+++ b/src/sisl/viz/plots/bands.py
@@ -294,7 +294,7 @@ def fatbands_plot(
         group_vars=("color", "dash"),
         groups_dim="group",
         drop_empty=True,
-        spin_reduce=np.sum,
+        spin_reduce=False,
     )
     scaled_fatbands_data = scale_variable(
         fatbands_data,

--- a/src/sisl/viz/processors/bands.py
+++ b/src/sisl/viz/processors/bands.py
@@ -25,11 +25,12 @@ def filter_bands(
     # Shift the energies according to the reference energy, while keeping the
     # attributes (which contain the units, amongst other things)
     filtered_bands["E"] = bands_data.E - E0
-    continous_bands = filtered_bands.dropna("k", how="all", subset=["E"])
 
     # Get the bands that matter for the plot
     if Erange is None:
         if bands_range is None:
+            continous_bands = filtered_bands.dropna("k", how="all", subset=["E"])
+
             # If neither E range or bands_range was provided, we will just plot the 15 bands below and above the fermi level
             CB = int(
                 continous_bands.E.where(continous_bands.E <= 0).argmax("band").max()
@@ -40,17 +41,17 @@ def filter_bands(
             ]
 
         filtered_bands = filtered_bands.sel(band=slice(*bands_range))
-        continous_bands = filtered_bands.dropna("k", how="all", subset=["E"])
 
         # This is the new Erange
+        # continous_bands = filtered_bands.dropna("k", how="all", subset=["E"])
         # Erange = np.array([float(f'{val:.3f}') for val in [float(continous_bands.E.min() - 0.01), float(continous_bands.E.max() + 0.01)]])
     else:
         filtered_bands = filtered_bands.where(
             (filtered_bands <= Erange[1]) & (filtered_bands >= Erange[0])
         ).dropna("band", how="all", subset=["E"])
-        continous_bands = filtered_bands.dropna("k", how="all", subset=["E"])
 
         # This is the new bands range
+        # continous_bands = filtered_bands.dropna("k", how="all", subset=["E"])
         # bands_range = [int(continous_bands['band'].min()), int(continous_bands['band'].max())]
 
     # Give the filtered bands the same attributes as the full bands

--- a/src/sisl/viz/processors/bands.py
+++ b/src/sisl/viz/processors/bands.py
@@ -25,7 +25,7 @@ def filter_bands(
     # Shift the energies according to the reference energy, while keeping the
     # attributes (which contain the units, amongst other things)
     filtered_bands["E"] = bands_data.E - E0
-    continous_bands = filtered_bands.dropna("k", how="all")
+    continous_bands = filtered_bands.dropna("k", how="all", subset=["E"])
 
     # Get the bands that matter for the plot
     if Erange is None:
@@ -40,15 +40,15 @@ def filter_bands(
             ]
 
         filtered_bands = filtered_bands.sel(band=slice(*bands_range))
-        continous_bands = filtered_bands.dropna("k", how="all")
+        continous_bands = filtered_bands.dropna("k", how="all", subset=["E"])
 
         # This is the new Erange
         # Erange = np.array([float(f'{val:.3f}') for val in [float(continous_bands.E.min() - 0.01), float(continous_bands.E.max() + 0.01)]])
     else:
         filtered_bands = filtered_bands.where(
             (filtered_bands <= Erange[1]) & (filtered_bands >= Erange[0])
-        ).dropna("band", how="all")
-        continous_bands = filtered_bands.dropna("k", how="all")
+        ).dropna("band", how="all", subset=["E"])
+        continous_bands = filtered_bands.dropna("k", how="all", subset=["E"])
 
         # This is the new bands range
         # bands_range = [int(continous_bands['band'].min()), int(continous_bands['band'].max())]

--- a/src/sisl/viz/processors/tests/test_orbital.py
+++ b/src/sisl/viz/processors/tests/test_orbital.py
@@ -224,6 +224,17 @@ def test_reduce_orbital_data_spin(geometry, spin):
         assert np.allclose(sel_total.values, red_total.values)
 
 
+def test_reduce_orbital_data_no_spin(geometry, spin):
+    """Reduce orbital data without reducing the spin dimension"""
+    data = PDOSData.toy_example(geometry=geometry, spin=spin)._data
+
+    reduced = reduce_orbital_data(
+        data, [{"name": "all", "spin": "total"}], spin_reduce=False
+    )
+
+    assert np.all(data.spin == reduced.spin)
+
+
 def test_atom_data_from_orbital_data(geometry: Geometry, spin):
     data = PDOSData.toy_example(geometry=geometry, spin=spin)._data
 


### PR DESCRIPTION
thanks to @ialcon.

Before this commit, when computing fatbands contributions (grouping orbitals), the spin dimension was being reduced. This makes no sense because the bands for each spin might be different and therefore fatbands must be drawn separately for each spin (there is no meaningful way to aggregate them in general).

Also, there was a "bug" when filtering bands in the case of fatbands which resulted in plotting all bands even if they were out of range and slowed the rendering of the plot.
