### PR TITLE
New wheels

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -35,7 +35,7 @@ jobs:
     needs: sdist
 
     env:
-      CIBW_BUILD_VERBOSITY: 3
+      CIBW_BUILD_VERBOSITY: 1
       CIBW_BEFORE_BUILD: >-
         rm -rf {package}/build
       # Instead of running pytest directly, we use a bash script that will set up
@@ -52,7 +52,7 @@ jobs:
       # Perhaps in some later release
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       # Deployment of the SDK in MacOS
-      MACOSX_DEPLOYMENT_TARGET: "10.12"
+      MACOSX_DEPLOYMENT_TARGET: "${{ matrix.deployment_target }}"
 
     strategy:
       # Ensure that a wheel builder finishes even if another fails
@@ -83,11 +83,11 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      #- name: Ensure fortran
-      #  uses: fortran-lang/setup-fortran@v1
-      #  with:
-      #    compiler: gcc
-      #    version: 11
+      - name: Ensure fortran
+        uses: fortran-lang/setup-fortran@v1
+        with:
+          compiler: gcc
+          version: 11
 
       - name: Build wheels for CPython 3.12
         uses: pypa/cibuildwheel@v2.21.3

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -58,8 +58,6 @@ jobs:
           # Linux 64 bit manylinux2014
           - os: ubuntu-20.04
             cibw_archs: "x86_64"
-          - os: ubuntu-20.04
-            cibw_archs: "aarch64"
 
           # MacOS x86_64
           - os: macos-13
@@ -88,7 +86,7 @@ jobs:
       - name: Build wheels for CPython 3.13
         uses: pypa/cibuildwheel@v2.21.3
         env:
-          CIBW_BUILD: "cp313-* cp313t-*"
+          CIBW_BUILD: "cp313t-* cp313-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_BUILD_FRONTEND:
             "pip; args: --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
@@ -104,7 +102,24 @@ jobs:
           CIBW_BUILD: "cp312-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
-      # Upload the wheel to the action's artifact.
+      - name: Build wheels for CPython 3.11
+        uses: pypa/cibuildwheel@v2.21.3
+        env:
+          CIBW_BUILD: "cp311-*"
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+
+      - name: Build wheels for CPython 3.10
+        uses: pypa/cibuildwheel@v2.21.3
+        env:
+          CIBW_BUILD: "cp310-*"
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+
+      - name: Build wheels for CPython 3.9
+        uses: pypa/cibuildwheel@v2.21.3
+        env:
+          CIBW_BUILD: "cp39-*"
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -131,81 +146,6 @@ jobs:
           path: dist/*.tar.gz
           if-no-files-found: error
 
-  # Upload to testpypi
-  upload_testpypi:
-    needs: [sdist, wheels]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    name: Publish package to TestPyPI
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: cibw-*
-          path: dist
-          merge-multiple: True
-
-      - name: Print packages
-        run: ls dist
-
-      - uses: pypa/gh-action-pypi-publish@v1.10.3
-        with:
-          user: __token__
-          password: ${{ secrets.TESTPYPI_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
-
-  # Check that the testpypi installation works
-  test_testpypi:
-    needs: [upload_testpypi]
-    name: Test installation from TestPyPi
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      # If one of the jobs fails, continue with the others.
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-13, macos-14]
-
-    steps:
-      - name: Python installation
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
-      - name: Wait for testpypi to catch up
-        run: |
-          sleep 20
-          version=${GITHUB_REF#refs/*/v}
-          echo "SISL_VERSION=${version#refs/*/}" >> $GITHUB_ENV
-          ls -lh
-
-      - name: Install sisl + dependencies (oldest numpy, not ARM)
-        if: matrix.os != 'macos-14'
-        run: |
-          python -m pip install -v \
-            --progress-bar=off \
-            --index-url https://test.pypi.org/simple/ \
-            --extra-index-url https://pypi.org/simple/ \
-            "sisl[test,viz]==${{ env.SISL_VERSION }}" \
-            "numpy==1.21.*" "scipy==1.6.*" "xarray==0.21.*"
-
-      - name: Install sisl + dependencies (arm)
-        if: matrix.os == 'macos-14'
-        run: |
-          python -m pip install -v \
-            --progress-bar=off \
-            --index-url https://test.pypi.org/simple/ \
-            --extra-index-url https://pypi.org/simple/ \
-            "sisl[test,viz]==${{ env.SISL_VERSION }}"
-
-      - name: sisl debug info
-        run: |
-          python -c 'from sisl._debug_info import * ; print_debug_info()'
-
-      - name: Test the installation
-        run: |
-          pytest --pyargs sisl
-
-  # Upload to PyPI on every tag
   upload_pypi:
     needs: [test_testpypi]
     name: Publish package to Pypi

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -26,79 +26,56 @@ jobs:
   # and python versions so that builds are ran in parallel.
   # The job matrix is basically copied from https://github.com/scikit-learn/scikit-learn/blob/main/.github/workflows/wheels.yml
   wheels:
