### PR TITLE
Git ignoring debug_info.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ docs/tutorials/**/*.{cube,xyz,fdf}
 */sisl.egg-info
 src/sisl/**/*.html
 src/sisl/_version.py
+src/sisl/_debug_info.py
 
 # OS generated files
 .DS_Store


### PR DESCRIPTION
The `_debug_info.py` file (generated on installation) was messing with my git control :smile:  