### PR TITLE
fixed bug reading geometry from ncSileSiesta

### DIFF
--- a/src/sisl/io/siesta/siesta_nc.py
+++ b/src/sisl/io/siesta/siesta_nc.py
@@ -143,9 +143,7 @@ class ncSileSiesta(SileCDFSiesta):
         xyz.shape = (-1, 3)
 
         if "BASIS" in self.groups:
-            basis = self.read_basis()
-            species = self.groups["BASIS"].variables["basis"][:] - 1
-            atom = Atoms([basis[i] for i in species])
+            atom = self.read_basis()
         else:
             atom = Atom(1)
 


### PR DESCRIPTION
Fixes #840 

It was a simple bug, in `read_geometry` after reading the basis with `read_basis` the basis was used as a "table" when in reality what `read_basis` returns is directly the `Atoms` object to pass to the geometry.

Probably it would help to have tests with a `nc` file.