### PR TITLE
Added support for I/O from zipfiles and buffers

### DIFF
--- a/changes/914.feat.rst
+++ b/changes/914.feat.rst
@@ -1,0 +1,81 @@
+Full I/O support for buffers and zip files
+
+Up to now, the support for buffers was limited to text buffers. Now,
+byte buffers are also supported, so one can read/write binary files
+and CDF files from/to buffers.
+
+This change also introduced support for zipfiles.
+
+**Example for buffers:**
+
+Writing a grid to a buffer:
+
+.. code-block:: python
+
+    import sisl
+    import io
+
+    geometry = sisl.geom.graphene()
+    grid = sisl.Grid((2, 2, 2), geometry=geometry)
+    grid[:] = np.random.random(grid.shape)
+
+    buffer = io.BytesIO()
+
+    nc = sisl.io.gridncSileSiesta(buffer, mode="wb")
+    nc.write_grid(grid)
+
+Reading a grid from a buffer:
+
+.. code-block:: python
+
+    import sisl
+    import io
+
+    buffer = ... # Get a buffer with the grid data
+
+    grid = sisl.io.gridncSileSiesta(buffer).read_grid()
+
+**Example for zip files:**
+
+Reading the Hamiltonian from a SIESTA run inside a zip file:
+
+.. code-block:: python
+
+    import sisl
+
+    sisl.get_sile("/path/to/data.zip/run/RUN.fdf").read_hamiltonian()
+
+Writing a Hamiltonian inside a zip file:
+
+..  code-block:: python
+
+    import sisl
+
+    geom = sisl.geom.graphene()
+    H = sisl.Hamiltonian(geom)
+
+    H.write_hamiltonian("/path/to/data.zip/graphene.HSX")
+
+By passing the path inside the zip file as a string, ``sisl`` will
+automatically create the ``zipfile.ZipFile`` object and close it
+when it is done. If you don't want the zip file to be closed, you can
+create it externally and then pass a ``zipfile.Path`` to ``sisl``:
+
+.. code-block:: python
+
+    import sisl
+    import zipfile
+
+    # Create a zip file or append to an existing one
+    zip_file = zipfile.ZipFile("myzipfile.zip", "a")
+    # Define path inside the zip file
+    H_path = zipfile.Path(zip_file, "graphene.HSX")
+
+    geom = sisl.geom.graphene()
+    H = sisl.Hamiltonian(geom)
+
+    H.write_hamiltonian(H_path)
+
+    # Now the zip file is not closed, it is up to you to close it
+    # when you are done
+    zip_file.close()

--- a/docs/api/io/index.rst
+++ b/docs/api/io/index.rst
@@ -6,18 +6,42 @@ Input/Output
 
 .. module:: sisl.io
 
-Available files for reading/writing
+Read and write files to many different formats used within
+the atomic simulation community.
 
-`sisl` handles a large variety of input/output files from a large selection
-of DFT software and other post-processing tools.
+The sile framework
+--------------------
 
-In `sisl` all files are conventionally named *siles*
-to distinguish them from files from other packages.
+`sisl` provides a unified interface to read and write files.
+To distinguish a normal file from a `sisl` file, we use the term *sile*:
 
-All files are generally accessed through the `get_sile` method
-which exposes all siles through their extension recognition.
+-------------------------------------
 
-The current procedure for determining the file type is based on these
+**sile**, noun (*sisl-file*)
+
+*A supercharged file that has the capability to read and write
+quantities related to atomic simulations.*
+
+-------------------------------------
+
+One can create a sile by simply doing:
+
+.. code-block:: python
+
+   import sisl
+   sile = sisl.get_sile('myfile.extension')
+
+Which will automatically determine the sile type based on the file extension.
+Then, you might ask to read whatever the file contains. For example, if the
+file contains a Hamiltonian, you can do:
+
+.. code-block:: python
+
+   hamiltonian = sile.read_hamiltonian()
+
+Sometimes, the file extension is ambiguous as there are multiple file formats
+that use the same extension. For this reason, `sisl` has other mechanisms at
+your disposal. The current procedure for determining the file type is based on these
 steps:
 
 1. Extract the extension of the filename passed to `get_sile`, for instance
@@ -39,11 +63,117 @@ steps:
 4. If there is only 1 match, then return that class. If there are multiple `sisl` will try all ``read_*``
    methods and if all fail, then the sile will be removed from the eligible list.
 
