### PR TITLE
Refactor non-standard object identity test

### DIFF
--- a/changes/996.change.rst
+++ b/changes/996.change.rst
@@ -1,0 +1,1 @@
+Fix non-standard object identity test in `SparseOrbital.iter_nnz`.

--- a/changes/996.change.rst
+++ b/changes/996.change.rst
@@ -1,1 +1,0 @@
-Fix non-standard object identity test in `SparseOrbital.iter_nnz`.

--- a/changes/996.dev.rst
+++ b/changes/996.dev.rst
@@ -1,0 +1,3 @@
+Refactor non-standard object identity tests.
+
+Refactors `not object is None` to `object is not None` to improve readability and adhere to the standard.

--- a/src/sisl/_category.py
+++ b/src/sisl/_category.py
@@ -371,7 +371,7 @@ class NotCategory(GenericCategory):
 
 def _composite_name(sep):
     def getter(self):
-        if not self._name is None:
+        if self._name is not None:
             return self._name
 
         # Name is unset, we simply return the other parts

--- a/src/sisl/_core/_ufuncs_geometry.py
+++ b/src/sisl/_core/_ufuncs_geometry.py
@@ -395,7 +395,7 @@ def sort(
 
         def __init__(geometry, idx=None, sort=False):
             geometry._idx = []
-            if not idx is None:
+            if idx is not None:
                 geometry.append(idx, sort)
 
         def append(geometry, idx, sort=False):

--- a/src/sisl/_core/_ufuncs_grid.py
+++ b/src/sisl/_core/_ufuncs_grid.py
@@ -147,7 +147,7 @@ def sub(grid: Grid, idx: Union[int, Sequence[int]], axis: CellAxis) -> Grid:
     shift_geometry = False
     if len(idx) > 1:
         if np.allclose(np.diff(idx), 1):
-            shift_geometry = not grid.geometry is None
+            shift_geometry = grid.geometry is not None
 
     if shift_geometry:
         out = grid._copy_sub(len(idx), axis)
@@ -193,7 +193,7 @@ def append(grid: Grid, other: GridLike, axis: CellAxis) -> Grid:
     shape[axis] += other.shape[axis]
     d = grid._sc_geometry_dict()
     if "geometry" in d:
-        if not other.geometry is None:
+        if other.geometry is not None:
             d["geometry"] = d["geometry"].append(other.geometry, axis)
     else:
         d["geometry"] = other.geometry

--- a/src/sisl/_core/grid.py
+++ b/src/sisl/_core/grid.py
@@ -402,7 +402,7 @@ class Grid(
         """Internal routine for copying the Lattice and Geometry"""
         d = dict()
         d["lattice"] = self.lattice.copy()
-        if not self.geometry is None:
+        if self.geometry is not None:
             d["geometry"] = self.geometry.copy()
         return d
 
@@ -429,7 +429,7 @@ class Grid(
         grid = self.__class__(shape, dtype=self.dtype, **self._sc_geometry_dict())
         # Update cell shape (the cell is smaller now)
         grid.set_lattice(cell)
-        if scale_geometry and not self.geometry is None:
+        if scale_geometry and self.geometry is not None:
             geom = self.geometry.copy()
             fxyz = geom.fxyz.copy()
             geom.set_lattice(grid.lattice)
@@ -847,7 +847,7 @@ class Grid(
             s += f"commensurate: [{l[0]} {l[1]} {l[2]}]"
         else:
             s += "{}".format(str(self.lattice).replace("\n", "\n "))
-        if not self.geometry is None:
+        if self.geometry is not None:
             s += ",\n {}".format(str(self.geometry).replace("\n", "\n "))
         return f"{s}\n}}"
 

--- a/src/sisl/_core/lattice.py
+++ b/src/sisl/_core/lattice.py
@@ -313,7 +313,7 @@ class Lattice(
             self._bc = _a.fulli([3, 2], getitem("Unknown"))
         old = self._bc.copy()
 
-        if not boundary is None:
+        if boundary is not None:
             if isinstance(boundary, (Integral, str, bool)):
                 try:
                     getitem(boundary)
@@ -450,9 +450,9 @@ class Lattice(
         c : int, optional
            number of supercells in the third unit-cell vector direction
         """
-        if not nsc is None:
+        if nsc is not None:
             for i in range(3):
-                if not nsc[i] is None:
+                if nsc[i] is not None:
                     self.nsc[i] = nsc[i]
         if a:
             self.nsc[0] = a
@@ -601,7 +601,7 @@ class Lattice(
         ireps = np.amax(ix, axis=0) - np.amin(ix, axis=0) + 1
 
         # Reduce the non-set axis
-        if not axes is None:
+        if axes is not None:
             axes = map(direction, listify(axes))
             for ax in (0, 1, 2):
                 if ax not in axes:
@@ -857,10 +857,10 @@ class Lattice(
         else:
             idx = (self.sc_off[:, 0] == sc_off[0]).nonzero()[0]
 
-        if not sc_off[1] is None:
+        if sc_off[1] is not None:
             idx = idx[(self.sc_off[idx, 1] == sc_off[1]).nonzero()[0]]
 
-        if not sc_off[2] is None:
+        if sc_off[2] is not None:
             idx = idx[(self.sc_off[idx, 2] == sc_off[2]).nonzero()[0]]
 
         return idx

--- a/src/sisl/_core/sparse_geometry.py
+++ b/src/sisl/_core/sparse_geometry.py
@@ -1890,7 +1890,7 @@ class SparseOrbital(_SparseGeometry):
         transfer_idx = _a.arangei(self.geometry.no_s).reshape(-1, self.geometry.no)
         transfer_idx += _a.arangei(self.geometry.n_s).reshape(-1, 1) * other.geometry.no
         # Remove couplings along axis
-        if not axis is None:
+        if axis is not None:
             idx = (self.geometry.lattice.sc_off[:, axis] != 0).nonzero()[0]
             # Tell the routine to delete these indices
             transfer_idx[idx, :] = full_no_s + 1

--- a/src/sisl/_core/sparse_geometry.py
+++ b/src/sisl/_core/sparse_geometry.py
@@ -1497,7 +1497,7 @@ class SparseOrbital(_SparseGeometry):
         """
         if atoms is not None:
             orbitals = self.geometry.a2o(atoms, all=True)
-        elif not orbitals is None:
+        elif orbitals is not None:
             orbitals = _a.asarrayi(orbitals)
         if orbitals is None:
             yield from self._csr

--- a/src/sisl/_help.py
+++ b/src/sisl/_help.py
@@ -231,7 +231,7 @@ def array_replace(array, *replace, **kwargs):
     others = []
 
     for idx, val in replace:
-        if not val is None:
+        if val is not None:
             ar[idx] = val
         others.append(np.asarray(idx).ravel())
 

--- a/src/sisl/_namedindex.py
+++ b/src/sisl/_namedindex.py
@@ -35,7 +35,7 @@ class NamedIndex:
 
         if isinstance(name, str):
             self.add_name(name, index)
-        elif not name is None:
+        elif name is not None:
             for n, i in zip(name, index):
                 self.add_name(n, i)
 

--- a/src/sisl/geom/_category/_coord.py
+++ b/src/sisl/geom/_category/_coord.py
@@ -247,11 +247,11 @@ class AtomXYZ(AtomCategory):
             # Now we are ready to build our scheme
             if value.size == 2:
                 # do it twice
-                if not value[0] is None:
+                if value[0] is not None:
                     coord_ops.append(
                         create2(is_frac, is_abs, operator.ge, sdir, value[0])
                     )
-                if not value[1] is None:
+                if value[1] is not None:
                     coord_ops.append(
                         create2(is_frac, is_abs, operator.le, sdir, value[1])
                     )

--- a/src/sisl/geom/_category/_neighbors.py
+++ b/src/sisl/geom/_category/_neighbors.py
@@ -113,7 +113,7 @@ class AtomNeighbors(AtomCategory):
             return NullCategory()
 
         # Check if we have a condition
-        if not self._in is None:
+        if self._in is not None:
             # Get category of neighbors
             cat = self._in.categorize(geometry, geometry.asc2uc(idx))
             idx = [i for i, c in zip(idx, cat) if not isinstance(c, NullCategory)]

--- a/src/sisl/io/cube.py
+++ b/src/sisl/io/cube.py
@@ -298,7 +298,7 @@ class cubeSile(Sile):
             the imaginary part of the grid. If the geometries does not match
             an error will be raised.
         """
-        if not imag is None:
+        if imag is not None:
             if not isinstance(imag, Grid):
                 imag = Grid.read(imag)
 

--- a/src/sisl/io/openmx/omx.py
+++ b/src/sisl/io/openmx/omx.py
@@ -392,7 +392,7 @@ class omxSileOpenMX(SileOpenMX):
         cell = np.empty([3, 3], np.float64)
 
         lc = self.get("Atoms.UnitVectors")
-        if not lc is None:
+        if lc is not None:
             for i in range(3):
                 cell[i, :] = [float(k) for k in lc[i].split()[:3]]
         else:

--- a/src/sisl/io/scaleup/ref.py
+++ b/src/sisl/io/scaleup/ref.py
@@ -162,7 +162,7 @@ class restartSileScaleUp(refSileScaleUp):
             ref = None
 
         restart = super().read_geometry()
-        if not ref is None:
+        if ref is not None:
             restart.lattice = Lattice(
                 np.dot(ref.lattice.cell, restart.lattice.cell.T), nsc=restart.nsc
             )

--- a/src/sisl/io/siesta/bands.py
+++ b/src/sisl/io/siesta/bands.py
@@ -164,7 +164,7 @@ class bandsSileSiesta(SileSiesta):
                         ax.plot(x, y[ib, :])
                     ax.set_ylabel("E-Ef [eV]")
                     ax.set_xlim(x.min(), x.max())
-                    if not E is None:
+                    if E is not None:
                         ax.set_ylim(E[0], E[1])
 
                 if b.shape[1] == 2:

--- a/src/sisl/io/siesta/binaries.py
+++ b/src/sisl/io/siesta/binaries.py
@@ -836,7 +836,7 @@ class hsxSileSiesta(SileBinSiesta):
 
         def get_geom_handle(xij):
             atoms = self.read_basis(geometry=geometry, **kwargs)
-            if not atoms is None:
+            if atoms is not None:
                 return Geometry(np.zeros([len(atoms), 3]), atoms)
 
             N = len(xij)

--- a/src/sisl/io/siesta/eig.py
+++ b/src/sisl/io/siesta/eig.py
@@ -359,7 +359,7 @@ class eigSileSiesta(SileSiesta):
                         ax.scatter(ik, y[:, ib], s=s)
                     ax.set_xlabel("k-index")
                     ax.set_xlim(-0.5, len(y) + 0.5)
-                    if not E is None:
+                    if E is not None:
                         ax.set_ylim(E[0], E[1])
 
                 if E.shape[0] == 2:

--- a/src/sisl/io/siesta/stdout.py
+++ b/src/sisl/io/siesta/stdout.py
@@ -1732,15 +1732,15 @@ class stdoutSileSiesta(SileSiesta):
         if not (FOUND_SCF or FOUND_MD):
             # none of these are found
             # we request that user does not request any input
-            if (opt_iscf or (not iscf is None)) or (opt_imd or (not imd is None)):
+            if (opt_iscf or (iscf is not None)) or (opt_imd or (imd is not None)):
                 raise SileError(f"{self!s} does not contain MD/SCF charges")
 
         elif not FOUND_SCF:
-            if opt_iscf or (not iscf is None):
+            if opt_iscf or (iscf is not None):
                 raise SileError(f"{self!s} does not contain SCF charges")
 
         elif not FOUND_MD:
-            if opt_imd or (not imd is None):
+            if opt_imd or (imd is not None):
                 raise SileError(f"{self!s} does not contain MD charges")
 
         # if either are options they may hold

--- a/src/sisl/io/sile.py
+++ b/src/sisl/io/sile.py
@@ -258,7 +258,7 @@ def get_sile_class(filename, *args, **kwargs):
 
     # searchable rules
     eligible_rules = []
-    if cls is None and not cls_search is None:
+    if cls is None and cls_search is not None:
         # cls has not been set, and fcls is found
         # Figure out if fcls is a valid sile, if not
         # do nothing (it may be part of the file name)
@@ -1378,7 +1378,7 @@ class Sile(Info, BaseSile):
         comment = kwargs.pop("comment", None)
         if isinstance(comment, (list, tuple)):
             self._comment = list(comment)
-        elif not comment is None:
+        elif comment is not None:
             self._comment = [comment]
         else:
             self._comment = []

--- a/src/sisl/io/tbtrans/se.py
+++ b/src/sisl/io/tbtrans/se.py
@@ -195,7 +195,7 @@ class tbtsencSileTBtrans(_devncSileTBtrans):
         elec : str or int
            the electrode to request information from
         """
-        if not elec is None:
+        if elec is not None:
             elec = self._elec(elec)
 
         # Create a StringIO object to retain the information

--- a/src/sisl/io/tbtrans/tbt.py
+++ b/src/sisl/io/tbtrans/tbt.py
@@ -484,7 +484,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
                 NORM = geom.orbitals[a].sum()
             return NORM
 
-        if not orbitals is None:
+        if orbitals is not None:
             raise ValueError(
                 f"{self.__class__.__name__}.norm both atom and orbital cannot be specified!"
             )
@@ -528,7 +528,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
         if isinstance(orbitals, bool):
             if not orbitals:
                 orbitals = None
-        if not atoms is None and not orbitals is None:
+        if atoms is not None and orbitals is not None:
             raise ValueError(
                 "Both atoms and orbitals keyword in DOS request "
                 "cannot be specified, only one at a time."
@@ -1174,7 +1174,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
         col = self._value("list_col") - 1
 
         # get subset orbitals
-        if not orbitals is None:
+        if orbitals is not None:
             orbitals = geom._sanitize_orbs(orbitals)
 
             # select values for all supercells
@@ -1222,7 +1222,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
             for i in (0, 1, 2):
                 if nsc[i] == 1:
                     isc[i] = 0
-                if not isc[i] is None:
+                if isc[i] is not None:
                     nsc[i] = 1
 
             # Small function for creating the supercells allowed
@@ -2777,7 +2777,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
         elec : str or int
            the electrode to request information from
         """
-        if not elec is None:
+        if elec is not None:
             elec = self._elec(elec)
 
         # Create a StringIO object to retain the information
@@ -3234,7 +3234,7 @@ class tbtncSileTBtrans(_devncSileTBtrans):
             @collect_action
             @ensure_E
             def __call__(self, parser, ns, value, option_string=None):
-                if not value is None:
+                if value is not None:
                     # we are storing the spectral DOS
                     e = ns._tbt._elec(value)
                     if e not in ns._tbt.elecs:

--- a/src/sisl/io/tests/test_cube.py
+++ b/src/sisl/io/tests/test_cube.py
@@ -46,16 +46,16 @@ def test_geometry(sisl_tmp):
     grid.write(f)
     read = grid.read(f)
     assert np.allclose(grid.grid, read.grid)
-    assert not grid.geometry is None
-    assert not read.geometry is None
+    assert grid.geometry is not None
+    assert read.geometry is not None
     assert grid.geometry == read.geometry
 
     # write in another unit
     grid.write(f, unit="nm")
     read = grid.read(f)
     assert np.allclose(grid.grid, read.grid)
-    assert not grid.geometry is None
-    assert not read.geometry is None
+    assert grid.geometry is not None
+    assert read.geometry is not None
     assert grid.geometry == read.geometry
 
 
@@ -75,8 +75,8 @@ def test_imaginary(sisl_tmp):
     read_i = grid.read(fi)
     read.grid = read.grid + 1j * read_i.grid
     assert np.allclose(grid.grid, read.grid)
-    assert not grid.geometry is None
-    assert not read.geometry is None
+    assert grid.geometry is not None
+    assert read.geometry is not None
     assert grid.geometry == read.geometry
 
     read = grid.read(fr, imag=fi)

--- a/src/sisl/io/tests/test_xsf.py
+++ b/src/sisl/io/tests/test_xsf.py
@@ -60,7 +60,7 @@ def test_xsf_geometry(sisl_tmp):
     grid = Grid(0.2, geometry=geom)
     grid.grid = np.random.rand(*grid.shape)
     grid.write(f)
-    assert not grid.geometry is None
+    assert grid.geometry is not None
 
 
 def test_xsf_imaginary(sisl_tmp):
@@ -73,7 +73,7 @@ def test_xsf_imaginary(sisl_tmp):
     grid = Grid(0.2, geometry=geom, dtype=np.complex128)
     grid.grid = np.random.rand(*grid.shape) + 1j * np.random.rand(*grid.shape)
     grid.write(f)
-    assert not grid.geometry is None
+    assert grid.geometry is not None
 
 
 def test_axsf_geoms(sisl_tmp):

--- a/src/sisl/physics/electron.py
+++ b/src/sisl/physics/electron.py
@@ -1762,7 +1762,7 @@ class _electron_State:
                 }
                 for key in ("gauge",):
                     val = self.info.get(key, None)
-                    if not val is None:
+                    if val is not None:
                         opt[key] = val
                 return self.parent.Sk(**opt)
 

--- a/src/sisl/physics/hamiltonian.py
+++ b/src/sisl/physics/hamiltonian.py
@@ -372,7 +372,7 @@ class Hamiltonian(SparseOrbitalBZSpin):
         for name in ("spin",):
             if name in kwargs:
                 info[name] = kwargs[name]
-        if not format is None:
+        if format is not None:
             info["format"] = format
         return EigenvalueElectron(e, self, **info)
 
@@ -413,7 +413,7 @@ class Hamiltonian(SparseOrbitalBZSpin):
         for name in ("spin",):
             if name in kwargs:
                 info[name] = kwargs[name]
-        if not format is None:
+        if format is not None:
             info["format"] = format
         # Since eigh returns the eigenvectors [:, i] we have to transpose
         return EigenstateElectron(v.T, e, self, **info)

--- a/src/sisl/utils/misc.py
+++ b/src/sisl/utils/misc.py
@@ -337,9 +337,9 @@ def direction(d: Union[int, str], abc=None, xyz=None) -> Union[int, Any]:
     # We take it as a string
     d = d.lower().strip()
 
-    if not abc is None and d in "abc012":
+    if abc is not None and d in "abc012":
         return abc["a0b1c2".index(d) // 2]
-    elif not xyz is None and d in "xyz012":
+    elif xyz is not None and d in "xyz012":
         return xyz["x0y1z2".index(d) // 2]
     else:
         if d in ("x", "y", "z", "a", "b", "c", "0", "1", "2"):
@@ -456,7 +456,7 @@ def allow_kwargs(*args):
             elif p.kind == p.VAR_KEYWORD:
                 kwargs_name = name
 
-        if not kwargs_name is None:
+        if kwargs_name is not None:
             return func
 
         # First we figure out which arguments are already in the lists

--- a/src/sisl_toolbox/siesta/atom/_atom.py
+++ b/src/sisl_toolbox/siesta/atom/_atom.py
@@ -640,13 +640,13 @@ class AtomInput:
                 orb = self.atom.orbitals[il]
 
                 r, w = get_xy(f"AEWFNR{il}")
-                if not r is None:
+                if r is not None:
                     p = ax.plot(r, w, label=f"AE {_spdfgh[il]}")
                     color = p[0].get_color()
                     ax.axvline(orb.R * _Ang2Bohr, color=color, alpha=0.5)
 
                 r, w = get_xy(f"PSWFNR{il}")
-                if not r is None:
+                if r is not None:
                     ax.plot(r, w, "--", label=f"PS {_spdfgh[il]}")
 
             ax.set_xlim(0, atom_r * 5)
@@ -662,7 +662,7 @@ class AtomInput:
             ae_r, ae_cc = get_xy("AECHARGE", [0, 0, 0, 1])
             _, ae_vc = get_xy("AECHARGE", [0, 1, 1, -1])
 
-            if not ae_cc is None:
+            if ae_cc is not None:
                 p = ax.plot(ae_r, ae_cc, label=f"AE core")
                 color = p[0].get_color()
                 if self.opts.get("cc", False):
@@ -672,7 +672,7 @@ class AtomInput:
             ps_r, ps_cc = get_xy("PSCHARGE", [0, 0, 0, 1])
             _, ps_vc = get_xy("PSCHARGE", [0, 1, 1])
 
-            if not ps_r is None:
+            if ps_r is not None:
                 ax.plot(ps_r, ps_cc, "--", label=f"PS core")
                 ax.plot(ps_r, ps_vc, ":", label=f"PS valence")
 
@@ -730,7 +730,7 @@ class AtomInput:
                 if emark.ndim == 1:
                     emark = emark.reshape(1, -1)
                 emark = emark[:, 0]
-                if not e is None:
+                if e is not None:
                     p = ax.plot(e, log, label=f"AE {_spdfgh[il]}")
 
                     idx_mark = np.fabs(e.reshape(-1, 1) - emark.reshape(1, -1)).argmin(
@@ -744,7 +744,7 @@ class AtomInput:
                 if emark.ndim == 1:
                     emark = emark.reshape(1, -1)
                 emark = emark[:, 0]
-                if not e is None:
+                if e is not None:
                     p = ax.plot(e, log, ":", label=f"PS {_spdfgh[il]}")
 
                     idx_mark = np.fabs(e.reshape(-1, 1) - emark.reshape(1, -1)).argmin(
@@ -764,7 +764,7 @@ class AtomInput:
                 orb = self.atom.orbitals[il]
 
                 r, V = get_xy(f"PSPOTR{il}")
-                if not r is None:
+                if r is not None:
                     p = ax.plot(r, V, label=f"PS {_spdfgh[il]}")
                     color = p[0].get_color()
                     ax.axvline(orb.R * _Ang2Bohr, color=color, alpha=0.5)
@@ -806,7 +806,7 @@ class AtomInput:
 def atom_plot_cli(subp=None, parser_kwargs={}):
     """Run plotting command for the output of atom"""
 
-    is_sub = not subp is None
+    is_sub = subp is not None
 
     title = "Plotting facility for atom output (run in the atom output directory)"
     if is_sub:

--- a/src/sisl_toolbox/siesta/minimizer/_atom_basis.py
+++ b/src/sisl_toolbox/siesta/minimizer/_atom_basis.py
@@ -337,7 +337,7 @@ class AtomBasis:
                     # a confinement potential below 1meV makes no sense
                     if V0 > 0.001:
                         line += f" E {V0*_eV2Ry:.10f}"
-                        if not ri is None:
+                        if ri is not None:
                             if ri > 0:
                                 # explicit radius, convert to Bohr
                                 ri *= _Ang2Bohr
@@ -359,9 +359,9 @@ class AtomBasis:
                     if abs(Z) > 0.005:
                         # only consider charges above 0.005 electrons
                         line += f" Q {Z:.10f}"
-                        if not yukawa is None:
+                        if yukawa is not None:
                             line += f" {yukawa/_Ang2Bohr:.10f}"
-                        if not width is None:
+                        if width is not None:
                             line += f" {width*_Ang2Bohr:.10f}"
                 else:
                     raise ValueError(f"Unknown option for n={n} l={l}: {key}")

--- a/src/sisl_toolbox/siesta/minimizer/_minimize.py
+++ b/src/sisl_toolbox/siesta/minimizer/_minimize.py
@@ -72,11 +72,11 @@ class BaseMinimize:
         # log
         log = ""
 
-        if not out is None:
+        if out is not None:
             log += f" out={str(out)}"
             self.out = Path(out)
 
-        if not norm is None:
+        if norm is not None:
             log += f" norm={str(norm)}"
             if isinstance(norm, str):
                 self.norm = (norm, 1.0)

--- a/src/sisl_toolbox/transiesta/poisson/fftpoisson_fix.py
+++ b/src/sisl_toolbox/transiesta/poisson/fftpoisson_fix.py
@@ -219,7 +219,7 @@ def solve_poisson(
     # Short-hand notation
     xyz = geometry.xyz
 
-    if not device_val is None:
+    if device_val is not None:
         print(f"\nApplying device potential = {device_val}")
         idx = geometry.names["Device"]
         device = _create_shape_tree(xyz, idx)
@@ -345,7 +345,7 @@ def solve_poisson(
 
 
 def fftpoisson_fix_cli(subp=None, parser_kwargs={}):
-    is_sub = not subp is None
+    is_sub = subp is not None
 
     title = "FFT Poisson corrections for TranSiesta calculations for arbitrary number of electrodes."
     if is_sub:
@@ -572,7 +572,7 @@ def fftpoisson_fix_run(args):
         **elecs_V,
     )
 
-    if not args.plot is None:
+    if args.plot is not None:
         dat = V.average(args.plot)
         import matplotlib.pyplot as plt
 
@@ -601,7 +601,7 @@ def fftpoisson_fix_run(args):
 
     print("")
     # Write solution to the output
-    if not args.out is None:
+    if args.out is not None:
         for out in args.out:
             print(f"Writing to file: {out}...")
             V.write(out)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes https://github.com/zerothi/sisl/issues/995
 - [x] Changes documented in `changes/996.dev.rst`
 <!-- num can be either an issue or PR number.
 Note! You can do both in the same PR, if you want references to both!
 -->

<!--
Creating a PR will check whether the pre-commit hooks
have run, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`.

The short message is:
- run `isort .` (version=6.0.0) at the top level
- run `black .` (version=25.1.0) at top-level
-->

It also refactors all other occurrences of `not [object_name] is None` to `[object_name] is not None`.