### PR TITLE
Bumped to Python 3.14 in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,16 +68,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10', '3.13']
+        python-version: ['3.10', '3.14']
         full-test: [true, false]
         minimal-dep: [true, false]
         os: [ubuntu-latest, macos-latest]
         exclude:
-          # only full test suite on 3.13
-          - python-version: '3.13'
+          # only full test suite on 3.14
+          - python-version: '3.14'
             full-test: false
-          # no minimal dependency on 3.13
-          - python-version: '3.13'
+          # no minimal dependency on 3.14
+          - python-version: '3.14'
             minimal-dep: true
           # minimal dependency on ARM does not make sense (wheels not present)
           - os: macos-latest

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -80,6 +80,19 @@ jobs:
           compiler: gcc
           version: 12
 
+      - name: Build wheels for CPython 3.14
+        uses: pypa/cibuildwheel@v3.3.1
+        env:
+          CIBW_BUILD: "cp314t-* cp314-*"
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_BUILD_FRONTEND:
+            "pip; args: --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+          CIBW_ENABLE: "cpython-freethreading"
+          CIBW_BEFORE_TEST: >-
+            pip install --pre
+            --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+            numpy scipy
+
       - name: Build wheels for CPython 3.13
         uses: pypa/cibuildwheel@v3.3.1
         env:

--- a/changes/978.dev.rst
+++ b/changes/978.dev.rst
@@ -1,0 +1,1 @@
+Bumped CI to Python 3.14

--- a/changes/README.rst
+++ b/changes/README.rst
@@ -18,6 +18,7 @@ Each file should be named like ``<PULL REQUEST>.<TYPE>.rst``, where
 * ``change``: Changes to API, and other operational changes.
 * ``highlight``: Adds a highlight bullet point to use as a possibly highlight
 * ``doc``: Changing or adding documentation
+* ``dev``: Changes to internal development ways of doing things, CI, pre-commit, etc.
 
 It is possible to add more files with different categories (and text), but
 same pull request if all are relevant. For example a new feature might change

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -407,6 +407,11 @@ orphan_prefix = "orphan."
     name = "Documentation"
     showcontent = true
 
+    [[tool.towncrier.type]]
+    directory = "dev"
+    name = "Internal development changes"
+    showcontent = true
+
 [tool.rstcheck]
 ignore_directives = [
     "autosummary",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #978 
 - [x] Added tests for new/changed functions?
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `changes/<num>.<type>.rst`
 <!-- num can be either an issue or PR number.
 Note! You can do both in the same PR, if you want references to both!
 -->

<!--
Creating a PR will check whether the pre-commit hooks
have run, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`.

The short message is:
- run `isort .` (version=6.0.0) at the top level
- run `black .` (version=25.1.0) at top-level
-->