+You can find more information about the core functions and classes of the `sisl.io` module
+here:
 
 .. toctree::
    :maxdepth: 2
 
    basic
+
+I/O from buffers and zip files
+------------------------------
+
+Sometimes, things are not as simple as reading/writing from/to the normal file system.
+For example, you might have the files inside a zip file or you might have acces to the
+file contents through a buffer (``io.StringIO``, ``io.BytesIO``...).
+
+**All siles in `sisl` have the ability of reading and writing from buffers and zip files.**
+In this case, there is no automatic detection of the sile type, so you will need to specify
+the exact sile type you want to use. Following, we provide some examples:
+
+Example for buffers:
+^^^^^^^^^^^^^^^^^^^^
+
+Writing a grid to a buffer:
+
+.. code-block:: python
+
+    import sisl
+    import io
+
+    geometry = sisl.geom.graphene()
+    grid = sisl.Grid((2, 2, 2), geometry=geometry)
+    grid[:] = np.random.random(grid.shape)
+
+    buffer = io.BytesIO()
+
+    nc = sisl.io.gridncSileSiesta(buffer, mode="wb")
+    nc.write_grid(grid)
+
+Reading a grid from a buffer:
+
+.. code-block:: python
+
+    import sisl
+    import io
+
+    buffer = ... # Get a buffer with the grid data
+
+    grid = sisl.io.gridncSileSiesta(buffer).read_grid()
+
+Example for zip files:
+^^^^^^^^^^^^^^^^^^^^^^
+
+Reading the Hamiltonian from a SIESTA run inside a zip file:
+
+.. code-block:: python
+
+    import sisl
+
+    sisl.get_sile("/path/to/data.zip/run/RUN.fdf").read_hamiltonian()
+
+Writing a Hamiltonian inside a zip file:
+
+..  code-block:: python
+
+    import sisl
+
+    geom = sisl.geom.graphene()
+    H = sisl.Hamiltonian(geom)
+
+    H.write_hamiltonian("/path/to/data.zip/graphene.HSX")
+
+By passing the path inside the zip file as a string, ``sisl`` will
+automatically create the ``zipfile.ZipFile`` object and close it
+when it is done. If you don't want the zip file to be closed, you can
+create it externally and then pass a ``zipfile.Path`` to ``sisl``:
+
+.. code-block:: python
+
+    import sisl
+    import zipfile
+
+    # Create a zip file or append to an existing one
+    zip_file = zipfile.ZipFile("myzipfile.zip", "a")
+    # Define path inside the zip file
+    H_path = zipfile.Path(zip_file, "graphene.HSX")
+
+    geom = sisl.geom.graphene()
+    H = sisl.Hamiltonian(geom)
+
+    H.write_hamiltonian(H_path)
+
+    # Now the zip file is not closed, it is up to you to close it
+    # when you are done
+    zip_file.close()
+
+List of available siles
+-----------------------
+
+The above is a full list of all the available siles in `sisl`, and therefore
+all the formats that you can read to and write from.
+
+.. note::
+
+   If you are missing the ability to read or write a specific file format in `sisl`,
+   you can open an issue/PR. If you already have the code to read or write the file format,
+   adding a new sile is easy, and it will make your main code compatible with
+   other formats (e.g. other DFT codes) thanks to the unified interface.
+
+.. toctree::
+   :maxdepth: 2
+
    generic
    bigdft
    dftb

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -3,10 +3,10 @@
 Introduction
 ============
 
-sisl has a number of features which makes it easy to jump right into
+`sisl` has a number of features which makes it easy to jump right into
 and perform a large variation of tasks.
 
-1. Easy creation of geometries. Similar to `ASE`_ sisl provides an
+1. **Easy creation of geometries.** Similar to `ASE`_ sisl provides an
    easy scripting engine to create and manipulate geometries.
    The goal of sisl is not specifically DFT-related software which
    typically only targets a limited number of atoms. One of the main
@@ -16,7 +16,7 @@ and perform a large variation of tasks.
    Everything is optimized for extremely large scale systems `>1,000,000` atoms
    such that creating geometries for tight-binding models becomes a breeze.
 
-2. Easy creation of tight-binding Hamiltonians via intrinsic and very fast
+2. **Easy creation of tight-binding Hamiltonians** via intrinsic and very fast
    algorithms for creating sparse matrices.
    One of the key-points is that the Hamiltonian is treated as a matrix.
    I.e. one may easily specify couplings without using routine calls.
