### PR TITLE
Fixed bugs in EllipticalCylinder and indices_in_cylinder.

### DIFF
--- a/src/sisl/shape/_cylinder.py
+++ b/src/sisl/shape/_cylinder.py
@@ -97,7 +97,7 @@ class EllipticalCylinder(PureShape):
         self._h = h
 
     def copy(self) -> Self:
-        return self.__class__(self.radial_vector, self.height, self.center)
+        return self.__class__(self.radial_vector, self.height, center=self.center)
 
     @property
     def volume(self) -> float:
@@ -140,7 +140,7 @@ class EllipticalCylinder(PureShape):
         else:
             v = self._v * scale
             h = self._h * scale
-        return self.__class__(v, h, self.center)
+        return self.__class__(v, h, center=self.center)
 
     def expand(self, radius: SeqOrScalarFloat) -> Self:
         """Expand elliptical cylinder by a constant value along each vector and height
@@ -163,7 +163,7 @@ class EllipticalCylinder(PureShape):
             raise ValueError(
                 f"{self.__class__.__name__}.expand requires the radius to be either (1,) or (3,)"
             )
-        return self.__class__([v0, v1], h, self.center)
+        return self.__class__([v0, v1], h, center=self.center)
 
     @deprecate_argument(
         "tol",


### PR DESCRIPTION
In indices_in_cylinder():
* there was no check on lower bounds along the cylinder axis;
* the height of the cylinder was doubled with respect to the value initialized in EllipticalCylinder class;
* the input R was defaulted to be a single float. This fails when radius has shape (2,) or (2,3).

In _cylinder.py:
* every call to EllipticalCylinder.__class__ was setting "axes" argument to "self.center".
