### PR TITLE
fixing windows wheel creation

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -82,8 +82,8 @@ jobs:
             deployment_target: "14.0"
 
           # Windows
-          #- os: windows-latest
-          #  cibw_archs: "AMD64"
+          - os: windows-latest
+            cibw_archs: "AMD64"
 
     steps:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ if(NOT sisl_has_ipo)
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
 endif()
 
-
 # Build configuration details
 message(STATUS "Build configuration information")
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
@@ -75,9 +74,21 @@ message(CHECK_PASS "Found Cython")
 
 
 # Define global definitions
+# Comment from Cython documentation:
+# > In order to prevent the joined binary from exporting all of the module
+# > init functions as public symbols, Cython 0.28 and later can hide these
+# > symbols if the macro CYTHON_NO_PYINIT_EXPORT is defined while C-compiling
+# > the module C files.
+# Cython's PyMODINIT_FUNC carries __declspec(dllexport) on Windows, which is what
+# makes PyInit_<module> visible in the resulting .pyd. Defining
+# CYTHON_NO_PYINIT_EXPORT strips that attribute, so it may only be used on
+# platforms where symbols are exported by default (ELF/Mach-O).
+if(NOT WIN32)
+  add_compile_definitions(CYTHON_NO_PYINIT_EXPORT=1)
+endif()
+
 # We will never use the deprecated API any-more
 add_compile_definitions(NPY_NO_DEPRECATED_API=NPY_1_20_API_VERSION)
-add_compile_definitions(CYTHON_NO_PYINIT_EXPORT=1)
 
 # All libraries in sisl will *not* be prefixed with
 #: lib, perhaps we should change this

--- a/changes/orphan.7.dev.rst
+++ b/changes/orphan.7.dev.rst
@@ -1,0 +1,7 @@
+enabled windows wheels
+
+Fully compilable wheels for windows.
+The cython sources has been fixed such
+that Windows builds are enabled.
+Note that the shipped wheels do not
+enable Fortran sources.

--- a/src/sisl/_core/_dtypes.pxd
+++ b/src/sisl/_core/_dtypes.pxd
@@ -6,11 +6,7 @@ cimport cython
 import numpy as np
 
 cimport numpy as cnp
