### PR TITLE
streamlined projection options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ we hit release version 1.0.0.
 
 ### Fixed
 
-- `project` arguments of several functions has been streamlined
+- `projection` arguments of several functions has been streamlined
 
 
 ## [0.15.2] - 2024-11-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ we hit release version 1.0.0.
       import sisl
       sisl.geom.graphene
 
+### Fixed
+
+- `project` arguments of several functions has been streamlined
+
 
 ## [0.15.2] - 2024-11-06
 

--- a/docs/api/typing.rst
+++ b/docs/api/typing.rst
@@ -48,6 +48,12 @@ The typing types are shown below:
    LatticeLike
    LatticeOrGeometry
    LatticeOrGeometryLike
+   ProjectionTypeMatrix
+   ProjectionTypeTrace
+   ProjectionTypeDiag
+   ProjectionTypeHadamard
+   ProjectionTypeHadamardAtoms
+   ProjectionType
    SileLike
    SparseMatrix
    SparseMatrixExt

--- a/src/sisl/__init__.py
+++ b/src/sisl/__init__.py
@@ -219,6 +219,10 @@ def __getattr__(attr):
         import sisl.constant as constant
 
         return constant
+    if attr == "typing":
+        import sisl.typing as typing
+
+        return typing
 
     raise AttributeError(f"module {__name__} has no attribute {attr}")
 

