### PR TITLE
restructuring the read_scf for stdoutSileSiesta

### DIFF
--- a/changes/919.fix.rst
+++ b/changes/919.fix.rst
@@ -1,0 +1,4 @@
+Fixed `stdoutSileSiesta.read_scf`
+
+It parsed the wrong spin moment and so
+had a wrong read of the first SCF iteration.


### PR DESCRIPTION
This fixes #918 which cause erroneous reads because some details are stored *after* the scf: key.
Essentially the spin moment is consistently written after.

The current approach in read_scf, is to read data until it hits the same data-key *again*, at which point it serializes the data and stores it for further processing.

The logic has been streamlined and it should be simpler to follow and edit.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #918
 - [x] Added tests for new/changed functions?
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `changes/<pr-num>.<type>.rst`

<!--
Creating a PR will check whether the pre-commit hooks
have runned, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`

The short message is:
- run `isort .` (version=6.0.0) at the top level
- run `black .` (version=25.1.0) at top-level
-->