@@ -24,15 +24,18 @@ and perform a large variation of tasks.
    sub-grids of atoms to speed up the creation by orders of magnitudes.
    sisl intrinsically implements such algorithms.
 
-3. Post-processing of data from DFT software. One may easily add additional
+3. **Post-processing of data from DFT software.** One may easily add additional
    post-processing tools to use sisl on non-implemented data-files.
 
+4. **Input/Output for many different formats.** Sisl provides a unified interface
+   to read and write files for many different formats relevant to the atomistic
+   simulation community. See the :ref:`I/O documentation <io>` for more details.
 
 
 Package
 -------
 
-sisl is mainly a Python package with many intrinsic capabilities.
+`sisl` is mainly a Python package with many intrinsic capabilities.
 
 Follow `these <installation>` instructions for installing sisl.
 

--- a/src/sisl/io/_zipfile.py
+++ b/src/sisl/io/_zipfile.py
@@ -2,8 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import functools
+import sys
 import zipfile
 from pathlib import Path
+
+_is_python_old = sys.version_info < (3, 10)
 
 
 class ZipPath(zipfile.Path):
@@ -50,6 +53,12 @@ class ZipPath(zipfile.Path):
 
     def __init__(self, *args, close_zipfile: bool = False, **kwargs):
         """Initialize the ZipPath with a zipfile object and a path"""
+        if _is_python_old:
+            raise RuntimeError(
+                "Zip file functionality in sisl requires Python 3.10 or newer. "
+                "Upgrade your Python version if you want to use it."
+            )
+
         super().__init__(*args, **kwargs)
 
         self.close_zipfile = close_zipfile

--- a/src/sisl/io/_zipfile.py
+++ b/src/sisl/io/_zipfile.py
@@ -1,0 +1,131 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import functools
+import zipfile
+from pathlib import Path
+
+
+class ZipPath(zipfile.Path):
+    """Extension of the zipfile.Path class to mimic the pathlib.Path class.
+
+    The main goal is this extension of zipfile.Path can be used within the
+    sile framework as a drop in replacement for pathlib.Path. By enabling
+    that, all the reading/writing functionality also works with zipfiles.
+
+    The extension has two purposes:
+
+    1. Some methods were missing in the original zipfile.Path class if we
+    wanted to use it as a Path object:
+
+        - ``with_suffix``
+
+    2. When writing a file in a zipfile, it is important to not only close the
+    file handle for the written file, but also to close the zipfile itself, so
+    that it writes the changes to disk.
+
+    To this end, when `open` is called, we wrap the `close` method of the returned
+    file handle so that we can close the zipfile if necessary.
+
+    Parameters
+    ----------
+    *args :
+        Arguments passed to the zipfile.Path constructor.
+    close_zipfile :
+        Whether to close the root zipfile when closing an open file handle
+        produced by this path.
+        Closing the zipfile is necessary for the changes to be written to disk.
+        However, if the zipfile is passed by the user, we do not want to close
+        the zipfile, because we don't know if the user wants to continue writing
+        to it.
+        Therefore, the default is ``False``, but if the ``ZipPath`` is created
+        from a normal path (i.e. the user didn't input the zipfile, it was created
+        on the fly), we set it to ``True`` (see ``ZipPath.from_path``).
+    **kwargs :
+        Keyword arguments passed to the zipfile.Path constructor.
+    """
+
+    #: Whether to close the root zipfile when closing the file handles.
+    close_zipfile: bool = False
+
+    def __init__(self, *args, close_zipfile: bool = False, **kwargs):
+        """Initialize the ZipPath with a zipfile object and a path"""
+        super().__init__(*args, **kwargs)
+
+        self.close_zipfile = close_zipfile
+
+    @property
+    def suffix(self):
+        """Override the suffix property to ensure it returns a string"""
+        return Path(str(self)).suffix
+
+    def with_suffix(self, *args, **kwargs):
+        """Override the with_suffix method to ensure it returns a ZipPath"""
+
+        file_path = Path(str(self)).relative_to(self.root.filename)
+
+        return self.__class__(self.root, str(file_path.with_suffix(*args, **kwargs)))
+
+    def open(self, *args, **kwargs):
+        """Override the open method to patch the file handle if necessary"""
+
+        fh = super().open(*args, **kwargs)
+
+        if self.close_zipfile:
+            # The root zipfile needs to be closed when closing the file handle,
+            # so we wrap the close method of the file handle
+            close = fh.close
+
+            @functools.wraps(close)
+            def _close(*args, **kwargs):
+                close(*args, **kwargs)
+                self.root.close()
+
+            fh.close = _close
+
+        return fh
+
+    @classmethod
+    def from_zipfile_path(cls, zipfile_path: zipfile.Path, close_zipfile: bool = False):
+        """Create a ZipPath from a zipfile.Path object"""
+
+        file_path = Path(str(zipfile_path)).relative_to(zipfile_path.root.filename)
+
+        return cls(zipfile_path.root, str(file_path), close_zipfile=close_zipfile)
+
+    @classmethod
+    def from_path(cls, path: Path, mode: str = "r", close_zipfile: bool = True):
+        """Create a ZipPath from a Path object.
+
+        Given a path object, scans the path to find the first zip file in the path.
+        If a zip file is found, a ZipPath object is created.
+
+        This function initializes a new ``zipfile.ZipFile`` object to use as the root.
+
+        Parameters
+        ----------
+        path :
+            The path to the file or directory.
+        mode :
+            The mode in which you will want to open paths. This
+            determines the mode in which the zipfile is opened.
+        close_zipfile :
+            Whether to close the zipfile when closing the file handle.
+            This is important because if you write to a zipfile, you need
+            to close it to write the changes to disk.
+            Since the zipfile is created internally, the default is to close
+            it when we are done reading/writing to the path.
+        """
+        for i, part in enumerate(path.parts[:-1]):
+            if part.endswith(".zip"):
+                zip_path = Path(*path.parts[: i + 1])
+                if zip_path.is_file():
+                    zipfile_mode = "r" if mode.startswith("r") else "a"
+                    root_zip = zipfile.ZipFile(zip_path, zipfile_mode)
+                    return cls(
+                        root_zip,
+                        str(path.relative_to(zip_path)),
+                        close_zipfile=close_zipfile,
+                    )
+        else:
+            raise FileNotFoundError(f"Could not find zip file in {path}")

