### PR TITLE
clarified documentation for Geometry.scale

### DIFF
--- a/changes/949.doc.rst
+++ b/changes/949.doc.rst
@@ -1,0 +1,4 @@
+Fixed wording in `Geometry.scale` documentation
+
+It is now clearer that both lattice vectors and
+atomic coordinates are scaled.

--- a/changes/README.rst
+++ b/changes/README.rst
@@ -17,6 +17,7 @@ Each file should be named like ``<PULL REQUEST>.<TYPE>.rst``, where
 * ``fix``: A fix for the code-base, could be a bugfix, or behavioral.
 * ``change``: Changes to API, and other operational changes.
 * ``highlight``: Adds a highlight bullet point to use as a possibly highlight
+* ``doc``: Changing or adding documentation
 
 It is possible to add more files with different categories (and text), but
 same pull request if all are relevant. For example a new feature might change

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -395,6 +395,11 @@ orphan_prefix = "orphan."
     name = "Bugfixes"
     showcontent = true
 
+    [[tool.towncrier.type]]
+    directory = "doc"
+    name = "Documentation"
+    showcontent = true
+
 [tool.rstcheck]
 ignore_directives = [
     "autosummary",

--- a/src/sisl/_core/_ufuncs_geometry.py
+++ b/src/sisl/_core/_ufuncs_geometry.py
@@ -1648,7 +1648,7 @@ def scale(
     what: Literal["abc", "xyz"] = "abc",
     scale_basis: bool = True,
 ) -> Geometry:
-    """Scale coordinates and unit-cell to get a new geometry with proper scaling
+    """Scale coordinates and lattice vectors.
 
     Parameters
     ----------
@@ -1661,7 +1661,7 @@ def scale(
          Is applied on the corresponding lattice vector and the fractional coordinates.
 
        ``xyz``
-         Is applied *only* to the atomic coordinates.
+         Is applied *only* to the Cartesian coordinates (both atomic and lattice vectors).
 
        If three different scale factors are provided, each will correspond to the
        Cartesian direction/lattice vector.


### PR DESCRIPTION
It is now clearer that it scales both atomic
and lattice coordinates.

Fixes #949.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #949
 - [x] Added tests for new/changed functions?
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `changes/<pr-num>.<type>.rst`

<!--
Creating a PR will check whether the pre-commit hooks
have runned, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`

The short message is:
- run `isort .` (version=6.0.0) at the top level
- run `black .` (version=25.1.0) at top-level
-->
