### PR TITLE
fixed 5.2 reading of charges

### DIFF
--- a/src/sisl/io/siesta/stdout.py
+++ b/src/sisl/io/siesta/stdout.py
@@ -9,7 +9,6 @@ from functools import lru_cache
 from typing import Literal, Optional
 
 import numpy as np
-from matplotlib import namedtuple
 
 import sisl._array as _a
 from sisl import Atom, Atoms, Geometry, Lattice

--- a/src/sisl/io/siesta/stdout.py
+++ b/src/sisl/io/siesta/stdout.py
@@ -117,7 +117,7 @@ def _parse_version(attr, instance, match):
     version, *spec = opt.split("-", maxsplit=1)
     try:
         version = tuple(int(v) for v in version.split("."))
-    except:
+    except BaseException:
         version = (0, 0, 0)
 
     # Convert version to a tuple
@@ -1427,7 +1427,7 @@ class stdoutSileSiesta(SileSiesta):
                             "Mulliken Atomic Populations",
                             "Mulliken Net Atomic Populations",
                         ]
-                except:
+                except BaseException:
                     pass
 
         else:


### PR DESCRIPTION
Now the stdout sile for siesta tries
to automatically determine the used charge
reading algorithm, one can still forcefully
request the old-style. But if the version
is 5.2 or later, it will default
to the new scheme.

This commit also fixes the issue of the changed
column names.

The stdout sile now also contains the version
specification.

Fixes #856

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #856
 - [ ] Added tests for new/changed functions?
 - [ ] Documentation for functionality in `docs/`
 - [ ] Changes documented in `CHANGELOG.md`

<!--
Creating a PR will check whether the pre-commit hooks
have runned, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`

The short message is:
- run `isort .` at the top level
- run `black .` (version=24.2.0) at top-level
-->
