### PR TITLE
worked on fixing cast mechanisms for handling cast-issues on MSVC

### DIFF
--- a/changes/orphan.6.fix.rst
+++ b/changes/orphan.6.fix.rst
@@ -1,0 +1,11 @@
+portable complex arithmetic in the fused-type Cython kernels
+
+The k-space matrix kernels are templated on independent fused types for the
+matrix data and the phases, so Cython instantiates real/complex combinations
+that never occur at runtime. Those instantiations emitted a cast from a
+complex to a real value, and in-place ``+=`` on complex memoryview elements,
+neither of which compiles unless the C compiler maps complex numbers onto the
+native C99 ``_Complex`` type. Both are now routed through the new
+``cast_add``/``cast_assign`` helpers in ``sisl/_core/_dtypes.pxd``, which
+resolve the real/complex distinction at compile time, so the extensions also
+build with the struct-based complex fallback (MSVC) and in C++ mode.

--- a/src/sisl/_core/_dtypes.pxd
+++ b/src/sisl/_core/_dtypes.pxd
@@ -51,6 +51,76 @@ ctypedef fused floatcomplexs_st:
     double complex
 
 
+# A second, *independent* float/complex fused type.
+# Cython ties together all occurrences of the same fused ctypedef in a
+# signature, so a routine that needs two unrelated float/complex types
+# (e.g. matrix data and phases) must use two distinct names.
+ctypedef fused _floatcomplexs2_st:
+    float
+    double
+    float complex
+    double complex
+
+
+# The two casting helpers below exist so that mixed real/complex fused
+# routines can be written *once*, without duplicating the loop bodies for
+# the real and the complex variants.
+#
+# Writing ``out[0] = <real_type> complex_value`` directly is not portable:
+# it only compiles when Cython maps complex numbers onto the native C99
+# ``_Complex`` type. With the struct fallback (``CYTHON_CCOMPLEX == 0``,
+# e.g. MSVC) or in C++ mode (``std::complex``) the generated cast is a hard
+# compile error, and Cython instantiates *every* combination of the fused
+# types, including the complex -> real ones that never occur at runtime.
+#
+# NOTE: `value` is deliberately *not* declared ``const``. Cython treats
+# ``const T`` as a distinct type from ``T`` for a by-value parameter, and
+# coerces a complex argument into it via a decompose/recompose round trip
+# (``from_parts(CREAL(x), CIMAG(x))``). That round trip is emitted at the
+# *call site*, so inlining cannot remove it, and gcc does not fold it away
+# even at -ffast-math. A by-value scalar gains nothing from ``const``.
+#
+# The ``is`` / ``in`` tests on the fused types are *compile-time*
+# conditions: Cython prunes the non-matching branches for every
+# specialization, so the offending cast is never emitted and neither a
+# runtime branch nor a call survives (both helpers are inlined).
+@cython.initializedcheck(False)
+@cython.boundscheck(False)
+cdef inline void cast_assign(floatcomplexs_st *out,
+                             _floatcomplexs2_st value) noexcept nogil:
+    """``out[0] = value``, dropping the imaginary part if `out` is real"""
+    if floatcomplexs_st is _floatcomplexs2_st:
+        out[0] = value
+    elif floatcomplexs_st in complexs_st:
+        out[0] = <floatcomplexs_st> value
+    elif _floatcomplexs2_st in complexs_st:
+        out[0] = <floatcomplexs_st> value.real
+    else:
+        out[0] = <floatcomplexs_st> value
+
+
+@cython.initializedcheck(False)
+@cython.boundscheck(False)
+cdef inline void cast_add(floatcomplexs_st *out,
+                          _floatcomplexs2_st value) noexcept nogil:
+    """``out[0] += value``, dropping the imaginary part if `out` is real
+
+    Not written as an in-place ``+=`` at the call sites: for complex fused
+    types Cython lowers in-place operators on memoryview elements to a raw
+    C ``+=``, which does not compile for the struct/std::complex fallbacks.
+    """
+    if floatcomplexs_st is _floatcomplexs2_st:
+        # identical types, no conversion (avoids a redundant complex
+        # decompose/recompose round trip that gcc does not fully fold)
+        out[0] = out[0] + value
+    elif floatcomplexs_st in complexs_st:
+        out[0] = out[0] + <floatcomplexs_st> value
+    elif _floatcomplexs2_st in complexs_st:
+        out[0] = out[0] + <floatcomplexs_st> value.real
+    else:
+        out[0] = out[0] + <floatcomplexs_st> value
+
+
 # We need this fused data-type to omit complex data-types
 ctypedef fused reals_st:
     int