--- a/src/sisl/io/_zipfile.py
+++ b/src/sisl/io/_zipfile.py
@@ -127,5 +127,7 @@ class ZipPath(zipfile.Path):
                         str(path.relative_to(zip_path)),
                         close_zipfile=close_zipfile,
                     )
-        else:
-            raise FileNotFoundError(f"Could not find zip file in {path}")
+
+        # If we got here it is because we did not find a zip file in the path,
+        # so we raise an error
+        raise FileNotFoundError(f"Could not find zip file in {path}")

--- a/src/sisl/io/sile.py
+++ b/src/sisl/io/sile.py
@@ -883,13 +883,13 @@ class BufferSileCDF(BaseBufferSile):
             # (tests will fail if this line is commented out)
             filename = "dummy"
 
-        if hasattr(filehandle, "mode") and filehandle.mode != mode:
+        # Remove the b from the mode, as netCDF4 only accepts "r" or "w"
+        mode = mode.replace("b", "")
+
+        if hasattr(filehandle, "mode") and filehandle.mode.replace("b", "") != mode:
             raise ValueError(
                 f"The filehandle's mode ({filehandle.mode}) does not match the sile's mode ({mode})"
             )
-
-        # Remove the b from the mode, as netCDF4 only accepts "r" or "w"
-        mode = mode.replace("b", "")
 
         self._buffer = filehandle
         self._wrapped = False
@@ -1598,7 +1598,6 @@ class SileCDF(BaseSile):
         """Opens the output file and returns it self"""
         # We do the import here
         if "fh" not in self.__dict__:
-            file = self.file
 
             if self._is_inside_zip:
                 if self._buffer_instance is None:

