### PR TITLE
allowed atoms in tbtnc, and enabled PDOS of ADOS in viz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ we hit release version 1.0.0.
 ## [0.15.3] - YYYY-MM-DD
 
 ### Added
+- added ADOS extraction of PDOS data in `sisl.viz`
 - enabled submodule access without imports:
 
       import sisl

--- a/src/sisl/io/tbtrans/_cdf.py
+++ b/src/sisl/io/tbtrans/_cdf.py
@@ -54,7 +54,13 @@ class _ncSileTBtrans(SileCDFTBtrans):
         return lattice
 
     def read_geometry(self, *args, **kwargs) -> Geometry:
-        """Returns `Geometry` object from this file"""
+        """Returns `Geometry` object from this file
+
+        Parameters
+        ----------
+        atoms :
+            atoms used instead of random species
+        """
         lattice = self.read_lattice()
 
         xyz = _a.arrayd(np.copy(self.xa))
@@ -64,23 +70,23 @@ class _ncSileTBtrans(SileCDFTBtrans):
         lasto = _a.arrayi(np.copy(self.lasto) + 1)
         nos = np.diff(lasto, prepend=0)
 
-        if "atom" in kwargs:
-            # The user "knows" which atoms are present
-            atms = kwargs["atom"]
+        atoms = kwargs.get("atoms", kwargs.get("atom"))
+
+        if atoms is not None:
             # Check that all atoms have the correct number of orbitals.
             # Otherwise we will correct them
-            for i in range(len(atms)):
-                if atms[i].no != nos[i]:
-                    atms[i] = Atom(atms[i].Z, [-1] * nos[i], tag=atms[i].tag)
+            for i in range(len(atoms)):
+                if atoms[i].no != nos[i]:
+                    atoms[i] = Atom(atoms[i].Z, [-1] * nos[i], tag=atoms[i].tag)
 
         else:
             # Default to Hydrogen atom with nos[ia] orbitals
             # This may be counterintuitive but there is no storage of the
             # actual species
-            atms = [Atom("H", [-1] * o) for o in nos]
+            atoms = [Atom("H", [-1] * o) for o in nos]
 
         # Create and return geometry object
-        geom = Geometry(xyz, atms, lattice=lattice)
+        geom = Geometry(xyz, atoms, lattice=lattice)
 
         return geom
 


### PR DESCRIPTION
Enables plotting electrode PDOS from tbt.nc siles.

Simply do `fdf.plot.pdos(source="tbtnc", data_kwargs=dict(elec=0)`.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #
 - [x] Added tests for new/changed functions?
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`

<!--
Creating a PR will check whether the pre-commit hooks
have runned, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`

The short message is:
- run `isort .` at the top level
- run `black .` (version=24.2.0) at top-level
-->
