### PR TITLE
Formatting the argparse CLIs

### DIFF
--- a/src/sisl/_core/geometry.py
+++ b/src/sisl/_core/geometry.py
@@ -45,6 +45,7 @@ from sisl._indices import (
     list_index_le,
 )
 from sisl._internal import set_module
+from sisl._lib._argparse import SislHelpFormatter
 from sisl._math_small import cross3, is_ascending, xyz_to_spherical_cos_phi
 from sisl._namedindex import NamedIndex
 from sisl.messages import SislError, deprecate_argument, deprecation, info, warn
@@ -4783,7 +4784,7 @@ lattice vector.
 
     p = argparse.ArgumentParser(
         exe,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SislHelpFormatter,
         description=description,
     )
 

--- a/src/sisl/_core/grid.py
+++ b/src/sisl/_core/grid.py
@@ -20,6 +20,7 @@ from sisl._dispatch_class import _Dispatchs
 from sisl._dispatcher import AbstractDispatch, ClassDispatcher, TypeDispatcher
 from sisl._help import dtype_complex_to_real, wrap_filterwarnings
 from sisl._internal import set_module
+from sisl._lib._argparse import SislHelpFormatter
 from sisl.messages import deprecate_argument, deprecation
 from sisl.shape import Shape
 from sisl.utils import (
@@ -1747,7 +1748,7 @@ This may be unexpected but enables one to do advanced manipulations.
 
     p = argparse.ArgumentParser(
         exe,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SislHelpFormatter,
         description=description,
     )
 

--- a/src/sisl/_lib/_argparse.py
+++ b/src/sisl/_lib/_argparse.py
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+try:
+    from rich_argparse import RichHelpFormatter
+
+    SislHelpFormatter = RichHelpFormatter
+except ImportError:
+    import argparse
+
+    SislHelpFormatter = argparse.RawDescriptionHelpFormatter

--- a/src/sisl/utils/_sisl_cmd.py
+++ b/src/sisl/utils/_sisl_cmd.py
@@ -9,6 +9,8 @@ Easy conversion of data from different formats to other formats.
 """
 import argparse
 
+from sisl._lib._argparse import SislHelpFormatter
+
 __all__ = ["sisl_cmd"]
 
 
@@ -99,7 +101,7 @@ changing ways. It handles files dependent on type AND content.
 
     p = argparse.ArgumentParser(
         exe,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SislHelpFormatter,
         description=description,
         conflict_handler="resolve",
     )

--- a/src/sisl_toolbox/cli/_cli.py
+++ b/src/sisl_toolbox/cli/_cli.py
@@ -14,6 +14,8 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+from sisl._lib._argparse import SislHelpFormatter
+
 
 class SToolBoxCLI:
     """Run the CLI `stoolbox`"""
@@ -47,7 +49,9 @@ class SToolBoxCLI:
         # Create command-line
         cmd = Path(sys.argv[0])
         p = argparse.ArgumentParser(
-            f"{cmd.name}", description="Specific toolboxes to aid sisl users"
+            f"{cmd.name}",
+            description="Specific toolboxes to aid sisl users",
+            formatter_class=SislHelpFormatter,
         )
 
         info = {
@@ -64,7 +68,7 @@ class SToolBoxCLI:
         subp = p.add_subparsers(**info)
 
         for cmd in self._cmds:
-            cmd(subp)
+            cmd(subp, parser_kwargs=dict(formatter_class=p.formatter_class))
 
         args = p.parse_args(argv)
         args.runner(args)

--- a/src/sisl_toolbox/siesta/atom/_atom.py
+++ b/src/sisl_toolbox/siesta/atom/_atom.py
@@ -803,7 +803,7 @@ class AtomInput:
         return fig, axs
 
 
-def atom_plot_cli(subp=None):
+def atom_plot_cli(subp=None, parser_kwargs={}):
     """Run plotting command for the output of atom"""
 
     is_sub = not subp is None
@@ -812,11 +812,11 @@ def atom_plot_cli(subp=None):
     if is_sub:
         global _script
         _script = f"{_script} atom-plot"
-        p = subp.add_parser("atom-plot", description=title, help=title)
+        p = subp.add_parser("atom-plot", description=title, help=title, **parser_kwargs)
     else:
         import argparse
 
-        p = argparse.ArgumentParser(title)
+        p = argparse.ArgumentParser(title, **parser_kwargs)
 
     p.add_argument(
         "--plot",

--- a/src/sisl_toolbox/transiesta/poisson/fftpoisson_fix.py
+++ b/src/sisl_toolbox/transiesta/poisson/fftpoisson_fix.py
@@ -344,16 +344,16 @@ def solve_poisson(
     return grid
 
 
-def fftpoisson_fix_cli(subp=None):
+def fftpoisson_fix_cli(subp=None, parser_kwargs={}):
     is_sub = not subp is None
 
     title = "FFT Poisson corrections for TranSiesta calculations for arbitrary number of electrodes."
     if is_sub:
         global _script
         _script = f"{_script} ts-fft"
-        p = subp.add_parser("ts-fft", description=title, help=title)
+        p = subp.add_parser("ts-fft", description=title, help=title, **parser_kwargs)
     else:
-        p = argp.ArgumentParser(title)
+        p = argp.ArgumentParser(title, **parser_kwargs)
 
     tuning = p.add_argument_group(
         "tuning", "Tuning fine details of the Poisson calculation."


### PR DESCRIPTION
This PR adds the possibility to use formatting from `rich-argparse` if the package is installed.

It formats all of the CLIs in sisl. 

I think this is a very good compromise that could unblock some nice features (https://github.com/zerothi/sisl/pull/801, basis optimization CLI) that haven't gone in due to discrepancies on what the CLI should look like :) (see https://github.com/zerothi/sisl/pull/608,  https://github.com/zerothi/sisl/issues/735).

The formatting could be gradually made nicer and nicer by extending the formatter, and nothing about the implementation of the CLIs needs to change.

I don't know whether `rich-argparse` should be a dependency, optional dependency or what. But if it is not a dependency it should be advertised, because it makes things look nicer :sparkles: 