--- a/src/sisl/io/tests/test_buffers.py
+++ b/src/sisl/io/tests/test_buffers.py
@@ -1,0 +1,67 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import io
+import tempfile
+import zipfile
+
+import numpy as np
+import pytest
+
+import sisl
+
+
+def test_buffer_write_read():
+    """Test that we can write and read using a text buffer."""
+
+    buffer = io.StringIO("")
+
+    geometry = sisl.geom.graphene()
+
+    sisl.io.fdfSileSiesta(buffer).write_geometry(geometry)
+
+    buffer = io.StringIO(buffer.getvalue())
+
+    read_geometry = sisl.io.fdfSileSiesta(buffer).read_geometry()
+
+    assert np.allclose(read_geometry.xyz, geometry.xyz)
+    assert np.allclose(read_geometry.cell, geometry.cell)
+
+
+def test_buffer_write_read_binary():
+    """Test that we can write and read binary files using buffers"""
+
+    buffer = io.BytesIO()
+
+    geometry = sisl.geom.graphene()
+    H = sisl.Hamiltonian(geometry)
+    H[0, 0] = 1.3
+    H[1, 1] = 1.5
+
+    sisl.io.hsxSileSiesta(buffer, mode="wb").write_hamiltonian(H)
+
+    buffer = io.BytesIO(buffer.getvalue())
+
+    read_H = sisl.io.hsxSileSiesta(buffer).read_hamiltonian()
+
+    assert np.allclose(H.tocsr().toarray(), read_H.tocsr().toarray())
+
+
+def test_buffer_write_read_cdf():
+    """Test that we can write and read CDF files using buffers"""
+    pytest.importorskip("netCDF4")
+
+    buffer = io.BytesIO()
+
+    geometry = sisl.geom.graphene()
+    grid = sisl.Grid((2, 2, 2), geometry=geometry)
+    grid[:] = np.random.random(grid.shape)
+
+    nc = sisl.io.gridncSileSiesta(buffer, mode="wb")
+    nc.write_grid(grid)
+
+    buffer = io.BytesIO(buffer.getvalue())
+
+    read_grid = sisl.io.gridncSileSiesta(buffer).read_grid()
+
+    assert np.allclose(grid.grid, read_grid.grid)

--- a/src/sisl/io/tests/test_buffers.py
+++ b/src/sisl/io/tests/test_buffers.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import io
-import tempfile
-import zipfile
 
 import numpy as np
 import pytest

--- a/src/sisl/io/tests/test_zipfile.py
+++ b/src/sisl/io/tests/test_zipfile.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import sys
 import tempfile
 import zipfile
 
@@ -10,7 +11,21 @@ import pytest
 import sisl
 from sisl.io._zipfile import ZipPath
 
+# We will xfail all tests if the python version is <=3.9,
+# this is because sisl is expected to raise a RuntimeError
+# explaining that zipfile functionality requires Python 3.10 or newer.
+_is_old_python = sys.version_info < (3, 10)
+# 3.9 also prints very ugly errors when deleting a zipfile which make
+# it difficult to read the test output. So we patch the __del__ method.
+if _is_old_python:
+    zipfile.ZipFile.__del__ = lambda self: None
 
