### PR TITLE
BLD: Fix build failure with scikit-build-core >= 0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ fallback_version = "0.16.4"
 [build-system]
 requires = [
     "setuptools_scm[toml]>=8",
-    "scikit-build-core[pyproject]>=0.8",
+    "scikit-build-core[pyproject]>=0.10",
     "Cython>=3.0.8",
     "numpy>=2.0.0rc1"
 ]
@@ -108,7 +108,7 @@ metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 build-dir = "build/{wheel_tag}"
 
 # cmake and ninja stuff
-cmake.verbose = true
+build.verbose = true
 cmake.version = ">=3.20"
 
 # source configuration


### PR DESCRIPTION
`pyproject.toml` sets `cmake.verbose = true`. It was renamed in scikit-build-core 0.10 to `build.verbose`.
