### PR TITLE
Fully implemented spin-block rotation

### DIFF
--- a/changes/924.fix.rst
+++ b/changes/924.fix.rst
@@ -1,0 +1,8 @@
+Fixed spin-rotations
+
+Now one can denote rotations in a much more
+generic way.
+
+Removed `rotation_matrix` and superseeded by
+`parse_rotation` which returns a `Quaternion`
+which can be used to create a rotation-matrix.

--- a/docs/api/typing.rst
+++ b/docs/api/typing.rst
@@ -57,6 +57,7 @@ The typing types are shown below:
    DistributionStr
    DistributionFunc
    DistributionType
+   RotationType
    SileLike
    SparseMatrix
    SparseMatrixExt

--- a/src/sisl/_core/sparse.py
+++ b/src/sisl/_core/sparse.py
@@ -2273,7 +2273,9 @@ def _ufunc_reduce(ufunc, array, axis=0, *args, **kwargs):
         )
 
     ret = ufunc.reduce(array._D[0:1, :], axis=0, *args, **kwargs)
-    ret = empty([array.shape[0], array.shape[2]], dtype=kwargs.get("dtype", ret.dtype))
+    if dtype := kwargs.get("dtype") is None:
+        dtype = ret.dtype
+    ret = empty([array.shape[0], array.shape[2]], dtype=dtype)
 
     # Now do ufunc calculations, note that initial gets passed directly
     ptr = array.ptr

--- a/src/sisl/physics/tests/test_density_matrix.py
+++ b/src/sisl/physics/tests/test_density_matrix.py
@@ -429,7 +429,7 @@ class TestDensityMatrix:
 
         # Rotate back
         d = d.spin_rotate((-90, "x"), rad=False)
-        assert np.allclose(d.mulliken(), [[1.5, 1.5], [0.5, 0.5]])
+        assert np.allclose(d.mulliken(), [[1.5, 1.5], [0, 0], [0, 0], [0.5, 0.5]])
 
     def test_spin_rotate_pol_full(self):
         bond = 1.42

--- a/src/sisl/typing/_common.py
+++ b/src/sisl/typing/_common.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Tuple, Union
 
 import scipy.sparse as sps
 
@@ -12,7 +12,7 @@ import scipy.sparse as sps
 # and use a string literal forward reference to it in subsequent types
 # https://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
 if TYPE_CHECKING:
-    from sisl import Geometry, Lattice, SparseAtom, SparseCSR, SparseOrbital
+    from sisl import Geometry, Lattice, Quaternion, SparseAtom, SparseCSR, SparseOrbital
 
 __all__ = [
     "Coord",
@@ -29,6 +29,7 @@ __all__ = [
     "SparseMatrix",
     "SparseMatrixExt",
     "SparseMatrixGeometry",
+    "RotationType",
 ]
 
 
@@ -68,3 +69,12 @@ SparseMatrix = Union[
 ]
 
 SparseMatrixGeometry = Union["SparseAtom", "SparseOrbital"]
+
+# Specify a rotation around Cartesian lattice vectors
+RotationType = Union[
+    Tuple[float, Union[str, SeqFloat]],  # (ang, [x, y, z] | "x")
+    SeqFloat,  # (ang-x, ang-y, ang-z)
+    "Quaternion",  # Direct
+]
+RotationCartesian = Union[str, SeqFloat]
+RotationDirect = Tuple[float, Union[str, Coord]]

--- a/src/sisl/typing/_common.py
+++ b/src/sisl/typing/_common.py
@@ -76,5 +76,3 @@ RotationType = Union[
     SeqFloat,  # (ang-x, ang-y, ang-z)
     "Quaternion",  # Direct
 ]
-RotationCartesian = Union[str, SeqFloat]
-RotationDirect = Tuple[float, Union[str, Coord]]

--- a/src/sisl/utils/tests/test_mathematics.py
+++ b/src/sisl/utils/tests/test_mathematics.py
@@ -80,14 +80,3 @@ def test_cart2spher_nd_maxr():
     assert R.ndim == 1
     assert theta.ndim == 1
     assert phi.ndim == 1
-
-
-def test_rotation_matrix():
-    angles = [10, 40, 59]
-    R1 = rotation_matrix(*angles, order="xyz")
-    R2 = rotation_matrix(*list(map(lambda x: -x, angles)), order="zyx")
-    assert np.allclose(R1 @ R2, np.identity(3))
-
-    R1 = rotation_matrix(*angles, order="xz")
-    R2 = rotation_matrix(*list(map(lambda x: -x, angles)), order="zx")
-    assert np.allclose(R1 @ R2, np.identity(3))


### PR DESCRIPTION
Fixes #924.

The problem was that the rotation should be performed using the Lie group SU(2) rotation matrix.

This merge does a lot of things:

1. extends Quaternion to return norm2, rotation_matrix rotation_matrix_su2, rotation_vector.
2. A bug in reduction calls for sparse matrices that are complex. It had used the wrong data-type.
3. Generalized rotation arguments to allow more, and simpler rotations. Now the rotations can be any of:

    - 3 floats: angles for each Cartesian direction
    - (float, str): angle + direction
    - (float, 3 floats): angle + vector of rotation
    - Quaternion

    Or any sequence of the above. In this, latter case,
    they will be combined into a single Quaternion.

4. General clean-ups in the spin-align method.
5. Added checks to ensure Hermitian matrix after rotation.

The code is relatively simple, and allows for much improved handling.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [X] Closes #924
 - [X] Added tests for new/changed functions?
 - [X] Documentation for functionality in `docs/`
 - [X] Changes documented in `changes/<pr-num>.<type>.rst`

<!--
Creating a PR will check whether the pre-commit hooks
have runned, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`

The short message is:
- run `isort .` (version=6.0.0) at the top level
- run `black .` (version=25.1.0) at top-level
-->
