### PR TITLE
Accessors and grouping documentation entries

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,33 +1,191 @@
-{% extends "!autosummary/class.rst" %}
+{{ fullname | escape | underline}}
 
-    {% block attributes %}
-    {% if attributes %}
-    .. rubric:: {{ _('Attributes') }}
+{# Global variables specified for use further down #}
 
-    .. autosummary::
-    {% for item in attributes %}
-        {% if not item.startswith('_') %}
-          ~{{ name }}.{{ item }}
-	{% endif %}
-    {%- endfor %}
-    {% endif %}
-    {% endblock %}
+{% set check_ns = namespace(
+      plot=false,
+      to=false,
+      new=false,
+      apply=false,
+      )
+%}
+{% set specials = [
+      'plot',
+      'apply',
+      'to',
+      'new',
+   ]
+%}
 
-   {% block methods %}
-   {% if methods %}
+{% macro check_sections() %}
+{# Check for variables that should be in specific sections #}
+
+{% for things in varargs %}
+{% for item in things %}
+
+   {# Determine whether we should do any Plotting section #}
+   {% if item.startswith('plot.') %}
+      {% set check_ns.plot = true %}
+   {%- endif %}
+
+   {% if item.startswith('to.') %}
+      {% set check_ns.to = true %}
+   {%- endif %}
+
+   {% if item.startswith('new.') %}
+      {% set check_ns.new = true %}
+   {%- endif %}
+
+   {# Determine whether we should do any Dispatch section #}
+   {% if item.startswith('apply.') %}
+      {% set check_ns.apply = true %}
+   {%- endif %}
+
+{%- endfor %}
+{%- endfor %}
+{%- endmacro %}
+
+
+{% macro extract_startswith(start, short) %}
+{#
+
+Write out a list of items that starts with `start`
+
+Parameters
+ start :
+      what to check if the item starstwith. If yes, then keep it.
+ short :
+      whether it should be formatted like ~{{name}}.{{item}} (true)
+      or without the ~.
+
+#}
+
+{% for things in varargs %}
+{% for item in things %}
+
+   {% if item.startswith(start) %}
+      {% if short %}
+      ~{{ name }}.{{ item }}
+      {% else %}
+      {{ name }}.{{ item }}
+      {%- endif %}
+   {%- endif %}
+
+{%- endfor %}
+{%- endfor %}
+{%- endmacro %}
+
+
+{% macro accepted_methods() %}
+{% set skip_methods =
+                   ['ArgumentParser', 'ArgumentParser_out',
+                    'is_keys', 'key2case', 'keys2case',
+                    'line_has_key', 'line_has_keys', 'readline',
+                    'step_either', 'step_to',
+                    'isDataset', 'isDimension', 'isGroup',
+                    'isRoot', 'isVariable'] + specials
+%}
+
+{# Loop on the arguments #}
+{% for things in varargs %}
+{% for item in things %}
+
+   {% set tmp = namespace(keep=true) %}
+
+   {#
+
+   Use the namespace variable to pass down
+   contexts. This is needed because variables
+   in Jinja are hard scoped.
+   #}
+
+   {% if item.startswith('_') %}
+      {% set tmp.keep = false %}
+   {%- endif %}
+   {% if item in skip_methods %}
+      {% set tmp.keep = false %}
+   {%- endif %}
+
+   {% for starts in specials %}
+   {% if item.startswith(starts + '.') %}
+      {% set tmp.keep = false %}
+   {%- endif %}
+   {%- endfor %}
+
+   {% if tmp.keep %}
+   {# Call the parent caller with the item that has
+      passed all tests for eligibility
+   #}
+   {{ caller(item) }}
+   {%- endif %}
+
+{%- endfor %}
+{%- endfor %}
+
+{%- endmacro %}
+
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+{#
+   Just call the macro, this won't write anything,
+   only set some variables in the check_ns namespace variable
+#}
+{{ check_sections(attributes, methods) }}
+
+{% block attributes %}
+{% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+      {% call(item) accepted_methods(attributes) %}
+      ~{{ name }}.{{ item }}
+      {%- endcall %}
+{%- endif %}
+{%- endblock %}
+
+{% if check_ns.to or check_ns.new %}
+   .. rubric:: {{ _('Conversions') }}
+
+   .. autosummary::
+      {% if check_ns.new %}
+      {{ name }}.new
+      {% endif %}
+      {{ extract_startswith('new.', false, attributes, methods) }}
+      {% if check_ns.to %}
+      {{ name }}.to
+      {% endif %}
+      {{ extract_startswith('to.', false, attributes, methods) }}
+
+{%- endif %}
+
+{% if check_ns.plot %}
+   .. rubric:: {{ _('Plotting') }}
+
+   .. autosummary::
+      {{ name }}.plot
+      {{ extract_startswith('plot.', false, attributes, methods) }}
+
+{%- endif %}
+
+{% if check_ns.apply %}
+   .. rubric:: {{ _('Dispatching') }}
+
+   .. autosummary::
+      {{ name }}.apply
+      {{ extract_startswith('apply.', false, attributes, methods) }}
+
+{%- endif %}
+
+{% block methods %}
+{% if methods %}
    .. rubric:: {{ _('Methods') }}
 
    .. autosummary::
-   {% for item in methods %}
-      {% if not (item.startswith('_') or item in
-                         ['ArgumentParser', 'ArgumentParser_out',
-			  'is_keys', 'key2case', 'keys2case',
-                          'line_has_key', 'line_has_keys', 'readline',
-                          'step_either', 'step_to',
-			  'isDataset', 'isDimension', 'isGroup',
-			  'isRoot', 'isVariable']) %}
-           ~{{ name }}.{{ item }}
-      {% endif %}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
+      {% call(item) accepted_methods(methods) %}
+      ~{{ name }}.{{ item }}
+      {%- endcall %}
+{%- endif %}
+{%- endblock %}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -122,7 +122,6 @@ Parameters
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
-
 {#
    Just call the macro, this won't write anything,
    only set some variables in the check_ns namespace variable
@@ -135,11 +134,13 @@ Parameters
 Now the actual writing of things happen!
 #}
 
-{% block conversions %}
+{% block conversion %}
 {% if 'to' in found_ns.found or 'new' in found_ns.found %}
-   .. rubric:: {{ _('Conversions') }}
+   .. rubric:: {{ _('Conversion') }}
 
    .. autosummary::
+      :removeprefix: {{ name }}.
+
       {% if 'new' in found_ns.found %}
       {{ name }}.new
       {% endif %}
@@ -158,6 +159,8 @@ Now the actual writing of things happen!
    .. rubric:: {{ _('Plotting') }}
 
    .. autosummary::
+      :removeprefix: {{ name }}.
+
       {{ name }}.plot
       {{ extract_startswith('plot.', false, attributes, methods) }}
 
@@ -170,6 +173,8 @@ Now the actual writing of things happen!
    .. rubric:: :math:`k`-{{ _('point') }} {{ _('calculations') }}
 
    .. autosummary::
+      :removeprefix: {{ name }}.
+
       {{ name }}.apply
       {{ extract_startswith('apply.', false, attributes, methods) }}
 

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -135,16 +135,10 @@ Parameters
 #}
 {{ check_sections(attributes, methods) }}
 
-{% block attributes %}
-{% if attributes %}
-   .. rubric:: {{ _('Attributes') }}
 
-   .. autosummary::
-      {% call(item) accepted_methods(attributes) %}
-      ~{{ name }}.{{ item }}
-      {%- endcall %}
-{%- endif %}
-{%- endblock %}
+{#
+Now the actual writing of things happen!
+#}
 
 {% if check_ns.to or check_ns.new %}
    .. rubric:: {{ _('Conversions') }}
@@ -185,6 +179,17 @@ Parameters
 
    .. autosummary::
       {% call(item) accepted_methods(methods) %}
+      ~{{ name }}.{{ item }}
+      {%- endcall %}
+{%- endif %}
+{%- endblock %}
+
+{% block attributes %}
+{% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+      {% call(item) accepted_methods(attributes) %}
       ~{{ name }}.{{ item }}
       {%- endcall %}
 {%- endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -853,6 +853,32 @@ def sisl_skip(app, what, name, obj, skip, options):
     return skip
 
 
+from docutils.parsers.rst import directives
+
+#######
+# @pfebrer's suggestion for overriding the shown prefix for the templates.
+from sphinx.ext.autosummary import Autosummary
+
+
+class RemovePrefixAutosummary(Autosummary):
+    """Wrapper around the autosummary directive to allow for custom display names.
+
+    Adds a new option `:removeprefix:` which removes a prefix from the display names.
+    """
+
+    option_spec = {**Autosummary.option_spec, "removeprefix": directives.unchanged}
+
+    def get_items(self, *args, **kwargs):
+        items = super().get_items(*args, **kwargs)
+
+        remove_prefix = self.options.get("removeprefix")
+        if remove_prefix is not None:
+            items = [(item[0].removeprefix(remove_prefix), *item[1:]) for item in items]
+
+        return items
+
+
 def setup(app):
     # Setup autodoc skipping
     app.connect("autodoc-skip-member", sisl_skip)
+    app.add_directive("autosummary", RemovePrefixAutosummary, override=True)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -746,17 +746,31 @@ def yield_types(obj: object, classes):
                 pass
 
 
+_found_dispatch_attributes = set()
 for obj in yield_objects(sisl):
 
     for name, attr in yield_types(obj, sisl._dispatcher.AbstractDispatcher):
         # Fix the class dispatchers methods
         assign_class_dispatcher_methods(obj, name, as_attributes=True)
+        # Collect all the different names where a dispatcher is associated.
+        # In this way we die if we add a new one, without documenting it!
+        _found_dispatch_attributes.add(name)
 
     for name, attr in yield_types(
         obj, (sisl.io._multiple.SileBound, sisl.io._multiple.SileBinder)
     ):
 
         assign_nested_attribute(obj, name, attr.__wrapped__)
+
+
+if (
+    len(
+        diff := _found_dispatch_attributes
+        - set(autosummary_context["sisl_dispatch_attributes"])
+    )
+    > 0
+):
+    raise ValueError(f"Found more sets than defined: {diff}")
 
 
 def sisl_skip(app, what, name, obj, skip, options):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -767,7 +767,7 @@ for obj in yield_objects(sisl):
 
     for name, attr in yield_types(obj, sisl._dispatcher.AbstractDispatcher):
         # Fix the class dispatchers methods
-        assign_class_dispatcher_methods(obj, name, as_attributes=False)
+        assign_class_dispatcher_methods(obj, name, as_attributes=name in ["apply"])
         # Collect all the different names where a dispatcher is associated.
         # In this way we die if we add a new one, without documenting it!
         _found_dispatch_attributes.add(name)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -752,6 +752,12 @@ for obj in yield_objects(sisl):
         # Fix the class dispatchers methods
         assign_class_dispatcher_methods(obj, name, as_attributes=True)
 
+    for name, attr in yield_types(
+        obj, (sisl.io._multiple.SileBound, sisl.io._multiple.SileBinder)
+    ):
+
+        assign_nested_attribute(obj, name, attr.__wrapped__)
+
 
 def sisl_skip(app, what, name, obj, skip, options):
     global autodoc_default_options, autosummary_context

--- a/src/sisl/_dispatcher.py
+++ b/src/sisl/_dispatcher.py
@@ -10,11 +10,12 @@ This method allows classes to dispatch methods through other classes.
 Here is a small snippet showing how to utilize this module.
 
 """
+import inspect
 import logging
 from abc import ABCMeta, abstractmethod
 from collections import ChainMap, namedtuple
 from functools import update_wrapper
-from typing import Any
+from typing import Any, Callable, Union
 
 from sisl.utils._search_mro import find_implementation
 
@@ -52,6 +53,70 @@ class AbstractDispatch(metaclass=ABCMeta):
         # This could in principle contain anything.
         self._attrs = attrs
         _log.debug(f"__init__ {self.__class__.__name__}", extra={"obj": self})
+
+    @classmethod
+    def __from_function__(
+        cls, func: Optional[Callable] = None, *, name: Optional[str] = None, **kwargs
+    ) -> Self:
+        """Wrap function to return a new class (in the named function) for easier
+        handling
+
+        Parameters
+        ----------
+        func :
+            the function to be wrapped to a new type.
+            If not specified the remaining arguments can be used to return
+            a decorator.
+        name :
+            Returned class name of the decorated function.
+        **kwargs :
+            Methods added to the ``type(name, (cls,), kwargs)``.
+
+        Examples
+        --------
+
+        >>> @DispatchClass.__from_function__
+        ... def func(msg):
+        ...     print(msg)
+        >>> print(func)
+        <class '__main__.func'>
+
+        >>> @DispatchClass.__from_function__(name="Hello")
+        ... def func(msg):
+        ...     print(msg)
+        >>> print(func)
+        <class '__main__.Hello'>
+        """
+        if func is None:
+
+            def decorator(func) -> Self:
+                return cls.__from_function__(func, name=name, **kwargs)
+
+            return decorator
+
+        if name is None:
+            name = func.__name__
+
+        things = dict(__signature__=inspect.signature(func), dispatch=func)
+        for attr in (
+            "__module__",
+            "__name__",
+            "__qualname__",
+            "__doc__",
+            "__annotations__",
+            "__type_params__",
+        ):
+            try:
+                value = getattr(func, attr)
+            except AttributeError:
+                pass
+            else:
+                things[attr] = value
+
+        # Add user-defined details
+        things.update(**kwargs)
+
+        return type(name, (cls,), things)
 
     def copy(self):
         """Create a copy of this object (will not copy `obj`)"""

--- a/src/sisl/_dispatcher.py
+++ b/src/sisl/_dispatcher.py
@@ -524,7 +524,7 @@ class TypeDispatcher(ObjectDispatcher):
             if isinstance(cls_dispatch, ClassDispatcher):
                 cls_dispatch.register(key, dispatch, overwrite=overwrite)
 
-    def __call__(self, obj, *args, **kwargs):
+    def __call__(self, obj: Any, *args, **kwargs) -> Any:
         # A call on a TypeDispatcher forces at least a single argument
         # where the type is being dispatched.
 

--- a/src/sisl/_dispatcher.py
+++ b/src/sisl/_dispatcher.py
@@ -110,6 +110,7 @@ class AbstractDispatch(metaclass=ABCMeta):
         A basic interception would be
 
         .. code:: python
+
             @wraps(method)
             def func(*args, **kwargs):
                 return method(*args, **kwargs)

--- a/src/sisl/io/_multiple.py
+++ b/src/sisl/io/_multiple.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable
 from functools import reduce, update_wrapper
 from itertools import zip_longest

--- a/src/sisl/io/_multiple.py
+++ b/src/sisl/io/_multiple.py
@@ -214,11 +214,6 @@ class SileBound:
         base_name = func.__name__
         name = f"{base_name}[...|{default_slice!r}]"
 
-        try:
-            doc = func.__doc__
-        except AttributeError:
-            doc = ""
-
         if default_slice == 0:
             default_slice = "the first"
         elif default_slice == -1:
@@ -257,9 +252,8 @@ class SileBound:
         # Correctly parse the doc strings.
         # Generally the first line has the wrong indentation.
         # So let's correct that!
-        doc0, *docs = doc.splitlines(True)
-        docs = "".join(docs)
-        doc = "\n".join([dedent(doc0), dedent(docs), dedent(docs_slicer)])
+        doc = inspect.getdoc(func)
+        doc = "\n".join([doc, dedent(docs_slicer)])
         return {"__name__": name, "__doc__": doc}
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This is an extended try of @pfebrer try in #839.

I took the details there, and played with it, and extended it a bit more.

So now basically all is done in the template files.
It ain't pretty, but is self-contained.

I kind-of-don't like it. But it seems much simpler than hacking in the python code, and extending what autodoc does.

The advantages are:
- we have manual control of how the layout should be
- we can also double document a few details, if needed, e.g. the `to`/`plot` could both be in their designated sections, but also in the `Methods` section.
- it is very easy to add another section
- right now everything is automatic, I just check whether an attribute of a class is an instance of a `sisl._dispatch.AbstractDispatcher`, and patches the attributes based on that.

Disadvantages:
- we don't have access to the actual documentation, so can't really do anything there in the jinja templates.
- the way we *get* the documentation is very hacky.... It overwrites attributes in the classes, which it shouldn't do, but
  it gives the effect. It just means that tool-tips might not work... :(
- fine-grained control is limited to a rather horrible jinja templating engine, which is extremely verbose, and sometimes limited.

@pfebrer let me know what you think?

Of course, the actual docs are still missing... ;)

Here are a few pics:

Type 1:
![image](https://github.com/user-attachments/assets/3e8df314-5ce8-4050-b421-b7ab85c27670)

Type 2:
![image](https://github.com/user-attachments/assets/bcb4bf83-701f-4a7e-9655-b3e799590be6)

Type 3:
![image](https://github.com/user-attachments/assets/4028f180-78f0-4f8c-a407-391f5d9b3def)

 - [x] Closes #839
 - [x] Added tests for new/changed functions?
 - [x] Ran `isort .` and `black .` [24.2.0] at top-level
 - [x] Documentation for functionality in `docs/`
 - [ ] Changes documented in `CHANGELOG.md`