@@ -88,7 +158,7 @@ ctypedef fused _type2dtype_types_st:
     uint64_t
 
 
-cdef object type2dtype(const _type2dtype_types_st v)
+cdef object type2dtype(const _type2dtype_types_st v) noexcept
 
 
 ctypedef fused _inline_sum_st:
@@ -101,5 +171,6 @@ ctypedef fused _inline_sum_st:
     uint16_t
     uint32_t
     uint64_t
+
 
 cdef Py_ssize_t inline_sum(const _inline_sum_st[::1] array) noexcept nogil

--- a/src/sisl/_core/_dtypes.pyx
+++ b/src/sisl/_core/_dtypes.pyx
@@ -23,7 +23,7 @@ from numpy cimport (
 
 
 @cython.initializedcheck(False)
-cdef inline object type2dtype(const _type2dtype_types_st v):
+cdef inline object type2dtype(const _type2dtype_types_st v) noexcept:
     if _type2dtype_types_st is int8_t:
         return np.int8
     elif _type2dtype_types_st is int16_t:
@@ -64,7 +64,6 @@ cdef inline object type2dtype(const _type2dtype_types_st v):
         return np.uint32
     elif _type2dtype_types_st is uint64_t:
         return np.uint64
-
 
 
 @cython.wraparound(False)

--- a/src/sisl/_core/_sparse.pyx
+++ b/src/sisl/_core/_sparse.pyx
@@ -221,4 +221,9 @@ def _sparse_dense(int_sp_st[::1] ptr,
     for r in range(ncol.shape[0]):
         for ind in range(ptr[r], ptr[r] + ncol[r]):
             for ix in range(s2):
-                dense[r, col[ind], ix] += data[ind, ix]
+                # not an in-place ``+=``: for complex fused types Cython lowers
+                # in-place operators on memoryview elements to a raw C ``+=``,
+                # which does not compile when complex numbers are represented
+                # as a struct (CYTHON_CCOMPLEX == 0, e.g. MSVC) or as
+                # std::complex (C++)
+                dense[r, col[ind], ix] = dense[r, col[ind], ix] + data[ind, ix]

--- a/src/sisl/physics/_matrix_phase.pyx
+++ b/src/sisl/physics/_matrix_phase.pyx
@@ -15,6 +15,7 @@ from sisl._indices cimport _index_sorted
 from sisl._core._sparse import fold_csr_matrix, fold_csr_matrix_diag
 
 from sisl._core._dtypes cimport (
+    cast_add,
     complexs_st,
     floatcomplexs_st,
     floats_st,
@@ -92,7 +93,6 @@ def phase_csr(const int_sp_st[::1] ptr,
     cdef int_sp_st[::1] v_col = V_COL
     cdef int_sp_st[::1] tmp
 
-    # This may fail, when floatcomplexs_st is complex, but phases_st is float
     cdef object dtype = type2dtype[phases_st](1)
     cdef cnp.ndarray[phases_st, mode='c'] V = np.zeros([v_col.shape[0]], dtype=dtype)
     cdef phases_st[::1] v = V
@@ -109,7 +109,7 @@ def phase_csr(const int_sp_st[::1] ptr,
 
                     tmp = v_col[v_ptr[r]:v_ptr[r] + v_ncol[r]]
                     s_idx = _index_sorted(tmp, c)
-                    v[v_ptr[r] + s_idx] += <phases_st> D[ind, idx]
+                    cast_add(&v[v_ptr[r] + s_idx], D[ind, idx])
 
         elif p_opt == 0:
             for r in range(nr):
@@ -118,7 +118,7 @@ def phase_csr(const int_sp_st[::1] ptr,
 
                     tmp = v_col[v_ptr[r]:v_ptr[r] + v_ncol[r]]
                     s_idx = _index_sorted(tmp, c)
-                    v[v_ptr[r] + s_idx] += <phases_st> (D[ind, idx] * phases[ind])
+                    cast_add(&v[v_ptr[r] + s_idx], D[ind, idx] * phases[ind])
 
         else:
             for r in range(nr):
@@ -128,7 +128,7 @@ def phase_csr(const int_sp_st[::1] ptr,
 
                     tmp = v_col[v_ptr[r]:v_ptr[r] + v_ncol[r]]
                     s_idx = _index_sorted(tmp, c)
-                    v[v_ptr[r] + s_idx] += <phases_st> (D[ind, idx] * phases[s])
+                    cast_add(&v[v_ptr[r] + s_idx], D[ind, idx] * phases[s])
 
     return csr_matrix((V, V_COL, V_PTR), shape=(nr, nr))
 
@@ -156,20 +156,20 @@ def phase_array(const int_sp_st[::1] ptr,
             for r in range(nr):
                 for ind in range(ptr[r], ptr[r] + ncol[r]):
                     c = col[ind] % nr
-                    v[r, c] += <phases_st> (D[ind, idx])
+                    cast_add(&v[r, c], D[ind, idx])
 
         elif p_opt == 0:
             for r in range(nr):
                 for ind in range(ptr[r], ptr[r] + ncol[r]):
                     c = col[ind] % nr
-                    v[r, c] += <phases_st> (D[ind, idx] * phases[ind])
+                    cast_add(&v[r, c], D[ind, idx] * phases[ind])
 
         else:
             for r in range(nr):
                 for ind in range(ptr[r], ptr[r] + ncol[r]):
                     c = col[ind] % nr
                     s = col[ind] / nr
-                    v[r, c] += <phases_st> (D[ind, idx] * phases[s])
+                    cast_add(&v[r, c], D[ind, idx] * phases[s])
 
     return V
 
@@ -212,7 +212,7 @@ def phase_csr_diag(const int_sp_st[::1] ptr,
 
                     d = <complexs_st> D[ind, idx]
                     for ic in range(per_row):
-                        v[v_ptr[rr+ic] + s_idx] += d
+                        cast_add(&v[v_ptr[rr+ic] + s_idx], d)
 
         elif p_opt == 0:
             for r in range(nr):
@@ -225,7 +225,7 @@ def phase_csr_diag(const int_sp_st[::1] ptr,
 
                     d = phases[ind] * D[ind, idx]
                     for ic in range(per_row):
-                        v[v_ptr[rr+ic] + s_idx] += d
+                        cast_add(&v[v_ptr[rr+ic] + s_idx], d)
 
         else:
             for r in range(nr):
@@ -239,7 +239,7 @@ def phase_csr_diag(const int_sp_st[::1] ptr,
 
                     d = phases[s] * D[ind, idx]
                     for ic in range(per_row):
-                        v[v_ptr[rr+ic] + s_idx] += d
+                        cast_add(&v[v_ptr[rr+ic] + s_idx], d)
 
     nr = nr * per_row
     return csr_matrix((V, V_COL, V_PTR), shape=(nr, nr))
@@ -274,7 +274,7 @@ def phase_array_diag(const int_sp_st[::1] ptr,
                     c = (col[ind] % nr) * per_row
                     d = D[ind, idx]
                     for ic in range(per_row):
-                        v[rr + ic, c + ic] += d
+                        cast_add(&v[rr + ic, c + ic], d)
 
         elif p_opt == 0:
             for r in range(nr):
@@ -283,7 +283,7 @@ def phase_array_diag(const int_sp_st[::1] ptr,
                     c = (col[ind] % nr) * per_row
                     d = phases[ind] * D[ind, idx]
                     for ic in range(per_row):
-                        v[rr + ic, c + ic] += d
+                        cast_add(&v[rr + ic, c + ic], d)
 
         else:
             for r in range(nr):
@@ -293,7 +293,7 @@ def phase_array_diag(const int_sp_st[::1] ptr,
                     s = col[ind] / nr
                     d = phases[s] * D[ind, idx]
                     for ic in range(per_row):
-                        v[rr + ic, c + ic] += d
+                        cast_add(&v[rr + ic, c + ic], d)
 
     return V
 

--- a/src/sisl/physics/_matrix_phase3.pyx
+++ b/src/sisl/physics/_matrix_phase3.pyx
@@ -15,6 +15,7 @@ from sisl._indices cimport _index_sorted
 from sisl._core._sparse import fold_csr_matrix
 
 from sisl._core._dtypes cimport (
+    cast_add,
     complexs_st,
     floatcomplexs_st,
     floats_st,
@@ -71,7 +72,6 @@ def phase3_csr(const int_sp_st[::1] ptr,
     cdef int_sp_st[::1] v_ncol = V_NCOL
     cdef int_sp_st[::1] v_col = V_COL
 
-    # This may fail, when floatcomplexs_st is complex, but phases_st is float
     cdef object dtype = type2dtype[phases_st](1)
     cdef cnp.ndarray[phases_st, mode='c'] Vx = np.zeros([v_col.shape[0]], dtype=dtype)
     cdef cnp.ndarray[phases_st, mode='c'] Vy = np.zeros([v_col.shape[0]], dtype=dtype)
@@ -93,9 +93,9 @@ def phase3_csr(const int_sp_st[::1] ptr,
                     c = col[ind] % nr
                     s_idx = _index_sorted(v_col[v_ptr[r]:v_ptr[r] + v_ncol[r]], c)
                     d = D[ind, idx]
-                    vx[v_ptr[r] + s_idx] += <phases_st> (d * phases[ind, 0])
-                    vy[v_ptr[r] + s_idx] += <phases_st> (d * phases[ind, 1])
-                    vz[v_ptr[r] + s_idx] += <phases_st> (d * phases[ind, 2])
+                    cast_add(&vx[v_ptr[r] + s_idx], d * phases[ind, 0])
+                    cast_add(&vy[v_ptr[r] + s_idx], d * phases[ind, 1])
+                    cast_add(&vz[v_ptr[r] + s_idx], d * phases[ind, 2])
 
         else:
             for r in range(nr):
@@ -104,9 +104,9 @@ def phase3_csr(const int_sp_st[::1] ptr,
                     s = col[ind] / nr
                     s_idx = _index_sorted(v_col[v_ptr[r]:v_ptr[r] + v_ncol[r]], c)
                     d = D[ind, idx]
-                    vx[v_ptr[r] + s_idx] += <phases_st> (d * phases[s, 0])
-                    vy[v_ptr[r] + s_idx] += <phases_st> (d * phases[s, 1])
-                    vz[v_ptr[r] + s_idx] += <phases_st> (d * phases[s, 2])
+                    cast_add(&vx[v_ptr[r] + s_idx], d * phases[s, 0])
+                    cast_add(&vy[v_ptr[r] + s_idx], d * phases[s, 1])
+                    cast_add(&vz[v_ptr[r] + s_idx], d * phases[s, 2])
 
     return csr_matrix((Vx, V_COL, V_PTR), shape=(nr, nr)), csr_matrix((Vy, V_COL, V_PTR), shape=(nr, nr)), csr_matrix((Vz, V_COL, V_PTR), shape=(nr, nr))
 
@@ -141,9 +141,9 @@ def phase3_array(const int_sp_st[::1] ptr,
                 for ind in range(ptr[r], ptr[r] + ncol[r]):
                     c = col[ind] % nr
                     d = D[ind, idx]
-                    vx[r, c] += <phases_st> (d * phases[ind, 0])
-                    vy[r, c] += <phases_st> (d * phases[ind, 1])
-                    vz[r, c] += <phases_st> (d * phases[ind, 2])
+                    cast_add(&vx[r, c], d * phases[ind, 0])
+                    cast_add(&vy[r, c], d * phases[ind, 1])
+                    cast_add(&vz[r, c], d * phases[ind, 2])
 
         else:
             for r in range(nr):
@@ -151,9 +151,9 @@ def phase3_array(const int_sp_st[::1] ptr,
                     c = col[ind] % nr
                     s = col[ind] / nr
                     d = D[ind, idx]
-                    vx[r, c] += <phases_st> (d * phases[s, 0])
-                    vy[r, c] += <phases_st> (d * phases[s, 1])
-                    vz[r, c] += <phases_st> (d * phases[s, 2])
+                    cast_add(&vx[r, c], d * phases[s, 0])
+                    cast_add(&vy[r, c], d * phases[s, 1])
+                    cast_add(&vz[r, c], d * phases[s, 2])
 
     return Vx, Vy, Vz
 

--- a/src/sisl/physics/_matrix_phase_sc.pyx
+++ b/src/sisl/physics/_matrix_phase_sc.pyx
@@ -11,6 +11,7 @@ cimport numpy as cnp
 from scipy.sparse import csr_matrix
 
 from sisl._core._dtypes cimport (
+    cast_assign,
     complexs_st,
     floatcomplexs_st,
     floats_st,
@@ -96,7 +97,7 @@ def phase_sc_csr(int_sp_st[::1] ptr,
             for r in range(nr):
                 v_ptr[r] = cind
                 for ind in range(ptr[r], ptr[r] + ncol[r]):
-                    v[cind] = <phases_st> D[ind, idx]
+                    cast_assign(&v[cind], D[ind, idx])
                     v_col[cind] = col[ind]
                     cind = cind + 1
 
@@ -105,7 +106,7 @@ def phase_sc_csr(int_sp_st[::1] ptr,
                 v_ptr[r] = cind
                 for ind in range(ptr[r], ptr[r] + ncol[r]):
                     ph = phases[ind]
-                    v[cind] = <phases_st> (D[ind, idx] * ph)
+                    cast_assign(&v[cind], D[ind, idx] * ph)
                     v_col[cind] = col[ind]
                     cind = cind + 1
 
@@ -114,7 +115,7 @@ def phase_sc_csr(int_sp_st[::1] ptr,
                 v_ptr[r] = cind
                 for ind in range(ptr[r], ptr[r] + ncol[r]):
                     ph = phases[col[ind] / nr]
-                    v[cind] = <phases_st> (D[ind, idx] * ph)
+                    cast_assign(&v[cind], D[ind, idx] * ph)
                     v_col[cind] = col[ind]
                     cind = cind + 1
 
@@ -145,19 +146,19 @@ def phase_sc_array(int_sp_st[::1] ptr,
         if p_opt == -1:
             for r in range(nr):
                 for ind in range(ptr[r], ptr[r] + ncol[r]):
-                    v[r, col[ind]] = <phases_st> D[ind, idx]
+                    cast_assign(&v[r, col[ind]], D[ind, idx])
 
         elif p_opt == 0:
             for r in range(nr):
                 for ind in range(ptr[r], ptr[r] + ncol[r]):
                     ph = phases[ind]
-                    v[r, col[ind]] = <phases_st> (D[ind, idx] * ph)
+                    cast_assign(&v[r, col[ind]], D[ind, idx] * ph)
 
         else:
             for r in range(nr):
                 for ind in range(ptr[r], ptr[r] + ncol[r]):
                     ph = phases[col[ind] / nr]
-                    v[r, col[ind]] = <phases_st> (D[ind, idx] * ph)
+                    cast_assign(&v[r, col[ind]], D[ind, idx] * ph)
 
     return V
 

--- a/src/sisl/physics/_matrix_utils.pyx
+++ b/src/sisl/physics/_matrix_utils.pyx
@@ -8,7 +8,13 @@ import numpy as np
 
 cimport numpy as cnp
 
-from sisl._core._dtypes cimport complexs_st, floatcomplexs_st, int_sp_st, reals_st
+from sisl._core._dtypes cimport (
+    cast_add,
+    complexs_st,
+    floatcomplexs_st,
+    int_sp_st,
+    reals_st,
+)
 
 """
 These routines converts an array of n-values into a spin-box matrix.
@@ -43,24 +49,30 @@ M[7] == Delta[1, 1]
 """
 
 
+# NOTE: the accumulations below go through `cast_add` rather than an in-place
+# ``v[i] += M[n]``. For complex fused types Cython lowers an in-place operator on
+# a memoryview element to a raw C ``+=``, which does not compile when complex
+# numbers are represented as a struct (CYTHON_CCOMPLEX == 0, e.g. MSVC) or as
+# std::complex (C++ mode). `v` and `M` share `complexs_st` here, so `cast_add`
+# resolves to a plain addition and compiles to identical machine code.
 cdef inline void matrix_add_csr_nc(const int_sp_st[::1] v_ptr,
                                    const int_sp_st r,
                                    const int_sp_st r_idx,
                                    complexs_st[::1] v,
                                    const complexs_st *M) noexcept nogil:
-    v[v_ptr[r] + r_idx] += M[0]
-    v[v_ptr[r] + r_idx+1] += M[1]
-    v[v_ptr[r+1] + r_idx] += M[2]
-    v[v_ptr[r+1] + r_idx+1] += M[3]
+    cast_add(&v[v_ptr[r] + r_idx], M[0])
+    cast_add(&v[v_ptr[r] + r_idx+1], M[1])
+    cast_add(&v[v_ptr[r+1] + r_idx], M[2])
+    cast_add(&v[v_ptr[r+1] + r_idx+1], M[3])
 
 cdef inline void matrix_add_array_nc(const int_sp_st r,
                                      const int_sp_st c,
                                      complexs_st[:, ::1] v,
                                      const complexs_st *M) noexcept nogil:
-    v[r, c] += M[0]
-    v[r, c+1] += M[1]
-    v[r+1, c] += M[2]
-    v[r+1,c+1] += M[3]
+    cast_add(&v[r, c], M[0])
+    cast_add(&v[r, c+1], M[1])
+    cast_add(&v[r+1, c], M[2])
+    cast_add(&v[r+1,c+1], M[3])
 
 cdef inline void matrix_box_nc_real(const reals_st *data,
                                     const complexs_st phase,
@@ -104,58 +116,58 @@ cdef inline void matrix_add_csr_nambu(const int_sp_st[::1] v_ptr,
                                       complexs_st[::1] v,
                                       const complexs_st *M) noexcept nogil:
     # H e-e
-    v[v_ptr[r] + r_idx] += M[0]
-    v[v_ptr[r] + r_idx+1] += M[1]
+    cast_add(&v[v_ptr[r] + r_idx], M[0])
+    cast_add(&v[v_ptr[r] + r_idx+1], M[1])
     # Delta [e-h]
-    v[v_ptr[r] + r_idx+2] += M[4]
-    v[v_ptr[r] + r_idx+3] += M[5]
+    cast_add(&v[v_ptr[r] + r_idx+2], M[4])
+    cast_add(&v[v_ptr[r] + r_idx+3], M[5])
     # H e-e
-    v[v_ptr[r+1] + r_idx] += M[2]
-    v[v_ptr[r+1] + r_idx+1] += M[3]
+    cast_add(&v[v_ptr[r+1] + r_idx], M[2])
+    cast_add(&v[v_ptr[r+1] + r_idx+1], M[3])
     # Delta [e-h]
-    v[v_ptr[r+1] + r_idx+2] += M[6]
-    v[v_ptr[r+1] + r_idx+3] += M[7]
+    cast_add(&v[v_ptr[r+1] + r_idx+2], M[6])
+    cast_add(&v[v_ptr[r+1] + r_idx+3], M[7])
     # -Delta^* [h-e]
-    v[v_ptr[r+2] + r_idx] += M[12]
-    v[v_ptr[r+2] + r_idx+1] += M[13]
+    cast_add(&v[v_ptr[r+2] + r_idx], M[12])
+    cast_add(&v[v_ptr[r+2] + r_idx+1], M[13])
     # H h-h: -H^*
-    v[v_ptr[r+2] + r_idx+2] += M[8]
-    v[v_ptr[r+2] + r_idx+3] += M[9]
+    cast_add(&v[v_ptr[r+2] + r_idx+2], M[8])
+    cast_add(&v[v_ptr[r+2] + r_idx+3], M[9])
     # -Delta^* [h-e]
-    v[v_ptr[r+3] + r_idx] += M[14]
-    v[v_ptr[r+3] + r_idx+1] += M[15]
+    cast_add(&v[v_ptr[r+3] + r_idx], M[14])
+    cast_add(&v[v_ptr[r+3] + r_idx+1], M[15])
     # H h-h: -H^*
-    v[v_ptr[r+3] + r_idx+2] += M[10]
-    v[v_ptr[r+3] + r_idx+3] += M[11]
+    cast_add(&v[v_ptr[r+3] + r_idx+2], M[10])
+    cast_add(&v[v_ptr[r+3] + r_idx+3], M[11])
 
 cdef inline void matrix_add_array_nambu(const int_sp_st r,
                                         const int_sp_st c,
                                         complexs_st[:, ::1] v,
                                         const complexs_st *M) noexcept nogil:
     # H e-e
-    v[r, c] += M[0]
-    v[r, c+1] += M[1]
+    cast_add(&v[r, c], M[0])
+    cast_add(&v[r, c+1], M[1])
     # Delta [e-h]
-    v[r, c+2] += M[4]
-    v[r, c+3] += M[5]
+    cast_add(&v[r, c+2], M[4])
+    cast_add(&v[r, c+3], M[5])
     # H e-e
-    v[r+1, c] += M[2]
-    v[r+1,c+1] += M[3]
+    cast_add(&v[r+1, c], M[2])
+    cast_add(&v[r+1,c+1], M[3])
     # Delta [e-h]
-    v[r+1, c+2] += M[6]
-    v[r+1, c+3] += M[7]
+    cast_add(&v[r+1, c+2], M[6])
+    cast_add(&v[r+1, c+3], M[7])
     # -Delta^* [h-e]
-    v[r+2, c] += M[12]
-    v[r+2, c+1] += M[13]
+    cast_add(&v[r+2, c], M[12])
+    cast_add(&v[r+2, c+1], M[13])
     # H h-h: -H^*
-    v[r+2, c+2] += M[8]
-    v[r+2, c+3] += M[9]
+    cast_add(&v[r+2, c+2], M[8])
+    cast_add(&v[r+2, c+3], M[9])
     # -Delta^* [h-e]
-    v[r+3, c] += M[14]
-    v[r+3, c+1] += M[15]
+    cast_add(&v[r+3, c], M[14])
+    cast_add(&v[r+3, c+1], M[15])
     # H h-h: -H^*
-    v[r+3, c+2] += M[10]
-    v[r+3, c+3] += M[11]
+    cast_add(&v[r+3, c+2], M[10])
+    cast_add(&v[r+3, c+3], M[11])
 
 
 cdef inline void matrix_box_nambu_real(const reals_st *data,


### PR DESCRIPTION
The problem is that MSVC does not have proper complex support.

Now we use an inline wrapper call that does the correct thing by compile time optimizations

Since cython removes branches we can use checks at the different branches of data-types, hence removing all boiler plate code before the heavy lifting.
This results in a little more verbose code, but will compile on windows (hopefully) and also with no performance penalty.

Also, one should never do += because Cython can't translate it to proper arithmetic on Windows (no support of the complex dtype).

The inlined code does not use *const* because Cython thinks that const T is no the same as T, meaning it reconstructs the type at pass.
I'll try and do this on the other parts of the code as well.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #1010 
 - [x] Added tests for new/changed functions?
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `changes/<num>.<type>.rst`
 <!-- num can be either an issue or PR number.
 Note! You can do both in the same PR, if you want references to both!
 -->

<!--
Creating a PR will check whether the pre-commit hooks
have run, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`.

The short message is:
- run `isort .` (version=6.0.0) at the top level
- run `black .` (version=25.1.0) at top-level
-->