+
+@pytest.mark.xfail(
+    _is_old_python,
+    reason="Zip file functionality requires Python 3.10 or newer",
+    raises=RuntimeError,
+)
 def test_zipfile_preserved():
     """Test that the zipfile is preserved through the sile framework
 
@@ -33,6 +48,11 @@ def test_zipfile_preserved():
     assert fdf.file.root is f
 
 
+@pytest.mark.xfail(
+    _is_old_python,
+    reason="Zip file functionality requires Python 3.10 or newer",
+    raises=RuntimeError,
+)
 @pytest.mark.parametrize("specify_class", [True, False])
 @pytest.mark.parametrize("external_zip", [True, False])
 def test_zipfile_write_read(external_zip: bool, specify_class: bool):
@@ -77,6 +97,11 @@ def test_zipfile_write_read(external_zip: bool, specify_class: bool):
     assert np.allclose(read_geometry.cell, geometry.cell)
 
 
+@pytest.mark.xfail(
+    _is_old_python,
+    reason="Zip file functionality requires Python 3.10 or newer",
+    raises=RuntimeError,
+)
 @pytest.mark.parametrize("external_zip", [True, False])
 @pytest.mark.parametrize("from_fdf", [True, False])
 def test_zipfile_write_read_binary(external_zip: bool, from_fdf: bool):
@@ -120,6 +145,11 @@ def test_zipfile_write_read_binary(external_zip: bool, from_fdf: bool):
     assert np.allclose(H.tocsr().toarray(), read_H.tocsr().toarray())
 
 
+@pytest.mark.xfail(
+    _is_old_python,
+    reason="Zip file functionality requires Python 3.10 or newer",
+    raises=RuntimeError,
+)
 @pytest.mark.parametrize("external_zip", [True, False])
 @pytest.mark.parametrize("from_fdf", [True, False])
 def test_zipfile_write_read_cdf(external_zip: bool, from_fdf: bool):

--- a/src/sisl/io/tests/test_zipfile.py
+++ b/src/sisl/io/tests/test_zipfile.py
@@ -1,0 +1,166 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import tempfile
+import zipfile
+
+import numpy as np
+import pytest
+
+import sisl
+from sisl.io._zipfile import ZipPath
+
+
+def test_zipfile_preserved():
+    """Test that the zipfile is preserved through the sile framework
+
+    This is VERY important, because the lookup for paths will only be
+    fast if the index is already built. If each time a new sile is
+    created we need to create a new zipfile, it will be very slow.
+    """
+    # Write a temporary zipfile
+    _, tempfile_path = tempfile.mkstemp(suffix=".zip")
+    with zipfile.ZipFile(tempfile_path, "a") as f:
+        ...
+
+    f = zipfile.ZipFile(tempfile_path)
+
+    root_path = zipfile.Path(f, "")
+
+    fdf = sisl.get_sile(root_path / "test.fdf")
+
+    assert isinstance(fdf.file, ZipPath)
+    assert fdf.file.root is f
+
+
+@pytest.mark.parametrize("specify_class", [True, False])
+@pytest.mark.parametrize("external_zip", [True, False])
+def test_zipfile_write_read(external_zip: bool, specify_class: bool):
+    """Test that we can write and read within a zipfile.
+
+    If the user provides the zipfile path, instead of
+    letting the sile framework build it, the sile should not
+    close the zipfile.
+
+    The user is then responsible for closing the zipfile. This
+    is important because if the sile closes the zipfile you can't
+    write to it anymore.
+    """
+
+    geometry = sisl.geom.graphene()
+
+    # Write a temporary zipfile
+    _, tempfile_path = tempfile.mkstemp(suffix=".zip")
+    zip_file = zipfile.ZipFile(tempfile_path, "a")
+
+    filename = "graphene.dat{xyzSile}" if specify_class else "graphene.xyz"
+
+    if external_zip:
+        graphene_xyz = zipfile.Path(zip_file, filename)
+    else:
+        graphene_xyz = tempfile_path + "/" + filename
+
+    geometry.write(graphene_xyz)
+
+    if external_zip:
+        # Try to write another file
+        zipfile.Path(zip_file, "other_file.txt").open("w").write("Hello world!")
+
+        # Close the zipfile
+        zip_file.close()
+
+    # Make sisl read from the written zipfile
+    graphene_xyz = str(graphene_xyz)
+    read_geometry = sisl.get_sile(graphene_xyz).read_geometry()
+
+    assert np.allclose(read_geometry.xyz, geometry.xyz)
+    assert np.allclose(read_geometry.cell, geometry.cell)
+
+
+@pytest.mark.parametrize("external_zip", [True, False])
+@pytest.mark.parametrize("from_fdf", [True, False])
+def test_zipfile_write_read_binary(external_zip: bool, from_fdf: bool):
+    """Test that we can write and read binary files within a zipfile"""
+
+    geometry = sisl.geom.graphene()
+    H = sisl.Hamiltonian(geometry)
+    H[0, 0] = 1.3
+    H[1, 1] = 1.5
+
+    # Write a temporary zipfile
+    _, tempfile_path = tempfile.mkstemp(suffix=".zip")
+    zip_file = zipfile.ZipFile(tempfile_path, "a")
+
+    H_filename = "siesta.HSX"
+
+    if external_zip:
+        H_path = zipfile.Path(zip_file, H_filename)
+        fdf_path = zipfile.Path(zip_file, "test.fdf")
+    else:
+        H_path = tempfile_path + "/" + H_filename
+        fdf_path = tempfile_path + "/test.fdf"
+
+    if from_fdf:
+        # Write the geometry to the fdf file
+        geometry.write(fdf_path)
+
+    H.write(H_path)
+
+    if external_zip:
+        # Try to write another file
+        zipfile.Path(zip_file, "other_file.txt").open("w").write("Hello world!")
+
+        # Close the zipfile
+        zip_file.close()
+
+    # Make sisl read from the written zipfile
+    path = str(fdf_path) if from_fdf else str(H_path)
+    read_H = sisl.get_sile(path).read_hamiltonian()
+
+    assert np.allclose(H.tocsr().toarray(), read_H.tocsr().toarray())
+
+
+@pytest.mark.parametrize("external_zip", [True, False])
+@pytest.mark.parametrize("from_fdf", [True, False])
+def test_zipfile_write_read_cdf(external_zip: bool, from_fdf: bool):
+    """Test that we can write and read CDF files within a zipfile"""
+    pytest.importorskip("netCDF4")
+
+    geometry = sisl.geom.graphene()
+    grid = sisl.Grid((2, 2, 2), geometry=geometry)
+    grid[:] = np.random.random(grid.shape)
+
+    # Write a temporary zipfile
+    _, tempfile_path = tempfile.mkstemp(suffix=".zip")
+    zip_file = zipfile.ZipFile(tempfile_path, "a")
+
+    grid_filename = "Rho.grid.nc"
+
+    if external_zip:
+        grid_path = zipfile.Path(zip_file, grid_filename)
+        fdf_path = zipfile.Path(zip_file, "test.fdf")
+    else:
+        grid_path = tempfile_path + "/" + grid_filename
+        fdf_path = tempfile_path + "/test.fdf"
+
+    if from_fdf:
+        # Write the geometry to the fdf file
+        geometry.write(fdf_path)
+
+    grid.write(grid_path)
+
+    if external_zip:
+        # Try to write another file
+        zipfile.Path(zip_file, "other_file.txt").open("w").write("Hello world!")
+
+        # Close the zipfile
+        zip_file.close()
+
+    # Make sisl read from the written zipfile
+    if from_fdf:
+        read_grid = sisl.get_sile(str(fdf_path)).read_grid("RHO")
+    else:
+        # Read the grid from the grid.nc file
+        read_grid = sisl.get_sile(str(grid_path)).read_grid()
+
+    assert np.allclose(grid.grid, read_grid.grid)


### PR DESCRIPTION
#### Motivation

When dealing with very big datasets (e.g. ML) you often need to compress it into a zip or tar file to move it around. Needing to then decompress it for reading the files is a pain, because:

1. Decompressing the full dataset might take a very long time
2. File number limitations in HPC clusters. (also recently I've used a cluster that removes unused files every 30 days, which can basically destroy the parts of the dataset that you have not used).

#### Why zip and not tar?

Because tar doesn't keep an index of the contained files, so it can be very slow to access files within it when the tarfile gets big.

Therefore I have determined that putting effort into zip files is much more worth it.

#### Approach taken in this PR

Turns out that the `zipfile` library already had a `zipfile.Path` object that mimics `pathlib.Path`. Therefore, `zipfile.Path` can be used within the sile framework. It just needed some extra functionality to fully work, so I created an extension `ZipPath`, which:

- Implements missing `pathlib.Path` functions that the sile framework was using, e.g. `with_suffix`.
- Wraps the `open` method of the returned file handles so that on close we can close also the root zip file. This is specially important when writing.

**What works at the moment:**
- Reading and writing text based files.
- Reading cdf files. This is done through the `memory` argument of `netCDF4.Dataset`, which accepts the in memory bytes.
- Reading binary files. This is done by writing on a temporary file. I need some clever way of knowing when the temporary file can be removed though.
- Searching for other files in the directory. E.g. when reading from an fdf inside a zipfile, it can find other files (other fdfs, basis files, matrices) that are also inside the zipfile.

**What doesn't work for now:**
- Writing CDF files. This can also be done through the `memory` argument.
- Writing binary files. This can also be done through temporary files.

#### Comments

I will implement the missing parts and also add tests when I get feedback on whether this approach is fine or it is preferrable to create separate sile classes as with `BufferSile`.

The handling of CDF and binary files I think it should be generalized to handle generic python filehandles/objects (e.g. `bytes`/`BytesIO`) and not just contents of a zip file.

#### How to test

Here is a zip file that you can use for testing, which contains a SIESTA run of a water molecule:

[run.zip](https://github.com/user-attachments/files/19929287/run.zip)

You can read the Hamiltonian like:

```python
import sisl

sisl.get_sile("/path/to/run.zip/run/RUN.fdf").read_hamiltonian()
```

The sile framework will automatically detect that the path contains a zip file and do the necessary adjustments.

**Hope you like it!**