-from numpy cimport (
-    complex64_t,
-    complex128_t,
-    float32_t,
-    float64_t,
+from libc.stdint cimport (
     int8_t,
     int16_t,
     int32_t,
@@ -21,15 +17,44 @@ from numpy cimport (
     uint64_t,
 )
 
+
+cdef extern from *:
+    """
+    #include <limits.h>
+    #if INT_MAX != 2147483647
+    #error "sisl requires a 32-bit int"
+    #endif
+    #if LLONG_MAX != 9223372036854775807LL
+    #error "sisl requires a 64-bit long long"
+    #endif
+    """
+    pass
+
 # Generic typedefs for sisl internal naming convention
 ctypedef size_t size_st
 
 
+# Signed integers.
+#
+# The members are the *fixed width* types, deliberately not `int`/`long`:
+# `long` is 64-bit on LP64 (Linux/macOS) but 32-bit on LLP64 (Windows/MSVC).
+# A fused (int, long) therefore expands to two *identical* 32-bit
+# specializations on Windows, and then nothing matches an int64 array at all
+# (dispatch is on itemsize+kind, so the second specialization is simply dead
+# code). int32_t and int64_t are distinct on every platform we build for, so
+# the fused type has exactly one member per width, everywhere.
+#
+# There is no way to make the member list itself conditional: the fused `is`
+# test is only valid inside a function body (where it is a compile-time
+# branch per specialization), and the compile-time IF/DEF statements are
+# deprecated and slated for removal. Choosing non-overlapping types is the
+# way to avoid duplicate specializations.
 ctypedef fused ints_st:
     int
-    long
+    long long
 
 
+# Index type of the scipy sparse matrices (int32 everywhere)
 ctypedef fused int_sp_st:
     int
 
@@ -124,30 +149,19 @@ cdef inline void cast_add(floatcomplexs_st *out,
 # We need this fused data-type to omit complex data-types
 ctypedef fused reals_st:
     int
-    long
+    long long
     float
     double
 
 ctypedef fused numerics_st:
     int
-    long
+    long long
     float
     double
     float complex
     double complex
 
 ctypedef fused _type2dtype_types_st:
-    short
-    int
-    long
-    float
-    double
-    float complex
-    double complex
-    float32_t
-    float64_t
-    #complex64_t # not usable...
-    #complex128_t
     int8_t
     int16_t
     int32_t
@@ -156,21 +170,26 @@ ctypedef fused _type2dtype_types_st:
     uint16_t
     uint32_t
     uint64_t
+    int
+    long long
+    float
+    double
+    float complex
+    double complex
 
 
 cdef object type2dtype(const _type2dtype_types_st v)
 
 
 ctypedef fused _inline_sum_st:
-    short
-    int
-    long
     int16_t
     int32_t
     int64_t
     uint16_t
     uint32_t
     uint64_t
+    int
+    long long
 
 
 cdef Py_ssize_t inline_sum(const _inline_sum_st[::1] array) noexcept nogil

--- a/src/sisl/_core/_dtypes.pyx
+++ b/src/sisl/_core/_dtypes.pyx
@@ -6,11 +6,7 @@ cimport cython
 import numpy as np
 
 cimport numpy as cnp
-from numpy cimport (
-    complex64_t,
-    complex128_t,
-    float32_t,
-    float64_t,
+from libc.stdint cimport (
     int8_t,
     int16_t,
     int32_t,
@@ -21,6 +17,9 @@ from numpy cimport (
     uint64_t,
 )
 
+ctypedef long long _longlong
+ctypedef float complex _complex64_t
+ctypedef double complex _complex128_t
 
 @cython.initializedcheck(False)
 cdef inline object type2dtype(const _type2dtype_types_st v):
@@ -28,31 +27,21 @@ cdef inline object type2dtype(const _type2dtype_types_st v):
         return np.int8
     elif _type2dtype_types_st is int16_t:
         return np.int16
-    elif _type2dtype_types_st is cython.short:
-        return np.int16
     elif _type2dtype_types_st is int32_t:
-        return np.int32
-    elif _type2dtype_types_st is cython.int:
         return np.int32
     elif _type2dtype_types_st is int64_t:
         return np.int64
-    elif _type2dtype_types_st is cython.long:
+    elif _type2dtype_types_st is int:
+        return np.int32
+    elif _type2dtype_types_st is _longlong:
         return np.int64
-    elif _type2dtype_types_st is float32_t:
+    elif _type2dtype_types_st is float:
         return np.float32
-    elif _type2dtype_types_st is cython.float:
-        return np.float32
-    elif _type2dtype_types_st is float64_t:
+    elif _type2dtype_types_st is double:
         return np.float64
-    elif _type2dtype_types_st is cython.double:
-        return np.float64
-    elif _type2dtype_types_st is complex64_t:
+    elif _type2dtype_types_st is _complex64_t:
         return np.complex64
-    elif _type2dtype_types_st is cython.floatcomplex:
-        return np.complex64
-    elif _type2dtype_types_st is complex128_t:
-        return np.complex128
-    elif _type2dtype_types_st is cython.doublecomplex:
+    elif _type2dtype_types_st is _complex128_t:
         return np.complex128
 
     # More special cases
@@ -64,6 +53,8 @@ cdef inline object type2dtype(const _type2dtype_types_st v):
         return np.uint32
     elif _type2dtype_types_st is uint64_t:
         return np.uint64
+
+    raise ValueError("Could not determine data-type (type2dtype)")
 
 
 @cython.wraparound(False)

--- a/src/sisl/_indices.pxd
+++ b/src/sisl/_indices.pxd
@@ -7,11 +7,10 @@ from sisl._core._dtypes cimport ints_st
 cdef bint in_1d(const ints_st[::1] array, const ints_st v) noexcept nogil
 
 ctypedef fused _ints_index_sorted_st:
-    short
-    int
-    long
     int16_t
     int32_t
     int64_t
+    int
+    long long
 
 cdef Py_ssize_t _index_sorted(const ints_st[::1] array, const _ints_index_sorted_st v) noexcept nogil

--- a/src/sisl/physics/_matrix_utils.pxd
+++ b/src/sisl/physics/_matrix_utils.pxd
@@ -13,6 +13,7 @@ ctypedef fused _internal_complexs_st:
     float complex
     double complex
 
+
 ctypedef void(*f_matrix_box_nc)(const floatcomplexs_st *data,
                                 const complexs_st phase,
                                 complexs_st *M) noexcept nogil


### PR DESCRIPTION
The cython sources where using int and long.
However, on Windows, long is equivalent to int.
Instead one should use long-long to ensure minimum int64.

This is just annoying, but it now fully works.

Also, one can't use stdlib int declarations in fused data-types because they cannot be coerced to proper cython data-types.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #1010
 - [x] Added tests for new/changed functions?
 - [x] Documentation for functionality in `docs/`
 - [x] Changes documented in `changes/<num>.<type>.rst`
 <!-- num can be either an issue or PR number.
 Note! You can do both in the same PR, if you want references to both!
 -->

<!--
Creating a PR will check whether the pre-commit hooks
have run, and if it fails, you should do this manually.

Please see here: https://zerothi.github.io/sisl/contribute.html
on how to enable the pre-commit hooks enabled in `sisl`.

The short message is:
- run `isort .` (version=6.0.0) at the top level
- run `black .` (version=25.1.0) at top-level
-->
