### PR TITLE
trying to allow plotly 6.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,7 @@ test = [
 
 docs = [
     "sphinx<8",
-    "plotly<6",
+    "plotly", # won't work with 6.0 or 6.1, it creates too many things.
     "nbsphinx",
     "sphinx-rtd-theme",
     "sphinx-design",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #
 - [ ] Added tests for new/changed functions?
 - [ ] Documentation for functionality in `docs/`
 - [ ] Changes documented in `changes/<pr-num>.<type>.rst`

<!--
Creating a PR will check whether the pre-commit hooks
have runned, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`

The short message is:
- run `isort .` (version=6.0.0) at the top level
- run `black .` (version=25.1.0) at top-level
-->
