### PR TITLE
fix wrong atom order from fdf  when the coordinates are not in natura…

### DIFF
--- a/src/sisl/io/siesta/orb_indx.py
+++ b/src/sisl/io/siesta/orb_indx.py
@@ -101,15 +101,15 @@ class orbindxSileSiesta(SileSiesta):
             def crt_atom(i_s, tag, orbs):
                 # Get the atom and add the orbitals
                 kwargs = {}
-                if atoms[i_s].tag != tag:
+                if atoms.atom[i_s].tag != tag:
                     # we know ORB_INDX tag is correct
                     kwargs["tag"] = tag
-                if len(atoms[i_s]) != len(orbs):
+                if len(atoms.atom[i_s]) != len(orbs):
                     # only overwrite if # of orbitals don't match
                     kwargs["orbitals"] = orbs
                 if kwargs:
-                    return atoms[i_s].copy(**kwargs)
-                return atoms[i_s]
+                    return atoms.atom[i_s].copy(**kwargs)
+                return atoms.atom[i_s]
 
         # Now we begin by reading the atoms
         atom, orbs = [], []


### PR DESCRIPTION
This is related to a issue here:
https://github.com/mailhexu/HamiltonIO/issues/2  (An example file is included)
But I think it is more related to sisl. 

The issue is that when reading a fdf file and the coordinates and spcies are not in natural order, the index of the species are not taken into account in the fdf.read_geometry(). 

```python
import sisl
import numpy as np

fdf = sisl.get_sile("MnSi2.fdf")
geom = fdf.read_geometry()
_atoms = geom._atoms

atomic_numbers = []
positions = geom.xyz
cell = np.array(geom.lattice.cell)

for ia, a in enumerate(_atoms):
    atomic_numbers.append(a.Z % 200)

print("Atomic numbers:", atomic_numbers)
```
The expected result is 3Mn and 6 Si, 
but we get 6Mn and 3 Si. 


For the following fdf :

```
%block ChemicalSpeciesLabel
 1 14 Si
 2 25 Mn
%endblock ChemicalSpeciesLabel

%block LatticeVectors
 4.6485538110989282   -0.0000000300155494    0.0000000000000000
-2.3242774676289093    4.0257653667177848   -0.0000000000000000
 0.0000000000000000   -0.0000000000000000    6.5916403889399717
%endblock LatticeVectors

%block AtomicCoordinatesAndAtomicSpecies
 0.5000000000000000  0.0000000000000000 -0.0000000000000000   2   <----- Comes before 1!
 0.0000000000000000  0.5000000000000000  0.6666669849999991   2
 0.5000000000000000  0.5000000000000000  0.3333329860000021   2
 0.1625883354385702  0.8374116345614273  0.3333329860000021   1
 0.3251756878974937  0.1625883354589230  0.6666669849999991   1
 0.8374116345410746  0.6748243411025053  0.0000000000000000   1
 0.8374116345614273  0.1625883354385702  0.3333329860000021   1
 0.6748243411025053  0.8374116345410746  0.6666669849999991   1
 0.1625883354589230  0.3251756878974937  0.0000000000000000   1
%endblock AtomicCoordinatesAndAtomicSpecies

```




<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #
 - [ ] Added tests for new/changed functions?
 - [ ] Documentation for functionality in `docs/`
 - [ ] Changes documented in `changes/<num>.<type>.rst`
 <!-- num can be either an issue or PR number.
 Note! You can do both in the same PR, if you want references to both!
 -->

<!--
Creating a PR will check whether the pre-commit hooks
have run, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`.

The short message is:
- run `isort .` (version=6.0.0) at the top level
- run `black .` (version=25.1.0) at top-level
-->
