### PR TITLE
moved direct imports into a getattr segment

### DIFF
--- a/src/sisl/__init__.py
+++ b/src/sisl/__init__.py
@@ -99,22 +99,6 @@ from .messages import SislDeprecation
 # The unit contain the SI standard conversions using
 # all digits (not program specific)
 from .unit import unit_group, unit_convert, unit_default, units
-from . import unit
-
-# Import numerical constants (they required unit)
-from . import constant
-
-# To make it easier to type ;)
-C = constant
-
-# Specific linear algebra
-from . import linalg
-
-# Utilities
-from . import utils
-
-# Mixing
-from . import mixing
 
 # Below are sisl-specific imports
 from .shape import *
@@ -133,7 +117,6 @@ from .physics import *
 #  sisl.get_sile
 # This will reduce the cluttering of the separate entities
 # that sisl is made of.
-from . import io
 from .io.sile import (
     add_sile,
     get_sile_class,
@@ -161,12 +144,6 @@ Lattice.new.register("Sile", Lattice.new._dispatchs[str])
 Lattice.to.register(BaseSile, Lattice.to._dispatchs[str])
 Lattice.to.register("Sile", Lattice.to._dispatchs[str])
 
-# Import the default geom structure
-# This enables:
-# import sisl
-# sisl.geom.graphene
-from . import geom
-
 from ._nodify import on_nodify as __nodify__
 
 # Set all the placeholders for the plot attribute
@@ -175,26 +152,69 @@ from ._lazy_viz import set_viz_placeholders
 
 set_viz_placeholders()
 
-# If someone tries to get the viz attribute, we will load the viz module
-_LOADED_VIZ = False
-
-
-def __getattr__(name):
-    global _LOADED_VIZ
-    if name == "viz" and not _LOADED_VIZ:
-        _LOADED_VIZ = True
-        import sisl.viz
-
-        return sisl.viz
-    raise AttributeError(f"module {__name__} has no attribute {name}")
-
-
 from ._ufuncs import expose_registered_methods
 
 expose_registered_methods("sisl")
 expose_registered_methods("sisl.physics")
 
 del expose_registered_methods
+
+
+# Lazy load modules to easier access sub-modules
+def __getattr__(attr):
+    """Enables simpler access of sub-modules, without having to import them"""
+
+    # One can test that this is only ever called once
+    # per sub-module.
+    # Insert a print statement, and you'll see that:
+    # import sisl
+    # sisl.geom
+    # sisl.geom
+    # will only print *once*.
+
+    if attr == "geom":
+        import sisl.geom as geom
+
+        return geom
+    if attr == "io":
+        import sisl.io as io
+
+        return io
+    if attr == "physics":
+        import sisl.physics as physics
+
+        return physics
+    if attr == "linalg":
+        import sisl.linalg as linalg
+
+        return linalg
+    if attr == "shape":
+        import sisl.shape as shape
+
+        return shape
+    if attr == "mixing":
+        import sisl.mixing as mixing
+
+        return mixing
+    if attr == "viz":
+        import sisl.viz as viz
+
+        return viz
+    if attr == "utils":
+        import sisl.utils as utils
+
+        return utils
+    if attr == "unit":
+        import sisl.unit as unit
+
+        return unit
+    if attr in ("C", "constant"):
+        import sisl.constant as constant
+
+        return constant
+
+    raise AttributeError(f"module {__name__} has no attribute {attr}")
+
 
 # Make these things publicly available
 __all__ = [s for s in dir() if not s.startswith("_")]

--- a/src/sisl/geom/nanoribbon.py
+++ b/src/sisl/geom/nanoribbon.py
@@ -9,12 +9,13 @@ from typing import Optional, Union
 
 import numpy as np
 
-from sisl import Atom, Geometry, geom
+from sisl import Atom, Geometry
 from sisl._internal import set_module
 from sisl.typing import AtomsLike
 
 from ._common import geometry_define_nsc
 from ._composite import CompositeGeometrySection, composite_geometry
+from .flat import honeycomb
 
 __all__ = [
     "nanoribbon",
@@ -78,7 +79,7 @@ def nanoribbon(
     width = max(width, 1)
     n, m = width // 2, width % 2
 
-    ribbon = geom.honeycomb(bond, atoms, orthogonal=True, vacuum=vacuum_perp)
+    ribbon = honeycomb(bond, atoms, orthogonal=True, vacuum=vacuum_perp)
     angle = 0
 
     kind = kind.lower()

--- a/src/sisl/viz/__init__.py
+++ b/src/sisl/viz/__init__.py
@@ -27,6 +27,7 @@ Or conda (only possible if inside a conda environment):
 # placeholders.
 from sisl._lazy_viz import clear_viz_placeholders
 
+print("CALLING clear")
 clear_viz_placeholders()
 
 del clear_viz_placeholders

--- a/src/sisl/viz/plotters/grid.py
+++ b/src/sisl/viz/plotters/grid.py
@@ -8,8 +8,9 @@ from typing import Optional
 import numpy as np
 import xarray as xr
 
-import sisl.viz.plotters.plot_actions as plot_actions
 from sisl.viz.processors.grid import get_isos
+
+from . import plot_actions
 
 
 def draw_grid(

--- a/src/sisl/viz/plotters/xarray.py
+++ b/src/sisl/viz/plotters/xarray.py
@@ -9,7 +9,7 @@ import typing
 import numpy as np
 from xarray import DataArray
 
-import sisl.viz.plotters.plot_actions as plot_actions
+from . import plot_actions
 
 # from sisl.viz.nodes.processors.grid import get_isos
 


### PR DESCRIPTION
This should enable easier access without doing imports. There were a couple of imports that were required to be moved around. So I think this should solve a few circular imports.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #
 - [ ] Added tests for new/changed functions?
 - [ ] Documentation for functionality in `docs/`
 - [ ] Changes documented in `CHANGELOG.md`

<!--
Creating a PR will check whether the pre-commit hooks
have runned, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`

The short message is:
- run `isort .` at the top level
- run `black .` (version=24.2.0) at top-level
-->