-    name: cp${{ matrix.python[0] }}-${{ matrix.platform_id }}-${{ matrix.manylinux_image }}
+    name: cp${{ matrix.os }}-${{ matrix.cibw_archs }}
     runs-on: ${{ matrix.os }}
+    needs: sdist
+
+    env:
+      CIBW_BUILD_VERBOSITY: 3
+      CIBW_BEFORE_BUILD: >-
+        rm -rf {package}/build
+      # Instead of running pytest directly, we use a bash script that will set up
+      # the appropiate value for the SISL_FILES_TEST variable, a path pointing to
+      # the sisl-files directory, which contains files for testing.
+      CIBW_TEST_COMMAND: >-
+        bash {project}/tools/build_tools/test_wheels.sh
+      CIBW_TEST_REQUIRES: "joblib"
+      CIBW_TEST_EXTRAS: "test"
+
+      CIBW_SKIP: "*-musllinux_aarch64 pp*"
+      # For now we use manylinux 2014, which supports ubuntu 20.
+      # We should in principle bump to 2_28, but that only supports ubuntu 21
+      # Perhaps in some later release
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+      # Deployment of the SDK in MacOS
+      MACOSX_DEPLOYMENT_TARGET: "10.12"
 
     strategy:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
         include:
-          # Window 64 bit
-          #- os: windows-latest
-          #  python: ["310", "3.10"]
-          #  platform_id: win_amd64
-
           # Linux 64 bit manylinux2014
-          - os: ubuntu-latest
-            python: ["39", "3.9"]
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python: ["310", "3.10"]
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python: ["311", "3.11"]
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python: ["312", "3.12"]
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python: ["313", "3.13"]
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+          - os: ubuntu-20.04
+            cibw_archs: "x86_64"
+          - os: ubuntu-20.04
+            cibw_archs: "aarch64"
 
           # MacOS x86_64
-          - os: macos-12
-            python: ["39", "3.9"]
-            platform_id: macosx_x86_64
-          - os: macos-12
-            python: ["310", "3.10"]
-            platform_id: macosx_x86_64
-          - os: macos-12
-            python: ["311", "3.11"]
-            platform_id: macosx_x86_64
-          - os: macos-12
-            python: ["312", "3.12"]
-            platform_id: macosx_x86_64
-          - os: macos-12
-            python: ["313", "3.13"]
-            platform_id: macosx_x86_64
-
-          # MacOS arm64
+          - os: macos-13
+            cibw_archs: "x86_64"
           - os: macos-14
-            python: ["39", "3.9"]
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: ["310", "3.10"]
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: ["311", "3.11"]
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: ["312", "3.12"]
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: ["313", "3.13"]
-            platform_id: macosx_arm64
+            cibw_archs: "arm64"
 
     steps:
 
-      - name: Checkout sisl
-        uses: actions/checkout@v4
+      - name: Set up QEMU
+        if: matrix.cibw_archs == 'aarch64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: actions/checkout@v4
 
       - name: Ensure fortran
         uses: fortran-lang/setup-fortran@v1
@@ -106,27 +83,19 @@ jobs:
           compiler: gcc
           version: 11
 
-      - name: Print-out commit information
-        run: |
-          echo "branch: ${{ github.event.inputs.branch }}"
-          echo "hash: ${{ github.sha }}"
-          echo "python-version: ${{ matrix.python[0] }} - ${{ matrix.python[1] }}"
-
-      - name: Build and test wheels
+      - name: Build wheels for CPython 3.12
+        uses: pypa/cibuildwheel@2.21.3
         env:
-          CIBW_BUILD: cp${{ matrix.python[0] }}-${{ matrix.platform_id }}
-          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
-          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_image }}
-        shell: bash -el {0}
-        run: |
-          bash -e tools/build_tools/build_wheels.sh
+          CIBW_BUILD: "cp312-*"
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       # Upload the wheel to the action's artifact.
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: artifact-cp${{ matrix.python[0] }}-${{ matrix.platform_id }}
+          name: cibw-wheels-${{ runner.os }}-${{ matrix.cibw_archs }}
           path: ./wheelhouse/*.whl
+          if-no-files-found: error
 
   # Build the source distribution as well
   sdist:
@@ -134,6 +103,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Build sdist
         run: |
@@ -141,7 +112,9 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: cibw-sdist
           path: dist/*.tar.gz
+          if-no-files-found: error
 
   # Upload to testpypi
   upload_testpypi:
@@ -177,7 +150,7 @@ jobs:
       - name: Python installation
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Wait for testpypi to catch up
         run: |

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -147,7 +147,6 @@ jobs:
           if-no-files-found: error
 
   upload_pypi:
-    needs: [test_testpypi]
     name: Publish package to Pypi
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -84,7 +84,7 @@ jobs:
           version: 11
 
       - name: Build wheels for CPython 3.12
-        uses: pypa/cibuildwheel@2.21.3
+        uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_BUILD: "cp312-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -90,13 +90,13 @@ jobs:
         env:
           CIBW_BUILD: "cp313-* cp313t-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          #CIBW_BUILD_FRONTEND:
-          #  "pip; args: --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+          CIBW_BUILD_FRONTEND:
+            "pip; args: --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
           CIBW_FREE_THREADED_SUPPORT: true
-          #CIBW_BEFORE_TEST: >-
-          #  pip install --pre
-          #  --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-          #  numpy scipy
+          CIBW_BEFORE_TEST: >-
+            pip install --pre
+            --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+            numpy scipy
 
       - name: Build wheels for CPython 3.12
         uses: pypa/cibuildwheel@v2.21.3

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -47,10 +47,6 @@ jobs:
       CIBW_TEST_EXTRAS: "test"
 
       CIBW_SKIP: "*-musllinux_aarch64 pp*"
-      # For now we use manylinux 2014, which supports ubuntu 20.
-      # We should in principle bump to 2_28, but that only supports ubuntu 21
-      # Perhaps in some later release
-      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       # Deployment of the SDK in MacOS
       MACOSX_DEPLOYMENT_TARGET: "${{ matrix.deployment_target }}"
 
@@ -88,6 +84,19 @@ jobs:
         with:
           compiler: gcc
           version: 11
+
+      - name: Build wheels for CPython 3.13
+        uses: pypa/cibuildwheel@v2.21.3
+        env:
+          CIBW_BUILD: "cp313-* cp313t-*"
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_BUILD_FRONTEND:
+            "pip; args: --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+          CIBW_FREE_THREADED_SUPPORT: true
+          CIBW_BEFORE_TEST: >-
+            pip install --pre
+            --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+            numpy
 
       - name: Build wheels for CPython 3.12
         uses: pypa/cibuildwheel@v2.21.3

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -18,6 +18,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+
+permissions:
+  contents: read
+
 jobs:
 
   # cibuildwheels already manages multiple python versions automatically
@@ -26,7 +30,7 @@ jobs:
   # and python versions so that builds are ran in parallel.
   # The job matrix is basically copied from https://github.com/scikit-learn/scikit-learn/blob/main/.github/workflows/wheels.yml
   wheels:
-    name: cp${{ matrix.os }}-${{ matrix.cibw_archs }}
+    name: ${{ matrix.os }} for ${{ matrix.cibw_archs }}
     runs-on: ${{ matrix.os }}
     needs: sdist
 
@@ -64,8 +68,10 @@ jobs:
           # MacOS x86_64
           - os: macos-13
             cibw_archs: "x86_64"
+            deployment_target: "13.0"
           - os: macos-14
             cibw_archs: "arm64"
+            deployment_target: "14.0"
 
     steps:
 
@@ -77,11 +83,11 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Ensure fortran
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: gcc
-          version: 11
+      #- name: Ensure fortran
+      #  uses: fortran-lang/setup-fortran@v1
+      #  with:
+      #    compiler: gcc
+      #    version: 11
 
       - name: Build wheels for CPython 3.12
         uses: pypa/cibuildwheel@v2.21.3
@@ -125,8 +131,12 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          merge-multiple: True
+          pattern: cibw-*
           path: dist
+          merge-multiple: True
+
+      - name: Print packages
+        run: ls dist
 
       - uses: pypa/gh-action-pypi-publish@v1.10.3
         with:
@@ -197,8 +207,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          merge-multiple: True
+          pattern: cibw-*
           path: dist
+          merge-multiple: True
 
       - uses: pypa/gh-action-pypi-publish@v1.10.3
         with:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -146,7 +146,83 @@ jobs:
           path: dist/*.tar.gz
           if-no-files-found: error
 
+  # Upload to testpypi
+  upload_testpypi:
+    needs: [sdist, wheels]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    name: Publish package to TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: True
+
+      - name: Print packages
+        run: ls dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.10.3
+        with:
+          user: __token__
+          password: ${{ secrets.TESTPYPI_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+
+  # Check that the testpypi installation works
+  test_testpypi:
+    needs: [upload_testpypi]
+    name: Test installation from TestPyPi
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # If one of the jobs fails, continue with the others.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-latest, macos-13, macos-14]
+
+    steps:
+      - name: Python installation
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Wait for testpypi to catch up
+        run: |
+          sleep 20
+          version=${GITHUB_REF#refs/*/v}
+          echo "SISL_VERSION=${version#refs/*/}" >> $GITHUB_ENV
+          ls -lh
+
+      - name: Install sisl + dependencies (oldest numpy, not ARM)
+        if: matrix.os != 'macos-14'
+        run: |
+          python -m pip install -v \
+            --progress-bar=off \
+            --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple/ \
+            "sisl[test,viz]==${{ env.SISL_VERSION }}" \
+            "numpy==1.21.*" "scipy==1.6.*" "xarray==0.21.*"
+
+      - name: Install sisl + dependencies (arm)
+        if: matrix.os == 'macos-14'
+        run: |
+          python -m pip install -v \
+            --progress-bar=off \
+            --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple/ \
+            "sisl[test,viz]==${{ env.SISL_VERSION }}"
+
+      - name: sisl debug info
+        run: |
+          python -c 'from sisl._debug_info import * ; print_debug_info()'
+
+      - name: Test the installation
+        run: |
+          sdata --help
+
+  # Upload to PyPI on every tag
   upload_pypi:
