### PR TITLE
Fixed matplotlib fatbands and enabled opacity

### DIFF
--- a/src/sisl/viz/figure/matplotlib.py
+++ b/src/sisl/viz/figure/matplotlib.py
@@ -238,6 +238,7 @@ class MatplotlibFigure(Figure):
         return {
             "dash": "dashed",
             "dot": "dotted",
+            None: "solid",
         }.get(dash, dash)
 
     def _sanitize_colorscale(self, colorscale):
@@ -380,6 +381,8 @@ class MatplotlibFigure(Figure):
         # Set the values used for colormapping
         lc.set_linewidth(line.get("width", 1))
         lc.set_linestyle(self._plotly_dash_to_matplotlib(line.get("dash", "solid")))
+        lc.set_color(line.get("color"))
+        lc.set_alpha(line.get("opacity"))
 
         axes = _axes or self._get_subplot_axes(row=row, col=col)
 
@@ -411,11 +414,21 @@ class MatplotlibFigure(Figure):
 
         if dependent_axis in ("y", None):
             axes.fill_between(
-                x, y + spacing, y - spacing, color=line.get("color"), label=name
+                x,
+                y + spacing,
+                y - spacing,
+                color=line.get("color"),
+                label=name,
+                alpha=line.get("opacity"),
             )
         elif dependent_axis == "x":
             axes.fill_betweenx(
-                y, x + spacing, x - spacing, color=line.get("color"), label=name
+                y,
+                x + spacing,
+                x - spacing,
+                color=line.get("color"),
+                label=name,
+                alpha=line.get("opacity"),
             )
         else:
             raise ValueError(
@@ -435,6 +448,7 @@ class MatplotlibFigure(Figure):
         col=None,
         _axes=None,
         meta={},
+        legendgroup=None,
         **kwargs,
     ):
         axes = _axes or self._get_subplot_axes(row=row, col=col)

--- a/src/sisl/viz/figure/plotly.py
+++ b/src/sisl/viz/figure/plotly.py
@@ -584,6 +584,7 @@ class PlotlyFigure(Figure):
                 "legendgroup": name,
                 "showlegend": kwargs.pop("showlegend", None),
                 "fill": "toself",
+                "opacity": line.get("opacity"),
                 "meta": kwargs.pop("meta", {}),
             },
             row=row,

--- a/src/sisl/viz/plots/bands.py
+++ b/src/sisl/viz/plots/bands.py
@@ -291,7 +291,7 @@ def fatbands_plot(
         orb_dim="orb",
         spin_dim="spin",
         sanitize_group=orbital_manager,
-        group_vars=("color", "dash"),
+        group_vars=("color", "dash", "opacity"),
         groups_dim="group",
         drop_empty=True,
         spin_reduce=False,


### PR DESCRIPTION
#790 had not been fully fixed by #799. There were some bugs regarding `fatbands_mode="scatter"` and `fatbands_mode="line"` for the matplotlib backend.

Also enabled the possibility to use `"opacity"` for all variants of fatbands, to avoid some fatbands getting hidden by the overlap with the next ones.

With the example that @rreho provided using "scatter" "and matplotlib", and setting `"opacity": 0.2` for the red fatbands:

![Screenshot from 2024-11-07 12-04-55](https://github.com/user-attachments/assets/3306a2bb-b64e-4a6d-b3b8-b41f70c28ab9)