--- a/src/sisl/physics/__init__.py
+++ b/src/sisl/physics/__init__.py
@@ -89,6 +89,7 @@ Sparse matrices
 
 """
 
+from ._common import *
 from ._feature import *
 from .distribution import *
 from .sparse import *

--- a/src/sisl/physics/_common.py
+++ b/src/sisl/physics/_common.py
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import get_args
+
+from sisl.typing import GaugeType, ProjectionType
+
+__all__ = ["comply_gauge", "comply_projection"]
+
+
+def comply_gauge(gauge: GaugeType) -> str:
+    """Comply the gauge to one of two words: atom | cell"""
+    return {
+        "R": "cell",
+        "cell": "cell",
+        "r": "atom",
+        "orbital": "atom",
+        "orbitals": "atom",
+        "atom": "atom",
+        "atoms": "atom",
+    }[gauge]
+
+
+def comply_projection(projection: ProjectionType) -> str:
+    """Comply the projection to one of the allowed variants"""
+    return {
+        "matrix": "matrix",
+        "ij": "matrix",
+        "trace": "trace",
+        "sum": "trace",
+        "diagonal": "diagonal",
+        "diag": "diagonal",
+        "ii": "diagonal",
+        "hadamard": "hadamard",
+        "basis": "hadamard",
+        "orbital": "hadamard",
+        "orbitals": "hadamard",
+        "hadamard:atoms": "hadamard:atoms",
+        "atoms": "hadamard:atoms",
+        "atom": "hadamard:atoms",
+    }[projection]

--- a/src/sisl/physics/_common.py
+++ b/src/sisl/physics/_common.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from enum import StrEnum
-from typing import get_args
-
 from sisl.typing import GaugeType, ProjectionType
 
 __all__ = ["comply_gauge", "comply_projection"]

--- a/src/sisl/physics/_feature.py
+++ b/src/sisl/physics/_feature.py
@@ -7,20 +7,7 @@ from collections.abc import Iterator
 
 import numpy as np
 
-__all__ = ["yield_manifolds", "comply_gauge"]
-
-
-def comply_gauge(gauge: GaugeType) -> str:
-    """Comply the gauge to one of two words: atom | cell"""
-    return {
-        "R": "cell",
-        "cell": "cell",
-        "r": "atom",
-        "orbital": "atom",
-        "orbitals": "atom",
-        "atom": "atom",
-        "atoms": "atom",
-    }[gauge]
+__all__ = ["yield_manifolds"]
 
 
 def yield_manifolds(values, atol: float = 0.1, axis: int = -1) -> Iterator[list]:

--- a/src/sisl/physics/_matrix_ddk.pyx
+++ b/src/sisl/physics/_matrix_ddk.pyx
@@ -8,7 +8,7 @@ import numpy as np
 
 cimport numpy as np
 
-from ._feature import comply_gauge
+from ._common import comply_gauge
 from ._matrix_phase3 import *
 from ._matrix_phase3_nc import *
 from ._matrix_phase3_so import *

--- a/src/sisl/physics/_matrix_dk.pyx
+++ b/src/sisl/physics/_matrix_dk.pyx
@@ -8,7 +8,7 @@ import numpy as np
 
 cimport numpy as np
 
-from ._feature import comply_gauge
+from ._common import comply_gauge
 from ._matrix_phase3 import *
 from ._matrix_phase3_nc import *
 from ._matrix_phase3_so import *

--- a/src/sisl/physics/_matrix_k.pyx
+++ b/src/sisl/physics/_matrix_k.pyx
@@ -7,7 +7,7 @@ import numpy as np
 
 cimport numpy as np
 
-from ._feature import comply_gauge
+from ._common import comply_gauge
 from ._matrix_phase import *
 from ._matrix_phase_nc import *
 from ._matrix_phase_nc_diag import *

--- a/src/sisl/physics/hamiltonian.py
+++ b/src/sisl/physics/hamiltonian.py
@@ -9,7 +9,7 @@ import sisl._array as _a
 from sisl._internal import set_module
 from sisl.typing import GaugeType
 
-from ._feature import comply_gauge
+from ._common import comply_gauge
 from .distribution import get_distribution
 from .electron import EigenstateElectron, EigenvalueElectron
 from .sparse import SparseOrbitalBZSpin

--- a/src/sisl/physics/tests/test_electron.py
+++ b/src/sisl/physics/tests/test_electron.py
@@ -28,12 +28,13 @@ def test_EigenstateElectron_norm2():
     assert len(state) == H.no
     assert state.norm2()[0] == pytest.approx(1)
     assert state.norm2().shape == (H.no,)
-    for p in ("sum", "orbital", "atom"):
+    for p in ("diagonal", "orbital", "atom"):
         assert state.norm2(projection=p).sum() == pytest.approx(H.no)
 
     ns = 3
     state3 = state.sub(range(ns))
-    assert state3.norm2(projection="sum").shape == (ns,)
+    assert state3.norm2(projection="trace").ndim == 0
+    assert state3.norm2(projection="diagonal").shape == (ns,)
     assert state3.norm2(projection="orbital").shape == (ns, H.no)
     assert state3.norm2(projection="atom").shape == (ns, H.na)
     assert state3.norm2(projection="atom").sum() == pytest.approx(ns)

--- a/src/sisl/physics/tests/test_hamiltonian.py
+++ b/src/sisl/physics/tests/test_hamiltonian.py
@@ -1252,7 +1252,7 @@ class TestHamiltonian:
         es = H.eigenstate()
         PDOS = es.PDOS(E, dist)[..., 0]
         SM = es.spin_moment()
-        SMp = es.spin_moment(project=True)
+        SMp = es.spin_moment(projection=True)
 
         # now check with spin stuff
         pdos = es.inner().real
@@ -1288,7 +1288,7 @@ class TestHamiltonian:
         es = H.eigenstate()
         PDOS = es.PDOS(E, dist)[..., 0]
         SM = es.spin_moment()
-        SMp = es.spin_moment(project=True)
+        SMp = es.spin_moment(projection=True)
 
         # now check with spin stuff
         pdos = es.inner().real
@@ -1636,7 +1636,7 @@ class TestHamiltonian:
             assert np.allclose(sm[2], sm2)
             assert np.allclose(sm[2], sm3)
 
-            om = es.spin_moment(project=True)
+            om = es.spin_moment(projection=True)
             assert np.allclose(sm, om.sum(-1))
 
             PDOS = es.PDOS(np.linspace(-1, 1, 21))
@@ -1710,7 +1710,7 @@ class TestHamiltonian:
 
             sm = es.spin_moment()
 
-            om = es.spin_moment(project=True)
+            om = es.spin_moment(projection=True)
             assert np.allclose(sm, om.sum(-1))
 
             PDOS = es.PDOS(np.linspace(-1, 1, 21))
@@ -1795,7 +1795,7 @@ class TestHamiltonian:
             assert np.allclose(sm[2], sm2)
             assert np.allclose(sm[2], sm3)
 
-            om = es.spin_moment(project=True)
+            om = es.spin_moment(projection=True)
             assert np.allclose(sm, om.sum(-1))
 
             PDOS = es.PDOS(np.linspace(-1, 1, 21))

--- a/src/sisl/physics/tests/test_state.py
+++ b/src/sisl/physics/tests/test_state.py
@@ -231,7 +231,8 @@ def test_state_inner_projections():
     state = State(ar(n, g.no), parent=g)
 
     for projs, shape in (
-        (("diag", "diagonal", "sum", True), (n,)),
+        (("diag", "diagonal", True), (n,)),
+        (("trace", "sum"), tuple()),
         (("matrix", False), (n, n)),
         (("basis", "orbitals", "orbital"), (n, g.no)),
         (("atoms", "atom"), (n, g.na)),
@@ -248,9 +249,10 @@ def test_state_norm_projections():
     assert state.shape[0] != state.shape[1]
 
     for projs, shape in (
-        (("sum", True), (n,)),
-        (("basis", "orbitals", "orbital"), (n, g.no)),
-        (("atoms", "atom"), (n, g.na)),
+        (("diagonal", True), (n,)),
+        (("trace", "sum"), tuple()),
+        (("hadamard", "basis", "orbitals", "orbital"), (n, g.no)),
+        (("atoms", "atom", "hadamard:atoms"), (n, g.na)),
     ):
         for proj in projs:
             data = state.norm2(projection=proj)

--- a/src/sisl/typing/_physics.py
+++ b/src/sisl/typing/_physics.py
@@ -3,8 +3,23 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, Union
 
-__all__ = ["GaugeType"]
+__all__ = [
+    "GaugeType",
+    "ProjectionType",
+    "ProjectionTypeTrace",
+    "ProjectionTypeDiag",
+    "ProjectionTypeMatrix",
+    "ProjectionTypeHadamard",
+    "ProjectionTypeHadamardAtoms",
+]
 
 GaugeType = Literal["cell", "atom"]
+
+ProjectionTypeMatrix = Literal["matrix", "ij"]
+ProjectionTypeTrace = Literal["trace", "sum"]
+ProjectionTypeDiag = Literal["diagonal", "diag", "ii"]
+ProjectionTypeHadamard = Literal["hadamard", "basis"]
+ProjectionTypeHadamardAtoms = Literal["hadamard:atoms", "atoms"]
+ProjectionType = Union[ProjectionTypeMatrix, ProjectionTypeDiag, ProjectionTypeTrace]


### PR DESCRIPTION
Still things to do, but for now this catches
many things.

One thing is that 'basis' projections are now called hadamard (the proper name of the operation). While 'basis' is still allowed it seems better to streamline a against a common name.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #
 - [ ] Added tests for new/changed functions?
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `CHANGELOG.md`

<!--
Creating a PR will check whether the pre-commit hooks
have runned, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`

The short message is:
- run `isort .` at the top level
- run `black .` (version=24.2.0) at top-level
-->