+    needs: [test_testpypi]
     name: Publish package to Pypi
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -90,13 +90,13 @@ jobs:
         env:
           CIBW_BUILD: "cp313-* cp313t-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          CIBW_BUILD_FRONTEND:
-            "pip; args: --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+          #CIBW_BUILD_FRONTEND:
+          #  "pip; args: --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
           CIBW_FREE_THREADED_SUPPORT: true
-          CIBW_BEFORE_TEST: >-
-            pip install --pre
-            --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-            numpy
+          #CIBW_BEFORE_TEST: >-
+          #  pip install --pre
+          #  --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+          #  numpy scipy
 
       - name: Build wheels for CPython 3.12
         uses: pypa/cibuildwheel@v2.21.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -330,36 +330,3 @@ extend-exclude = """
  | .*/\\..*
 )
 """
-
-
-[tool.cibuildwheel]
-build-verbosity = 3
-archs = ["auto"]
-
-test-requires = ["pytest", "joblib"]
-test-extras = "test"
-
-skip = [
-    "pp*",
-    "*musllinux*",
-]
-
-test-skip = ""
-
-# Instead of running pytest directly, we use a bash script that will set up
-# the appropiate value for the SISL_FILES_TEST variable, a path pointing to
-# the sisl-files directory, which contains files for testing.
-test-command = "bash {project}/tools/build_tools/test_wheels.sh"
-
-[tool.cibuildwheel.linux]
-
-
-[[tool.cibuildwheel.overrides]]
-# basically adding to test-requires for windows
-select = "*win*"
-inherit.test-requires = "prepend"
-test-requires = "delvewheel"
-
-[tool.cibuildwheel.windows]
-
-[tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Enables python 3.13 wheels. 
<!--
Creating a PR will check whether the pre-commit hooks
have runned, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`

The short message is:
- run `isort .` at the top level
- run `black .` (version=24.2.0) at top-level
-->
